### PR TITLE
Ignore local .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ dist-ssr
 *.sw?
 *.zip
 .build_local_instructions
+.env
+.env.local
+.env.*.local
+.env.development
+.env.production


### PR DESCRIPTION
Adds `.env` and its variants to `.gitignore`.

The repo relies on local `.env` / `.env.development` files holding the
`VITE_FIREBASE_*` config that `src/config/firebase.ts` reads at build time.
They were untracked but not ignored, so nothing prevented `git add -A` from
staging them.

### Verification

- `git log --all --full-history` over every ref: neither file has ever been committed
- `git check-ignore -v` confirms both are now matched (`.gitignore:27`, `.gitignore:30`)
- Piped all tracked files through `git check-ignore` — none are newly ignored, so nothing drops out of the repo
- `.env.example` is deliberately *not* matched by any pattern, so it stays committable
- `npm test` — 31/31 passing (unaffected by this change; a gitignore edit has no test surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)