### PR TITLE
Version the Firestore security rules

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,7 @@
+{
+  "projects": {
+    "default": "tab-keeper-extension-dev",
+    "dev": "tab-keeper-extension-dev",
+    "prod": "tab-keeper-extension-web"
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,20 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // The document id is a client-generated uuid v4, minted in App.tsx and
+    // persisted in chrome.storage.sync. It is NOT a Firebase auth uid, so
+    // `request.auth.uid == docId` would match nothing and break all sync.
+    //
+    // The id itself is the capability: 122 bits of randomness is what keeps
+    // one user's tabs private from another. That only holds while the
+    // collection cannot be enumerated, so `list` must stay denied - `read`
+    // grants get + list, and would hand every document to any anonymous
+    // caller. The client only ever does exact-path getDoc/setDoc.
+    match /tabGroupData/{docId} {
+      allow get, write: if request.auth != null;
+      allow list: if false;
+    }
+  }
+}


### PR DESCRIPTION
Brings the Firestore rules into the repo so changes are reviewable; previously they lived only in the Firebase console for each project.

Access to `tabGroupData` is by exact document path. The document id is a client-generated uuid (minted in `App.tsx`, persisted in `chrome.storage.sync`) rather than a Firebase auth uid. The client only performs `getDoc`/`setDoc` — there is no `getDocs`, `query`, or `collection()` call anywhere in `src/` — so nothing regresses.

Verified in both projects, and sync confirmed working on the Chrome Web Store build.

`.firebaserc` defaults to **dev**, so a bare `firebase deploy` cannot reach prod; prod requires `--project prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)