### PR TITLE
Add build:dev script and ignore local agent tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ dist-ssr
 .env.*.local
 .env.development
 .env.production
+
+# Agent tooling - vendored skills are restorable from skills-lock.json
+.agents/
+CODEBASE.md

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "vite",
     "preview": "vite preview",
     "build": "tsc && vite build",
+    "build:dev": "tsc && vite build --mode development",
     "test": "vitest run",
     "test-dev": "vitest",
     "test-build": "npm run test && npm run build",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "skills": {
+    "chrome-extensions": {
+      "source": "GoogleChrome/modern-web-guidance",
+      "sourceType": "github",
+      "skillPath": "skills/chrome-extensions/SKILL.md",
+      "computedHash": "64369232df72f529dc168b6c0767a7636d78e1e9a7033b1e5ce9a2aac966a721"
+    },
+    "modern-web-guidance": {
+      "source": "GoogleChrome/modern-web-guidance",
+      "sourceType": "github",
+      "skillPath": "skills/modern-web-guidance/SKILL.md",
+      "computedHash": "9f4a50b16567d3e146014ca1e36cf31d11a9b28468eebdbbbee06ffe3b08dda8"
+    }
+  }
+}


### PR DESCRIPTION
### `build:dev`

`npm run build:dev` runs Vite in development mode so the build picks up
`.env.development`, making a local build run against the dev Firebase project
rather than prod. Tagged releases are unaffected — CI injects prod config from
repository secrets.

Verified: the resulting bundle inlines `tab-keeper-extension-dev.firebaseapp.com`.

### Ignores

- `.agents/` — 1.3M of vendored skill content; restorable from the lock file
- `CODEBASE.md` — a local codebase map, kept local as it duplicates the issue tracker

`skills-lock.json` is committed so the pinned versions travel with the repo even
though the vendored copies don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)