### PR TITLE
Keep Firestore documents under the size limit without losing favicons

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,7 +8,11 @@
     "default_icon": "icons/icon128.png",
     "default_title": "Tab Keeper - Chrome Tab Manager & Sync Tool"
   },
-  "permissions": ["tabs", "storage"],
+  "permissions": [
+    "tabs",
+    "storage",
+    "favicon"
+  ],
   "icons": {
     "16": "icons/icon16.png",
     "32": "icons/icon32.png",

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -9,7 +9,10 @@ import { NormalLabel } from '../../common/Label';
 import { useFontFamily } from '../../../hooks/useFontFamily';
 import { useThemeColors } from '../../../hooks/useThemeColors';
 import { AppDispatch, RootState } from '../../../redux/store';
-import { decodeDataUrl } from '../../../utils/functions/local';
+import {
+  decodeDataUrl,
+  resolveFaviconUrl,
+} from '../../../utils/functions/local';
 import { NON_INTERACTIVE_ICON_STYLE } from '../../../utils/constants/common';
 import {
   deleteTab,
@@ -336,7 +339,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                   title={t('Open in new tab') + ': ' + title}
                 >
                   <Icon
-                    faviconUrl={favicon}
+                    faviconUrl={resolveFaviconUrl(favicon, url)}
                     type="globe"
                     style={`&:hover {background-color: unset;}`}
                   />

--- a/src/redux/slices/globalStateSlice.ts
+++ b/src/redux/slices/globalStateSlice.ts
@@ -70,6 +70,10 @@ export const saveToFirestoreIfDirty = createAsyncThunk(
       }
     } catch (error: any) {
       console.warn('Error updating Firestore: ', error.message);
+      // Reject so the `saveToFirestoreIfDirty.rejected` case sets syncStatus to
+      // 'error'. Catching here left the write silently failed while the UI
+      // reported success.
+      throw error;
     }
   }
 );

--- a/src/tests/utils/functions/local.test.ts
+++ b/src/tests/utils/functions/local.test.ts
@@ -12,7 +12,10 @@ import {
   isValidTabMasterContainer,
   loadFromLocalStorage,
   saveToLocalStorage,
+  stripEmbeddedFavicons,
+  FIRESTORE_MAX_DOCUMENT_BYTES,
 } from '../../../utils/functions/local';
+import { TabMasterContainer } from '../../../redux/slices/tabContainerDataStateSlice';
 
 describe('isValidDate', () => {
   // Valid dates
@@ -532,5 +535,109 @@ describe('should convert timestamp to "mmm DD, yyyy at H:MM:SS AM/PM" format', (
     const inputTimestamp = new Date('2023-10-17 00:00:00').getTime();
     const expectedOutputString = 'Oct 17, 2023 at 12:00:00 AM';
     expect(getPrettyDate(inputTimestamp)).toBe(expectedOutputString);
+  });
+});
+
+describe('stripEmbeddedFavicons', () => {
+  const EMBEDDED = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg';
+  const REMOTE = 'https://github.githubassets.com/favicons/favicon.svg';
+
+  const buildContainer = (
+    tabsPerWindow: number,
+    favicon: string
+  ): TabMasterContainer => ({
+    lastModified: 1785312544441,
+    selectedTabGroupId: 'group-0',
+    tabGroups: [
+      {
+        tabGroupId: 'group-0',
+        title: 'Extensions',
+        createdTime: '2026-07-27 04:08:12',
+        windowCount: 1,
+        tabCount: tabsPerWindow,
+        isAutoSave: false,
+        isSelected: true,
+        windows: [
+          {
+            windowId: 'window-0',
+            windowHeight: 550,
+            windowWidth: 790,
+            windowOffsetTop: 0,
+            windowOffsetLeft: 0,
+            tabCount: tabsPerWindow,
+            title: 'first tab title',
+            tabs: Array.from({ length: tabsPerWindow }, (_, i) => ({
+              tabId: `tab-${i}`,
+              favicon,
+              title: `Repository ${i}`,
+              url: `https://github.com/user/repo-${i}`,
+            })),
+          },
+        ],
+      },
+    ],
+  });
+
+  test('should replace embedded data: favicons with an empty string', () => {
+    const result = stripEmbeddedFavicons(buildContainer(3, EMBEDDED));
+    const favicons = result.tabGroups[0].windows[0].tabs.map((t) => t.favicon);
+    expect(favicons).toEqual(['', '', '']);
+  });
+
+  test('should leave remote favicon URLs untouched', () => {
+    const result = stripEmbeddedFavicons(buildContainer(3, REMOTE));
+    const favicons = result.tabGroups[0].windows[0].tabs.map((t) => t.favicon);
+    expect(favicons).toEqual([REMOTE, REMOTE, REMOTE]);
+  });
+
+  test('should preserve every field other than the favicon', () => {
+    const input = buildContainer(2, EMBEDDED);
+    const result = stripEmbeddedFavicons(input);
+
+    expect(result.lastModified).toBe(input.lastModified);
+    expect(result.selectedTabGroupId).toBe(input.selectedTabGroupId);
+    expect(result.tabGroups[0].tabCount).toBe(input.tabGroups[0].tabCount);
+    expect(result.tabGroups[0].windows[0].windowHeight).toBe(550);
+    expect(result.tabGroups[0].windows[0].tabs[1]).toEqual({
+      tabId: 'tab-1',
+      favicon: '',
+      title: 'Repository 1',
+      url: 'https://github.com/user/repo-1',
+    });
+  });
+
+  test('should not mutate the input container', () => {
+    const input = buildContainer(2, EMBEDDED);
+    stripEmbeddedFavicons(input);
+    expect(input.tabGroups[0].windows[0].tabs[0].favicon).toBe(EMBEDDED);
+  });
+
+  test('should bring an oversized container under the Firestore limit', () => {
+    // 12KB embedded favicon x 120 tabs - a plausible heavy session
+    const heavyFavicon = 'data:image/png;base64,' + 'A'.repeat(12000);
+    const oversized = buildContainer(120, heavyFavicon);
+
+    expect(JSON.stringify(oversized).length).toBeGreaterThan(
+      FIRESTORE_MAX_DOCUMENT_BYTES
+    );
+    expect(
+      JSON.stringify(stripEmbeddedFavicons(oversized)).length
+    ).toBeLessThan(FIRESTORE_MAX_DOCUMENT_BYTES);
+  });
+
+  test('should handle a container with no tab groups', () => {
+    const empty: TabMasterContainer = {
+      lastModified: 1,
+      selectedTabGroupId: null,
+      tabGroups: [],
+    };
+    expect(stripEmbeddedFavicons(empty)).toEqual(empty);
+  });
+
+  test('should not throw when a favicon field is missing', () => {
+    const malformed = buildContainer(1, EMBEDDED);
+    // simulates data written before the favicon field was guaranteed
+    delete (malformed.tabGroups[0].windows[0].tabs[0] as any).favicon;
+    expect(() => stripEmbeddedFavicons(malformed)).not.toThrow();
   });
 });

--- a/src/tests/utils/functions/local.test.ts
+++ b/src/tests/utils/functions/local.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 import {
   decodeDataUrl,
   filterTabGroups,
@@ -13,6 +13,7 @@ import {
   loadFromLocalStorage,
   saveToLocalStorage,
   stripEmbeddedFavicons,
+  resolveFaviconUrl,
   FIRESTORE_MAX_DOCUMENT_BYTES,
 } from '../../../utils/functions/local';
 import { TabMasterContainer } from '../../../redux/slices/tabContainerDataStateSlice';
@@ -639,5 +640,55 @@ describe('stripEmbeddedFavicons', () => {
     // simulates data written before the favicon field was guaranteed
     delete (malformed.tabGroups[0].windows[0].tabs[0] as any).favicon;
     expect(() => stripEmbeddedFavicons(malformed)).not.toThrow();
+  });
+});
+
+describe('resolveFaviconUrl', () => {
+  const EXT = 'chrome-extension://abcdefghijklmnop';
+  const withChrome = () => {
+    (globalThis as any).chrome = {
+      runtime: { getURL: (path: string) => `${EXT}${path}` },
+    };
+  };
+
+  afterEach(() => {
+    delete (globalThis as any).chrome;
+  });
+
+  test('should return the stored favicon when there is one', () => {
+    withChrome();
+    const stored = 'https://github.githubassets.com/favicons/favicon.svg';
+    expect(resolveFaviconUrl(stored, 'https://github.com')).toBe(stored);
+  });
+
+  test('should derive from the page URL when the favicon is empty', () => {
+    withChrome();
+    const result = resolveFaviconUrl('', 'https://github.com/user/repo');
+    expect(result).toBe(
+      `${EXT}/_favicon/?pageUrl=https%3A%2F%2Fgithub.com%2Fuser%2Frepo&size=32`
+    );
+  });
+
+  test('should derive for http as well as https', () => {
+    withChrome();
+    expect(resolveFaviconUrl('', 'http://example.com')).toContain('/_favicon/');
+  });
+
+  test('should not derive for non-http schemes', () => {
+    withChrome();
+    expect(resolveFaviconUrl('', 'chrome://extensions/')).toBe('');
+    expect(resolveFaviconUrl('', 'chrome-extension://x/suspended.html')).toBe('');
+    expect(resolveFaviconUrl('', 'file:///tmp/page.html')).toBe('');
+  });
+
+  test('should return empty string when there is no page URL', () => {
+    withChrome();
+    expect(resolveFaviconUrl('', '')).toBe('');
+  });
+
+  test('should not throw when the chrome API is unavailable', () => {
+    // chrome is undefined here - afterEach removed it
+    expect(() => resolveFaviconUrl('', 'https://github.com')).not.toThrow();
+    expect(resolveFaviconUrl('', 'https://github.com')).toBe('');
   });
 });

--- a/src/utils/functions/external.ts
+++ b/src/utils/functions/external.ts
@@ -33,8 +33,12 @@ export async function loadFromFirestore(
   try {
     const tabDataFromCloud: TabMasterContainer =
       await fetchDataFromFirestore(userId);
-    // documents written before favicons were stripped still carry them
-    return stripEmbeddedFavicons(tabDataFromCloud);
+    // Deliberately not stripped on read. Documents written before the write-side
+    // strip still carry embedded favicons, and those render fine locally - a
+    // document is capped at 1 MiB while localStorage holds far more, so there is
+    // nothing to gain by discarding them, and doing so would blank icons that
+    // still work.
+    return tabDataFromCloud;
   } catch (error: any) {
     if (error.message === 'Document does not exist for userId: ' + userId) {
       console.warn('handled error: ' + error.message);

--- a/src/utils/functions/external.ts
+++ b/src/utils/functions/external.ts
@@ -7,6 +7,7 @@ import {
 } from '../../redux/slices/globalStateSlice';
 import { TabMasterContainer } from '../../redux/slices/tabContainerDataStateSlice';
 import { AppDispatch } from '../../redux/store';
+import { stripEmbeddedFavicons } from './local';
 
 // display a toast message
 export const displayToast = (
@@ -32,7 +33,8 @@ export async function loadFromFirestore(
   try {
     const tabDataFromCloud: TabMasterContainer =
       await fetchDataFromFirestore(userId);
-    return tabDataFromCloud;
+    // documents written before favicons were stripped still carry them
+    return stripEmbeddedFavicons(tabDataFromCloud);
   } catch (error: any) {
     if (error.message === 'Document does not exist for userId: ' + userId) {
       console.warn('handled error: ' + error.message);
@@ -55,8 +57,11 @@ export async function saveToFirestore(
   data: TabMasterContainer
 ): Promise<void> {
   try {
-    await setDoc(doc(db, 'tabGroupData', userId), data);
+    await setDoc(doc(db, 'tabGroupData', userId), stripEmbeddedFavicons(data));
   } catch (error: any) {
+    // Rethrow so the caller leaves isDirty set and the sync indicator shows the
+    // real state. Swallowing here reported success while nothing was written.
     console.warn('Error updating Firestore: ', error.message);
+    throw error;
   }
 }

--- a/src/utils/functions/local.ts
+++ b/src/utils/functions/local.ts
@@ -201,6 +201,22 @@ export function stripEmbeddedFavicons(
   };
 }
 
+// Chrome keeps a favicon cache for pages the user has visited, reachable through
+// the `favicon` permission. Deriving the icon from the page URL costs no storage,
+// so a tab whose embedded favicon was dropped by stripEmbeddedFavicons still
+// renders. Only http(s) pages are derived; anything else keeps the caller's own
+// fallback so behaviour there is unchanged.
+export function resolveFaviconUrl(favicon: string, pageUrl: string): string {
+  if (favicon) return favicon;
+  if (!pageUrl || !/^https?:\/\//i.test(pageUrl)) return '';
+  if (typeof chrome === 'undefined' || !chrome?.runtime?.getURL) return '';
+
+  const url = new URL(chrome.runtime.getURL('/_favicon/'));
+  url.searchParams.set('pageUrl', pageUrl);
+  url.searchParams.set('size', '32');
+  return url.toString();
+}
+
 // validate import JSON structure - TabMasterContainer
 export const isValidTabMasterContainer = (
   data: any

--- a/src/utils/functions/local.ts
+++ b/src/utils/functions/local.ts
@@ -176,6 +176,31 @@ export function decodeDataUrl(url: string): string {
   return url;
 }
 
+// Firestore rejects any document larger than 1 MiB.
+export const FIRESTORE_MAX_DOCUMENT_BYTES = 1048576;
+
+// Chrome hands back some favicons as `data:image/png;base64,...` URIs weighing
+// 5-20KB each, rather than a remote URL of ~60 bytes. Stored verbatim, a large
+// session pushes the document past the Firestore ceiling and the write is
+// rejected outright. Dropping the embedded ones keeps remote URLs intact, so
+// most favicons still render.
+export function stripEmbeddedFavicons(
+  data: TabMasterContainer
+): TabMasterContainer {
+  return {
+    ...data,
+    tabGroups: data.tabGroups.map((tabGroup) => ({
+      ...tabGroup,
+      windows: tabGroup.windows.map((window) => ({
+        ...window,
+        tabs: window.tabs.map((tab) =>
+          tab.favicon?.startsWith('data:') ? { ...tab, favicon: '' } : tab
+        ),
+      })),
+    })),
+  };
+}
+
 // validate import JSON structure - TabMasterContainer
 export const isValidTabMasterContainer = (
   data: any


### PR DESCRIPTION
### Problem

Chrome returns some favicons as `data:image/png;base64,...` URIs rather than a
remote URL. These were stored verbatim in `tabData.favicon`, so a large session
can push the document past Firestore's 1 MiB ceiling and the write is rejected.

The failure was silent: `saveToFirestore` caught the error and returned, so the
caller dispatched `setIsNotDirty` and the sync indicator showed success while
nothing had been written.

### Change

Three commits:

1. **Strip embedded favicons on write.** `stripEmbeddedFavicons` drops `data:`
   favicons and keeps remote URLs. Applied at the write boundary rather than the
   three capture sites, so tabs already in state are covered too - which is what
   lets a session that is currently too large to sync finally succeed.
2. **Do not strip on read.** An earlier revision did, and it discarded embedded
   favicons from documents written before this change - blanking icons that
   still rendered. The only benefit was smaller local state, which is not a real
   constraint: a document caps at 1 MiB while localStorage holds several MB.
3. **Derive favicons from the page URL.** Stripping alone left a device pulling
   from the cloud with nothing to render. `resolveFaviconUrl` falls back to
   Chrome's favicon cache via the `favicon` permission, using the page URL that
   is already stored - no storage cost. Only http(s) pages are derived, so
   `chrome://` and `chrome-extension://` tabs keep the existing Material Symbols
   fallback and behave exactly as before.

Plus: the write failure now propagates. `saveToFirestoreIfDirty.rejected` →
`syncStatus = 'error'` already existed in `extraReducers` but was unreachable,
because both the helper and the thunk caught the error. Letting it through leaves
`isDirty` set for a retry and surfaces the real state in the sync indicator that
is already on screen - no new UI.

### On the `favicon` permission

Its warning collapses into the `tabs` permission this extension already requests,
so updating does not disable the extension or prompt users to re-consent.
`web_accessible_resources` is not required - that applies to content scripts, and
this extension has none.
https://developer.chrome.com/docs/extensions/how-to/ui/favicons

Worth confirming once at release time by loading a packed CRX over the previous
version, since Chrome compares against *granted* permissions.

### Verification

Measured on real dev documents:

| | before | after |
|---|---|---|
| tabs | 6 | 23 |
| embedded `data:` favicons | **4** | **0** |
| size | 9,547 B | 8,691 B |
| **bytes per tab** | **1,591** | **378** |

End to end in the extension, loaded unpacked against the dev project:

- Saved a session containing a page that serves a `data:` favicon over `http`.
  The stored document has `favicon: ""` for it, and the icon still renders — so
  it was derived, not stored.
- The same page served over `file://` renders the generic glyph, confirming the
  scheme guard rather than an icon appearing by accident.
- A document written *before* this change was pulled from the cloud with its 4
  embedded favicons intact and rendering — the behaviour commit 2 restores.
- That pull did not write back: `lastModified` unchanged.
- `chrome.runtime.getURL('/_favicon/?pageUrl=...')` loads successfully.

Unit tests:

- **44/44 pass** (13 new)
- Stubbing `stripEmbeddedFavicons` to an identity fails 3, including
  `should bring an oversized container under the Firestore limit`
- Stubbing the derivation fails 2

`tsc --noEmit` clean, `npm run build:dev` succeeds.

### Not included

Compression (`lz-string`, TBKR-20) is complementary, not an alternative: it moves
the ceiling rather than removing it, changes the stored format, and does nothing
about the silent failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)