### PR TITLE
Bump workflow actions off the retired v3

### DIFF
--- a/.github/workflows/build_and_release_artifact.yaml
+++ b/.github/workflows/build_and_release_artifact.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -47,7 +47,7 @@ jobs:
           sed -i 's|https://apis.google.com/js/api.js?onload=${a}||g' $INDEX_FILE
 
       - name: Upload release zip file ready for Chrome Web Store
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tab-keeper-react-chrome-extension-v${{steps.version.outputs.prop}}
           path: ./dist/

--- a/.github/workflows/build_and_release_artifact.yaml
+++ b/.github/workflows/build_and_release_artifact.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
@@ -47,7 +47,7 @@ jobs:
           sed -i 's|https://apis.google.com/js/api.js?onload=${a}||g' $INDEX_FILE
 
       - name: Upload release zip file ready for Chrome Web Store
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tab-keeper-react-chrome-extension-v${{steps.version.outputs.prop}}
           path: ./dist/

--- a/.github/workflows/build_before_merge.yaml
+++ b/.github/workflows/build_before_merge.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/build_before_merge.yaml
+++ b/.github/workflows/build_before_merge.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
Two problems, one fix.

**1. The release workflow cannot run.** GitHub shut down v3 of the artifact actions on **2025-01-30**; `actions/upload-artifact@v3` now fails outright. This hasn't bitten only because the last tag is `v1.3.1` from 2023-11-25 — the next tag would have failed at the upload step, *after* tests passed and the production build had run with real Firebase secrets.

**2. Node 20 is deprecated.** The #108 run warned:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/checkout@v3, actions/setup-node@v3
```

### Why the current majors rather than v4

v4 of all three actions targets `node20` — the runtime being deprecated. Bumping to v4 would have cleared the artifact shutdown while landing on a runtime already being migrated out from under it.

| action | node20 | node24 |
|---|---|---|
| `checkout` | v4 | v5+ |
| `setup-node` | v4 | v5+ |
| `upload-artifact` | v4, v5 | v6+ |

Taking the current majors, since this workflow gets touched about once a year. Verified against each action's `action.yml` runtime rather than release notes.

### Changed

All three bumped v3 → **v7**, across `build_before_merge.yaml` and `build_and_release_artifact.yaml`.

`upload-artifact` v7's changes don't affect this usage: the unique-name requirement from v4 is already satisfied (one upload, version-stamped name), and v7's opt-in direct uploads apply to single files, not the `./dist/` directory uploaded here.

### Verification

`build_before_merge` runs on this PR and **exercises `checkout@v7` and `setup-node@v7` directly** — it passes, and grepping the run log confirms the Node 20 deprecation warning is gone.

**`upload-artifact@v7` is not exercised until a tag is pushed** — that path only runs on `v*`. It stays unverified until the next release.

### Noted, not changed

- `setup-node` is invoked with **no `node-version`**, so it selects nothing; the build runs on whatever Node the runner image ships (currently v22.23.2) and drifts with the image. Pinning it would make builds reproducible but could change build output.
- `npm ci` reports **26 vulnerabilities (3 critical, 12 high)**. Unrelated to this change, worth its own pass.
- `notiz-dev/github-action-json-property@release` tracks a moving tag rather than a pinned version.

Sources: [artifact v3 shutdown](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/), [Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)