### PR TITLE
Release 1.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 Tab Keeper is an intuitive Chrome extension crafted to redefine the way users save, organize, and interact with their browser tabs. With the smart integration of the Chrome Storage API as a shared token storage, Tab Keeper ensures that users can seamlessly sync their data across Chrome browsers on desktop devices without signing up with their personal emails.
 <br><br>
 [![Static Badge](https://img.shields.io/badge/Featured_on-Chrome_Web_Store-cce7e8?style=for-the-badge)](https://chromewebstore.google.com/detail/tab-keeper-chrome-tab-man/gpibgniomobngodpnikhheifblbpbbah?ref=github)
-[![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fjustine-george%2Ftab-keeper-react-chrome-extension%2Fmain%2Fpackage.json&query=version&style=for-the-badge&label=Version
-)](#changelog)
+[![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fjustine-george%2Ftab-keeper-react-chrome-extension%2Fmain%2Fpackage.json&query=version&style=for-the-badge&label=Version)](#changelog)
 ![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fjustine-george%2Fjgeorge.com%2Fmain%2Fsrc%2Fdata%2Fextension-metrics.json&query=%24.tabKeeper.users&style=for-the-badge&label=Users)
 [![Static Badge](https://img.shields.io/badge/License-MIT-blue?style=for-the-badge)](https://raw.githubusercontent.com/justine-george/tab-keeper-react-chrome-extension/main/LICENSE)
 
@@ -59,7 +58,14 @@ Tab Keeper is an intuitive Chrome extension crafted to redefine the way users sa
 
 ## Changelog
 
-### v.1.3.1 (Latest)
+### v.1.3.2 (Latest)
+
+#### Improvements
+
+- Cloud sync is now reliable for large sessions. Tab icons are resolved on demand instead of being stored with each saved session, cutting stored data roughly 4x and keeping sessions within the cloud document size limit
+- A failed sync is now reflected in the toolbar sync icon, rather than the extension reporting success
+
+### v.1.3.1
 
 #### Improvements
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tab-keeper-react-chrome-extension",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tab-keeper-react-chrome-extension",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Justine George",
   "description": "Efficiently save and synchronize tabs across devices without the need for personal logins.",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "1.3.1",
+  "version": "1.3.2",
   "name": "Tab Keeper - Chrome Tab Manager & Sync Tool",
   "description": "Efficiently save and synchronize tabs across devices without the need for personal logins.",
   "action": {
@@ -8,11 +8,7 @@
     "default_icon": "icons/icon128.png",
     "default_title": "Tab Keeper - Chrome Tab Manager & Sync Tool"
   },
-  "permissions": [
-    "tabs",
-    "storage",
-    "favicon"
-  ],
+  "permissions": ["tabs", "storage", "favicon"],
   "icons": {
     "16": "icons/icon16.png",
     "32": "icons/icon32.png",

--- a/src/tests/utils/functions/local.test.ts
+++ b/src/tests/utils/functions/local.test.ts
@@ -677,7 +677,9 @@ describe('resolveFaviconUrl', () => {
   test('should not derive for non-http schemes', () => {
     withChrome();
     expect(resolveFaviconUrl('', 'chrome://extensions/')).toBe('');
-    expect(resolveFaviconUrl('', 'chrome-extension://x/suspended.html')).toBe('');
+    expect(resolveFaviconUrl('', 'chrome-extension://x/suspended.html')).toBe(
+      ''
+    );
     expect(resolveFaviconUrl('', 'file:///tmp/page.html')).toBe('');
   });
 


### PR DESCRIPTION
Version bump and changelog for 1.3.2.

### What ships

Only one user-facing change since v1.3.1 (2023-11-25) — the rest of the commits since then are README, badges, CI, gitignore, and Firestore rules.

**#108 — cloud sync reliability.** Sessions containing tabs with embedded (`data:`) favicons could exceed Firestore's 1 MiB document limit, so the write was rejected. The error was swallowed at two levels, leaving the sync indicator showing success while nothing had been saved. Favicons are now stripped on write and derived from the page URL at display time, and a failed write reaches the toolbar sync icon.

Fixes KAN-18.

### Contents

- `package.json`, `public/manifest.json`, `package-lock.json` → 1.3.2
- README changelog entry
- Prettier reformatting of `manifest.json` permissions and one test assertion (no semantic change)

The README version badge is dynamic — it reads `version` from `package.json` on `main`, so it updates on merge.

### After merge

```
npm run release-artifact    # tags v1.3.2 and pushes, firing the release workflow
```

**This will be the first tagged release since 2023-11-25**, and the first to exercise `actions/upload-artifact@v7` (#109). The old v3 was shut down 2025-01-30, so a tag before that PR would have failed at the upload step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)