### PR TITLE
Read the manifest version inline instead of via a third-party action

### DIFF
--- a/.github/workflows/build_and_release_artifact.yaml
+++ b/.github/workflows/build_and_release_artifact.yaml
@@ -25,10 +25,8 @@ jobs:
 
       - name: Get version from manifest
         id: version
-        uses: notiz-dev/github-action-json-property@release
-        with:
-          path: 'public/manifest.json'
-          prop_path: 'version'
+        run: |
+          echo "prop=$(node -p "require('./public/manifest.json').version")" >> "$GITHUB_OUTPUT"
 
       - name: Generate dist folder
         env:


### PR DESCRIPTION
`notiz-dev/github-action-json-property` existed only to read `version` out of `public/manifest.json`.

Two reasons to drop it:

- **It targets Node 20** — the last remaining source of the deprecation warning after #109. The v1.3.2 release log still showed it on the `Get version from manifest` step.
- **It was pinned to `@release`** — a moving tag, not a version. Whatever that repository pushed there would run in the release pipeline.

One line of `node` does the same job.

```yaml
- name: Get version from manifest
  id: version
  run: |
    echo "prop=$(node -p "require('./public/manifest.json').version")" >> "$GITHUB_OUTPUT"
```

Downstream usage is unchanged — the step keeps `id: version`, so `steps.version.outputs.prop` still resolves in the artifact name.

### Verification

- The command outputs `prop=1.3.2`, matching exactly what the action produced for the v1.3.2 release (artifact `tab-keeper-react-chrome-extension-v1.3.2`)
- Workflow YAML parses, with the step `id` intact

**Not exercised by CI.** This step only runs on a `v*` tag, so `build_before_merge` cannot cover it — it is proven on the next release.

### Unchanged deliberately

The Firebase secrets remain scoped to the `Generate dist folder` step rather than the job, so no other step sees them. Worth preserving.

`bahmutov/npm-install@v1` is left alone — it's a pinned major and works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)