### PR TITLE
Make the popup layout responsive

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -153,6 +153,8 @@ function App() {
   const containerStyle = css`
     background-color: ${COLORS.PRIMARY_COLOR};
     width: ${APP_WIDTH};
+    /* Chrome applies the browser's default page zoom to extension popups, so
+       the 800x600 allowance shrinks with it. Adapt rather than overflow. */
     max-width: 100%;
   `;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -153,6 +153,7 @@ function App() {
   const containerStyle = css`
     background-color: ${COLORS.PRIMARY_COLOR};
     width: ${APP_WIDTH};
+    max-width: 100%;
   `;
 
   return (

--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -93,6 +93,7 @@ export default function MainContainer() {
   const leftPaneStyle = css`
     width: 45%;
     height: ${APP_HEIGHT};
+    min-width: 0;
     border: 1px solid ${COLORS.BORDER_COLOR};
     border-right: none;
   `;
@@ -100,12 +101,14 @@ export default function MainContainer() {
   const rightPaneStyle = css`
     width: 55%;
     height: ${APP_HEIGHT};
+    min-width: 0;
     border: 1px solid ${COLORS.BORDER_COLOR};
   `;
 
   const leftPaneSettingsStyle = css`
     width: 30%;
     height: ${APP_HEIGHT};
+    min-width: 0;
     border: 1px solid ${COLORS.BORDER_COLOR};
     border-right: none;
   `;
@@ -113,6 +116,7 @@ export default function MainContainer() {
   const rightPaneSettingsStyle = css`
     width: 70%;
     height: ${APP_HEIGHT};
+    min-width: 0;
     border: 1px solid ${COLORS.BORDER_COLOR};
   `;
 

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -55,46 +55,47 @@ const Button: React.FC<ButtonProps> = ({
 
   iconStyle;
 
+  // No wrapper element: the button must be the flex child itself, otherwise a
+  // width: 100% passed through `style` resolves against a shrink-wrapped div
+  // and collapses back to the button's own text width.
   return (
-    <div>
-      <button
-        title={tooltipText}
-        aria-label={ariaLabel}
-        css={buttonStyle}
-        onClick={onClick}
-        tabIndex={onClick && focusableButton ? 0 : -1}
-      >
-        {iconType && (
-          <Icon
-            type={iconType}
-            disable={true}
-            focusable={true}
-            size={iconSize}
-            style={(imageSrc || text) && 'padding-right: 8px;' && iconStyle}
-          />
-        )}
-        {imageSrc && (
-          <img
-            src={imageSrc}
-            alt="icon"
-            css={css`
-              width: 30px;
-              height: 30px;
-              object-fit: contain;
-            `}
-          />
-        )}
-        {text && (
-          <span
-            css={css`
-              ${imageSrc && 'padding-left: 8px;'}
-            `}
-          >
-            {text}
-          </span>
-        )}
-      </button>
-    </div>
+    <button
+      title={tooltipText}
+      aria-label={ariaLabel}
+      css={buttonStyle}
+      onClick={onClick}
+      tabIndex={onClick && focusableButton ? 0 : -1}
+    >
+      {iconType && (
+        <Icon
+          type={iconType}
+          disable={true}
+          focusable={true}
+          size={iconSize}
+          style={(imageSrc || text) && 'padding-right: 8px;' && iconStyle}
+        />
+      )}
+      {imageSrc && (
+        <img
+          src={imageSrc}
+          alt="icon"
+          css={css`
+            width: 30px;
+            height: 30px;
+            object-fit: contain;
+          `}
+        />
+      )}
+      {text && (
+        <span
+          css={css`
+            ${imageSrc && 'padding-left: 8px;'}
+          `}
+        >
+          {text}
+        </span>
+      )}
+    </button>
   );
 };
 

--- a/src/components/common/Label.tsx
+++ b/src/components/common/Label.tsx
@@ -36,9 +36,19 @@ export const NormalLabel: React.FC<LabelProps> = ({
     ${style && style}
   `;
 
+  // The wrapper stays a flex container so callers can keep centring it and
+  // passing height: 100%. text-overflow does not apply to flex containers, so
+  // the ellipsis has to live on an inner box.
+  const truncateStyle = css`
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  `;
+
   return (
     <div title={tooltipText} css={textStyle} onClick={onClick}>
-      {value}
+      <span css={truncateStyle}>{value}</span>
     </div>
   );
 };

--- a/src/components/common/TextBox.tsx
+++ b/src/components/common/TextBox.tsx
@@ -45,6 +45,7 @@ const TextBox: React.FC<TextBoxProps> = ({
     padding: 10px;
     height: 3.5rem;
     flex-grow: 1;
+    min-width: 0;
     font-family: ${FONT_FAMILY};
     font-size: 0.9rem;
     color: ${COLORS.LABEL_L1_COLOR};

--- a/src/components/home/leftpane/HeroContainerLeft.tsx
+++ b/src/components/home/leftpane/HeroContainerLeft.tsx
@@ -75,6 +75,8 @@ export default function HeroContainer() {
       <div
         css={css`
           display: flex;
+          align-items: center;
+          min-width: 0;
         `}
         onClick={handleClickSearch}
         onKeyDown={(e) => handleKeyPress(e)}
@@ -89,7 +91,11 @@ export default function HeroContainer() {
           style="cursor: pointer;"
         />
       </div>
-      <div>
+      <div
+        css={css`
+          flex-shrink: 0;
+        `}
+      >
         <MenuContainer />
       </div>
     </div>

--- a/src/components/home/leftpane/TabGroupEntry.tsx
+++ b/src/components/home/leftpane/TabGroupEntry.tsx
@@ -55,6 +55,7 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
     padding: 8px;
     align-items: flex-start;
     width: 100%;
+    min-width: 0;
   `;
 
   const rightStyle = css`
@@ -96,7 +97,7 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
     >
       <div css={leftStyle}>
         <NormalLabel
-          style="max-width: 318px;"
+          style="max-width: 100%;"
           value={title}
           color={COLORS.TEXT_COLOR}
           size="0.95rem;"

--- a/src/components/home/leftpane/UserInputContainer.tsx
+++ b/src/components/home/leftpane/UserInputContainer.tsx
@@ -139,7 +139,7 @@ export default function UserInputContainer() {
         iconType="search"
         ariaLabel="search"
         onClick={filterResults}
-        style="padding: 12px;"
+        style="padding: 12px; flex-shrink: 0;"
         focusableButton={true}
       />
     </div>
@@ -161,7 +161,7 @@ export default function UserInputContainer() {
         ariaLabel="save session"
         iconType="add"
         onClick={createTabGroup}
-        style="padding: 12px;"
+        style="padding: 12px; flex-shrink: 0;"
         focusableButton={true}
       />
     </div>

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -89,6 +89,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     display: flex;
     align-items: center;
     flex-grow: 1;
+    min-width: 0;
   `;
 
   const parentRightStyle = css`
@@ -140,6 +141,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     align-items: center;
     height: 100%;
     flex-grow: 1;
+    min-width: 0;
     padding-right: 9px;
     ${!isSearchPanel && 'cursor: pointer;'}
   `;
@@ -250,7 +252,8 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                   font-size: 0.9rem;
                   padding-left: 8px;
                   height: 100%;
-                  width: 310px;
+                  width: 100%;
+                  min-width: 0;
                   &:focus {
                     outline: none;
                   }
@@ -264,7 +267,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                 style={`
                 padding-left: 8px;
                 ${!isSearchPanel && 'cursor: pointer'};
-                height: 100%; max-width: 330px;`}
+                height: 100%; max-width: 100%;`}
               />
             )}
           </div>
@@ -350,7 +353,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                       value={title}
                       color={COLORS.TEXT_COLOR}
                       size="0.9rem"
-                      style="padding-left: 4px; height: 100%; max-width: 289px;"
+                      style="padding-left: 4px; height: 100%; max-width: 100%;"
                     />
                   </div>
                 </div>

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -121,6 +121,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     display: flex;
     align-items: center;
     flex-grow: 1;
+    min-width: 0;
   `;
 
   const childRightStyle = (index: number) => css`
@@ -150,6 +151,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     align-items: center;
     height: 100%;
     flex-grow: 1;
+    min-width: 0;
     margin-left: 4px;
     margin-right: 4px;
     cursor: pointer;

--- a/src/components/settings/leftpane/SettingsCategoryContainer.tsx
+++ b/src/components/settings/leftpane/SettingsCategoryContainer.tsx
@@ -59,7 +59,7 @@ const SettingsCategoryContainer: React.FC = () => {
     background-color: ${isSelected
       ? COLORS.SELECTION_COLOR
       : COLORS.PRIMARY_COLOR};
-    padding: 15px 38px;
+    padding: 15px clamp(10px, 12%, 38px);
   `;
 
   return (

--- a/src/components/settings/rightpane/Account.tsx
+++ b/src/components/settings/rightpane/Account.tsx
@@ -24,7 +24,8 @@ const Account: React.FC = () => {
         flex-direction: column;
         justify-content: flex-start;
         align-items: center;
-        width: 350px;
+        width: 100%;
+        max-width: 350px;
         height: 100%;
       `}
     >

--- a/src/components/settings/rightpane/Account/CreateAccount.tsx
+++ b/src/components/settings/rightpane/Account/CreateAccount.tsx
@@ -121,7 +121,7 @@ const CreateAccount: React.FC<AccountChildProps> = ({
           text="Create an Account"
           iconType="person_add"
           onClick={validateCredentials}
-          style="width: 250px; justify-content: center;"
+          style="width: 100%; max-width: 250px; justify-content: center;"
         />
       </div>
 
@@ -135,7 +135,7 @@ const CreateAccount: React.FC<AccountChildProps> = ({
           <Button
             text="Already have an account? Sign In"
             onClick={handleBackToSignInClick}
-            style={`border: none; padding: 2px; width: 250px; justify-content: center; color: ${COLORS.LABEL_L3_COLOR}`}
+            style={`border: none; padding: 2px; width: 100%; max-width: 250px; justify-content: center; color: ${COLORS.LABEL_L3_COLOR}`}
           />
         </div>
       </div>

--- a/src/components/settings/rightpane/Account/ForgotPassword.tsx
+++ b/src/components/settings/rightpane/Account/ForgotPassword.tsx
@@ -85,7 +85,7 @@ const ForgotPassword: React.FC<AccountChildProps> = ({
           text="Reset Password"
           iconType="lock_reset"
           onClick={validateCredentials}
-          style="width: 250px; justify-content: center;"
+          style="width: 100%; max-width: 250px; justify-content: center;"
         />
       </div>
 
@@ -99,14 +99,14 @@ const ForgotPassword: React.FC<AccountChildProps> = ({
           <Button
             text="Return to Sign In"
             onClick={handleBackToSignInClick}
-            style={`border: none; width: 250px; justify-content: center; color: ${COLORS.LABEL_L3_COLOR}`}
+            style={`border: none; width: 100%; max-width: 250px; justify-content: center; color: ${COLORS.LABEL_L3_COLOR}`}
           />
         </div>
         <div>
           <Button
             text="New here? Create an account"
             onClick={handleCreateAccountClick}
-            style={`border: none; width: 250px; justify-content: center; color: ${COLORS.LABEL_L3_COLOR}`}
+            style={`border: none; width: 100%; max-width: 250px; justify-content: center; color: ${COLORS.LABEL_L3_COLOR}`}
           />
         </div>
       </div>

--- a/src/components/settings/rightpane/Account/LoggedIn.tsx
+++ b/src/components/settings/rightpane/Account/LoggedIn.tsx
@@ -14,7 +14,9 @@ const LoggedIn: React.FC = () => {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    padding: 22px 83px 32px;
+    width: 100%;
+    min-width: 0;
+    padding: 22px clamp(12px, 10%, 83px) 32px;
     border: 1px solid ${COLORS.BORDER_COLOR};
     margin-top: 8px;
     border-radius: 0px;
@@ -25,6 +27,8 @@ const LoggedIn: React.FC = () => {
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    max-width: 100%;
+    min-width: 0;
     margin-bottom: 16px;
   `;
 

--- a/src/components/settings/rightpane/Account/NotLoggedIn.tsx
+++ b/src/components/settings/rightpane/Account/NotLoggedIn.tsx
@@ -14,7 +14,9 @@ const NotLoggedIn: React.FC = () => {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    padding: 22px 64px 32px;
+    width: 100%;
+    min-width: 0;
+    padding: 22px clamp(12px, 10%, 64px) 32px;
     border: 1px solid ${COLORS.BORDER_COLOR};
     margin-top: 8px;
     border-radius: 0px;
@@ -25,6 +27,8 @@ const NotLoggedIn: React.FC = () => {
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    max-width: 100%;
+    min-width: 0;
     margin-bottom: 16px;
   `;
 

--- a/src/components/settings/rightpane/Account/SignIn.tsx
+++ b/src/components/settings/rightpane/Account/SignIn.tsx
@@ -104,7 +104,7 @@ const SignIn: React.FC<AccountChildProps> = ({ handleCurrentPageChange }) => {
           iconType="login"
           onClick={validateCredentials}
           ariaLabel="Sign In to your account"
-          style="width: 250px; justify-content: center;"
+          style="width: 100%; max-width: 250px; justify-content: center;"
         />
       </div>
 
@@ -118,14 +118,14 @@ const SignIn: React.FC<AccountChildProps> = ({ handleCurrentPageChange }) => {
           <Button
             text="Trouble logging in?"
             onClick={handleForgotPasswordClick}
-            style={`border: none; width: 250px; justify-content: center; color: ${COLORS.LABEL_L3_COLOR}`}
+            style={`border: none; width: 100%; max-width: 250px; justify-content: center; color: ${COLORS.LABEL_L3_COLOR}`}
           />
         </div>
         <div>
           <Button
             text="New here? Create an account"
             onClick={handleCreateAccountClick}
-            style={`border: none; width: 250px; justify-content: center; color: ${COLORS.LABEL_L3_COLOR}`}
+            style={`border: none; width: 100%; max-width: 250px; justify-content: center; color: ${COLORS.LABEL_L3_COLOR}`}
           />
         </div>
       </div>

--- a/src/components/settings/rightpane/SettingsDetailsContainer.tsx
+++ b/src/components/settings/rightpane/SettingsDetailsContainer.tsx
@@ -75,7 +75,11 @@ const SettingsDetailsContainer: React.FC = () => {
     flex-grow: 1;
     margin-top: 8px;
     border: 1px solid ${COLORS.BORDER_COLOR};
-    // overflow: auto;
+    /* Contain this pane's content. Several settings rows are still laid out at
+       fixed pixel widths, so without this they push the whole popup wide
+       instead of scrolling within the pane. */
+    overflow: auto;
+    min-width: 0;
     user-select: none;
   `;
 
@@ -178,7 +182,7 @@ const SettingsDetailsContainer: React.FC = () => {
             display: flex;
             flex-direction: column;
             align-items: flex-start;
-            margin-left: 72px;
+            padding-left: clamp(16px, 8%, 72px);
             width: 100%;
             margin-top: 20px;
           `}
@@ -202,7 +206,9 @@ const SettingsDetailsContainer: React.FC = () => {
               display: flex;
               justify-content: flex-start;
               align-items: center;
-              width: 250px;
+              flex-wrap: wrap;
+              gap: 4px;
+              max-width: 100%;
               margin-top: 8px;
             `}
           >
@@ -222,7 +228,6 @@ const SettingsDetailsContainer: React.FC = () => {
               tooltipText={t('Warm Light')}
               onClick={() => dispatch(setTheme(Theme.WARM_LIGHT))}
               style={`
-              margin-left: 16px;
               width: 60px;
               border: 1px solid ${COLORS.BORDER_COLOR};
               background-color: ${WARM_LIGHT_THEME.PRIMARY_COLOR};
@@ -236,7 +241,6 @@ const SettingsDetailsContainer: React.FC = () => {
               tooltipText={t('BB Pink')}
               onClick={() => dispatch(setTheme(Theme.BB_PINK))}
               style={`
-              margin-left: 16px;
               width: 60px;
               border: 1px solid ${COLORS.BORDER_COLOR};
               background-color: ${BB_PINK_THEME.PRIMARY_COLOR};
@@ -249,7 +253,6 @@ const SettingsDetailsContainer: React.FC = () => {
               tooltipText={t('Darkenheimer')}
               onClick={() => dispatch(setTheme(Theme.DARKENHEIMER))}
               style={`
-              margin-left: 16px;
               width: 60px;
               border: 1px solid ${COLORS.BORDER_COLOR};
               background-color: ${DARKENHEIMER_THEME.PRIMARY_COLOR};
@@ -262,7 +265,6 @@ const SettingsDetailsContainer: React.FC = () => {
               tooltipText={t('Blue')}
               onClick={() => dispatch(setTheme(Theme.BLUE))}
               style={`
-              margin-left: 16px;
               width: 60px;
               border: 1px solid ${COLORS.BORDER_COLOR};
               background-color: ${BLUE_THEME.PRIMARY_COLOR};
@@ -291,7 +293,7 @@ const SettingsDetailsContainer: React.FC = () => {
             display: flex;
             flex-direction: column;
             align-items: flex-start;
-            margin-left: 72px;
+            padding-left: clamp(16px, 8%, 72px);
             width: 100%;
             margin-top: 20px;
           `}
@@ -315,7 +317,8 @@ const SettingsDetailsContainer: React.FC = () => {
               display: flex;
               justify-content: space-between;
               align-items: center;
-              width: 250px;
+              width: 100%;
+              max-width: 250px;
               margin-top: 8px;
             `}
           >
@@ -323,7 +326,7 @@ const SettingsDetailsContainer: React.FC = () => {
               text={settingsData.isAutoSync ? t(`On`) : t(`Off`)}
               onClick={handleToggleAutoSync}
               style={`
-              width: 120px;
+              width: 100%;
             `}
             />
           </div>
@@ -335,7 +338,7 @@ const SettingsDetailsContainer: React.FC = () => {
             display: flex;
             flex-direction: column;
             align-items: flex-start;
-            margin-left: 72px;
+            padding-left: clamp(16px, 8%, 72px);
             width: 100%;
             margin-top: 20px;
           `}
@@ -375,7 +378,7 @@ const SettingsDetailsContainer: React.FC = () => {
             display: flex;
             flex-direction: column;
             align-items: flex-start;
-            margin-left: 72px;
+            padding-left: clamp(16px, 8%, 72px);
             width: 100%;
             margin-top: 20px;
           `}
@@ -399,7 +402,8 @@ const SettingsDetailsContainer: React.FC = () => {
               display: flex;
               justify-content: space-between;
               align-items: center;
-              width: 250px;
+              width: 100%;
+              max-width: 250px;
               margin-top: 8px;
             `}
           >
@@ -407,7 +411,7 @@ const SettingsDetailsContainer: React.FC = () => {
               text={settingsData.isLazyLoad ? t(`On`) : t(`Off`)}
               onClick={handleToggleLazyLoadTabs}
               style={`
-              width: 120px;
+              width: 100%;
             `}
             />
           </div>
@@ -419,7 +423,7 @@ const SettingsDetailsContainer: React.FC = () => {
             display: flex;
             flex-direction: column;
             align-items: flex-start;
-            margin-left: 72px;
+            padding-left: clamp(16px, 8%, 72px);
             width: 100%;
             margin-top: 20px;
           `}
@@ -443,7 +447,10 @@ const SettingsDetailsContainer: React.FC = () => {
               display: flex;
               flex-direction: column;
               justify-content: space-between;
-              align-items: center;
+              /* A definite width, so the buttons' width: 100% resolves against
+                 the row rather than against their own text. */
+              width: 100%;
+              align-items: flex-start;
               margin-top: 8px;
             `}
           >
@@ -451,13 +458,15 @@ const SettingsDetailsContainer: React.FC = () => {
               text={t(`Backup App Data to File`)}
               iconType="publish"
               onClick={handleExportJSON}
-              style="width: 260px; justify-content: center;"
+              style="width: 100%;
+              max-width: 260px; justify-content: center;"
             />
             <Button
               text={t('Restore App Data from File')}
               iconType="get_app"
               onClick={handleImportJSON}
-              style="width: 260px; justify-content: center; margin-top: 12px;"
+              style="width: 100%;
+              max-width: 260px; justify-content: center; margin-top: 12px;"
             />
           </div>
         </div>
@@ -479,7 +488,7 @@ const SettingsDetailsContainer: React.FC = () => {
             display: flex;
             flex-direction: column;
             align-items: flex-start;
-            margin-left: 72px;
+            padding-left: clamp(16px, 8%, 72px);
             width: 100%;
             margin-top: 20px;
           `}
@@ -501,7 +510,10 @@ const SettingsDetailsContainer: React.FC = () => {
           <div
             css={css`
               display: grid;
+              /* Two columns at every size. Without a definite width the grid
+                 shrink-wraps and auto-fit collapses to a single column. */
               grid-template-columns: 1fr 1fr;
+              width: 100%;
               gap: 12px;
               align-items: center;
               margin-top: 8px;
@@ -513,7 +525,7 @@ const SettingsDetailsContainer: React.FC = () => {
                 i18n.changeLanguage('en');
                 dispatch(setLanguage(Language.EN));
               }}
-              style="width: 217px; justify-content: center;"
+              style="width: 100%; min-width: 0; justify-content: center;"
             />
             <Button
               text={t(`German`)}
@@ -521,7 +533,7 @@ const SettingsDetailsContainer: React.FC = () => {
                 i18n.changeLanguage('de');
                 dispatch(setLanguage(Language.DE));
               }}
-              style="width: 217px; justify-content: center;"
+              style="width: 100%; min-width: 0; justify-content: center;"
             />
             <Button
               text={t('Chinese')}
@@ -529,7 +541,7 @@ const SettingsDetailsContainer: React.FC = () => {
                 i18n.changeLanguage('zh');
                 dispatch(setLanguage(Language.ZH));
               }}
-              style="width: 217px; justify-content: center;"
+              style="width: 100%; min-width: 0; justify-content: center;"
             />
             <Button
               text={t('Japanese')}
@@ -537,7 +549,7 @@ const SettingsDetailsContainer: React.FC = () => {
                 i18n.changeLanguage('ja');
                 dispatch(setLanguage(Language.JA));
               }}
-              style="width: 217px; justify-content: center;"
+              style="width: 100%; min-width: 0; justify-content: center;"
             />
             <Button
               text={t(`French`)}
@@ -545,7 +557,7 @@ const SettingsDetailsContainer: React.FC = () => {
                 i18n.changeLanguage('fr');
                 dispatch(setLanguage(Language.FR));
               }}
-              style="width: 217px; justify-content: center;"
+              style="width: 100%; min-width: 0; justify-content: center;"
             />
             <Button
               text={t(`Portuguese`)}
@@ -553,7 +565,7 @@ const SettingsDetailsContainer: React.FC = () => {
                 i18n.changeLanguage('pt');
                 dispatch(setLanguage(Language.PT));
               }}
-              style="width: 217px; justify-content: center;"
+              style="width: 100%; min-width: 0; justify-content: center;"
             />
             <Button
               text={t(`Russian`)}
@@ -561,7 +573,7 @@ const SettingsDetailsContainer: React.FC = () => {
                 i18n.changeLanguage('ru');
                 dispatch(setLanguage(Language.RU));
               }}
-              style="width: 217px; justify-content: center;"
+              style="width: 100%; min-width: 0; justify-content: center;"
             />
             <Button
               text={t(`Spanish`)}
@@ -569,7 +581,7 @@ const SettingsDetailsContainer: React.FC = () => {
                 i18n.changeLanguage('es');
                 dispatch(setLanguage(Language.ES));
               }}
-              style="width: 217px; justify-content: center;"
+              style="width: 100%; min-width: 0; justify-content: center;"
             />
             <Button
               text={t(`Italian`)}
@@ -577,7 +589,7 @@ const SettingsDetailsContainer: React.FC = () => {
                 i18n.changeLanguage('it');
                 dispatch(setLanguage(Language.IT));
               }}
-              style="width: 217px; justify-content: center;"
+              style="width: 100%; min-width: 0; justify-content: center;"
             />
             <Button
               text={t(`Hindi`)}
@@ -585,7 +597,7 @@ const SettingsDetailsContainer: React.FC = () => {
                 i18n.changeLanguage('hi');
                 dispatch(setLanguage(Language.HI));
               }}
-              style="width: 217px; justify-content: center;"
+              style="width: 100%; min-width: 0; justify-content: center;"
             />
           </div>
         </div>
@@ -599,6 +611,9 @@ const SettingsDetailsContainer: React.FC = () => {
           flex-direction: column;
           justify-content: flex-start;
           height: 100%;
+          /* Definite width, so the buttons below size to the column rather
+             than each to its own label. */
+          width: 100%;
           align-items: center;
           margin-top: 40px;
           flex-grow: 1;
@@ -626,7 +641,8 @@ const SettingsDetailsContainer: React.FC = () => {
           text={t('Rate this app')}
           iconType="thumb_up"
           onClick={() => window.open(APP_CHROME_WEBSTORE_LINK + '/reviews')}
-          style="width: 250px; justify-content: center; margin-top: 40px;"
+          style="width: 100%;
+              max-width: 250px; justify-content: center; margin-top: 40px;"
         />
         <Button
           text={t('Share your thoughts')}
@@ -634,13 +650,15 @@ const SettingsDetailsContainer: React.FC = () => {
           onClick={() =>
             (window.location.href = `mailto:${DEV_EMAIL}?subject=${FEEDBACK_MAIL_SUBJECT}`)
           }
-          style="width: 250px; justify-content: center; margin-top: 16px;"
+          style="width: 100%;
+              max-width: 250px; justify-content: center; margin-top: 16px;"
         />
         <Button
           text={t('Share on Twitter (X)')}
           iconType="send"
           onClick={() => window.open(SHARE_TWITTER_TEXT)}
-          style="width: 250px; justify-content: center; margin-top: 16px;"
+          style="width: 100%;
+              max-width: 250px; justify-content: center; margin-top: 16px;"
         />
         <NormalLabel
           color={COLORS.LABEL_L3_COLOR}


### PR DESCRIPTION
Fixes KAN-30.

### Problem

Chrome applies the browser's **default page zoom** to extension popups, so the 800x600 allowance shrinks with it — 727px at 110%, 533px at 150%. The layout was fixed at `790px` with the panes splitting it exactly 100%, so any narrower viewport overflowed. Measured at 110% before the fix:

```
scrollW: 790   clientW: 717      content exactly as designed;
scrollH: 550   clientH: 531      the viewport was what had shrunk
```

Letting the container shrink then revealed that the interior couldn't shrink either — components overlapped and controls became unreachable.

### Two rules, applied everywhere

Every change here is one of these:

1. **A flex item needs `min-width: 0`.** Flex items default to `min-width: auto` and refuse to shrink below their content, so one long tab title or label pushes its whole row wider than the pane.
2. **A percentage width needs a definite parent.** `flex-direction: column` with `align-items: center` shrink-wraps to its widest child, so `width: 100%` resolves circularly and collapses to content size.

Plus one special case: `width: 100%` with any margin always overflows, since `box-sizing` covers padding and border but never margin.

### Home view

| Component | Change |
|---|---|
| `App` | `max-width: 100%` — percentage, not `vw`, which is unreliable during a popup's first paint |
| `MainContainer` | `min-width: 0` on all four panes |
| `HeroContainerLeft` | title shrinks, icon group doesn't — the gear was unclickable at 150% |
| `UserInputContainer` / `TextBox` | input shrinks, save button doesn't — the `+` was pushed out of the pane |
| `WindowEntryContainer` | `min-width: 0` through the row chain; `310px` / `330px` / `289px` → percentages |
| `TabGroupEntry` | `318px` → percentage |

### Settings

- **`overflow: auto` on the detail pane** — it was commented out, so fixed-width content widened the entire popup instead of scrolling in place
- Six `margin-left: 72px` → `padding-left: clamp(16px, 8%, 72px)`
- Fixed widths (`250px`, `260px`, `217px`, `120px`, `350px`) → percentages **capped at their old values**, so full-width rendering is unchanged
- Language grid given a definite width — it stays two columns instead of collapsing to one
- Theme swatches wrap via `gap` rather than per-item margins
- Account panels: `83px` / `64px` side padding in a ~220px column → clamped
- Category rows: `padding: 15px 38px` → clamped; 76px of padding left ~81px for text in a 157px pane

### Shared components

- **`Button`** — dropped a vestigial wrapper `div`. It was the real flex child, so `width: 100%` resolved against a shrink-wrapped div and collapsed to the button's own text width. That's why Backup and Restore rendered at different widths.
- **`Label`** — truncate an inner `span` rather than the wrapper. `text-overflow` doesn't apply to flex containers, so long labels were cut mid-word. The wrapper stays flex, since two callers centre through it and several pass `height: 100%`.

### Verification

Tested in the real popup, loaded unpacked, at **100 / 110 / 125 / 150%**, across the home view and all five settings categories:

- No overlap, no page-level or pane-level horizontal scrollbar
- Every control reachable at 150%
- Labels truncate with an ellipsis rather than cutting mid-word
- **100% renders as before** — every `clamp` and `max-width` uses the old fixed value as its maximum
- `tsc --noEmit` clean, 44/44 tests pass

Found iteratively: each fix made the next layer's failure visible, so this converged by testing rather than by reading.

### Note

800x600 is hardcoded in Chromium (`kMaxSize = {800, 600}`) and cannot be raised. This makes the layout degrade gracefully within that ceiling; it does not create more space. A side panel or open-in-tab mode would be the route to genuinely more room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)