### PR TITLE
Use the Firestore lite build and fix the permission-denied match it broke

### DIFF
--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -1,5 +1,11 @@
 import { initializeApp } from 'firebase/app';
-import { doc, getDoc, getFirestore } from 'firebase/firestore';
+// The lite build, not the full SDK. Sync is a single getDoc on open and a
+// single setDoc on save - no realtime listeners, and offline persistence was
+// never enabled here. The full SDK's cache and write queue only pay off on
+// long-lived pages, and a popup is destroyed before either is used twice.
+// Switching costs ~106 kB gzipped. Moving back to 'firebase/firestore' means
+// paying that again, so only do it if onSnapshot or offline reads are needed.
+import { doc, getDoc, getFirestore } from 'firebase/firestore/lite';
 import { getAuth, onAuthStateChanged, signInAnonymously } from 'firebase/auth';
 
 import { AppDispatch } from '../redux/store';

--- a/src/tests/utils/functions/firestoreErrors.test.ts
+++ b/src/tests/utils/functions/firestoreErrors.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  isMissingDocumentError,
+  isPermissionDenied,
+} from '../../../utils/functions/firestoreErrors';
+
+const USER_ID = '69dd1795-aeaf-4a7c-a4a0-dd20b605e3d5';
+
+// Both predicates gate the same recovery in loadFromFirestore: seed a cloud
+// document from local state. A false negative here is silent - the read fails,
+// nothing is seeded, and the user's first sync never happens.
+describe('isMissingDocumentError', () => {
+  test('matches the error fetchDataFromFirestore throws for an absent document', () => {
+    const error = new Error('Document does not exist for userId: ' + USER_ID);
+    expect(isMissingDocumentError(error, USER_ID)).toBe(true);
+  });
+
+  test('does not match the same message for a different user', () => {
+    const error = new Error('Document does not exist for userId: someone-else');
+    expect(isMissingDocumentError(error, USER_ID)).toBe(false);
+  });
+
+  test('does not match an unrelated failure', () => {
+    expect(
+      isMissingDocumentError(new Error('network request failed'), USER_ID)
+    ).toBe(false);
+  });
+
+  test('tolerates a thrown value with no message', () => {
+    expect(isMissingDocumentError(undefined, USER_ID)).toBe(false);
+    expect(isMissingDocumentError({}, USER_ID)).toBe(false);
+  });
+});
+
+describe('isPermissionDenied', () => {
+  // The full SDK and the lite build word this differently, which is exactly
+  // why the check is on code rather than message. Before this fix the lite
+  // wording fell through to the "unexpected error" branch and skipped the
+  // retry, so both wordings are pinned here.
+  test('matches the full SDK wording', () => {
+    const error: any = new Error('Missing or insufficient permissions.');
+    error.code = 'permission-denied';
+    expect(isPermissionDenied(error)).toBe(true);
+  });
+
+  test('matches the lite build wording, which prefixes the message', () => {
+    const error: any = new Error(
+      'Request failed with error: Missing or insufficient permissions.'
+    );
+    error.code = 'permission-denied';
+    expect(isPermissionDenied(error)).toBe(true);
+  });
+
+  test('does not match a different Firestore error code', () => {
+    const error: any = new Error('The service is currently unavailable.');
+    error.code = 'unavailable';
+    expect(isPermissionDenied(error)).toBe(false);
+  });
+
+  test('does not match an error whose message merely mentions permissions', () => {
+    // No code, so it is not a Firestore permission failure however it reads.
+    const error = new Error('Missing or insufficient permissions.');
+    expect(isPermissionDenied(error)).toBe(false);
+  });
+
+  test('tolerates a thrown value with no code', () => {
+    expect(isPermissionDenied(undefined)).toBe(false);
+    expect(isPermissionDenied({})).toBe(false);
+  });
+});

--- a/src/utils/functions/external.ts
+++ b/src/utils/functions/external.ts
@@ -1,4 +1,6 @@
-import { doc, setDoc } from 'firebase/firestore';
+// Lite build - see the note in src/config/firebase.ts. Must match the import
+// there, since db is created by that module's getFirestore.
+import { doc, setDoc } from 'firebase/firestore/lite';
 import { db, fetchDataFromFirestore } from '../../config/firebase';
 import {
   saveToFirestoreIfDirty,
@@ -8,6 +10,7 @@ import {
 import { TabMasterContainer } from '../../redux/slices/tabContainerDataStateSlice';
 import { AppDispatch } from '../../redux/store';
 import { stripEmbeddedFavicons } from './local';
+import { isMissingDocumentError, isPermissionDenied } from './firestoreErrors';
 
 // display a toast message
 export const displayToast = (
@@ -40,11 +43,16 @@ export async function loadFromFirestore(
     // still work.
     return tabDataFromCloud;
   } catch (error: any) {
-    if (error.message === 'Document does not exist for userId: ' + userId) {
-      console.warn('handled error: ' + error.message);
-      thunkAPI.dispatch(setIsDirty());
-      thunkAPI.dispatch(saveToFirestoreIfDirty());
-    } else if (error.message === `Missing or insufficient permissions.`) {
+    // Both of these mean "no usable cloud document for this user yet": either
+    // none exists, or the rules rejected the read because anonymous sign-in
+    // has not landed. Either way the recovery is the same - seed the document
+    // from local state.
+    //
+    // Match the permission failure on error.code, not on the message. The lite
+    // build reports it as "Request failed with error: Missing or insufficient
+    // permissions.", so comparing against the bare message silently fell
+    // through to the unexpected branch and skipped the retry entirely.
+    if (isMissingDocumentError(error, userId) || isPermissionDenied(error)) {
       console.warn('handled error: ' + error.message);
       thunkAPI.dispatch(setIsDirty());
       thunkAPI.dispatch(saveToFirestoreIfDirty());

--- a/src/utils/functions/firestoreErrors.ts
+++ b/src/utils/functions/firestoreErrors.ts
@@ -1,0 +1,15 @@
+// Predicates for the Firestore read failures that loadFromFirestore recovers
+// from. Kept separate from external.ts so they can be tested without pulling
+// in the Redux slices, which touch window at module load.
+
+// The user has no cloud document yet. This is our own error from
+// fetchDataFromFirestore, not the SDK's, so the message is stable.
+export const isMissingDocumentError = (error: any, userId: string): boolean =>
+  error?.message === 'Document does not exist for userId: ' + userId;
+
+// Firestore rejected the read. Keyed on the stable error code rather than the
+// message: the full SDK reports "Missing or insufficient permissions." while
+// the lite build prefixes it with "Request failed with error: ", so a message
+// comparison silently stops matching depending on which build is imported.
+export const isPermissionDenied = (error: any): boolean =>
+  error?.code === 'permission-denied';


### PR DESCRIPTION
## Why

Sync is a single `getDoc` when the popup opens and a single `setDoc` on save. There are **no realtime listeners** anywhere in the app, and **offline persistence was never enabled** — `src/config/firebase.ts` calls a plain `getFirestore(app)`, and the web SDK does not enable IndexedDB persistence by default.

So the full SDK's cache, write queue and WebChannel transport are dormant. The popup is destroyed long before any of them get used twice — we were shipping ~360 kB of offline-sync machinery to do one REST GET and one REST PUT.

| | Raw | Gzip |
|---|---|---|
| `main` before the firebase 12 upgrade | 748.5 kB | 201.1 kB |
| `main` today | 844.5 kB | 255.3 kB |
| **this branch** | **483.5 kB** | **149.3 kB** |

41% below current `main`, and 26% below where it sat before the upgrade.

## The bug this surfaced

The switch **broke `loadFromFirestore`'s error handling**, which is most of this diff.

It matched the permission failure against the literal string `Missing or insufficient permissions.`. The lite build reports the same failure as `Request failed with error: Missing or insufficient permissions.`, so the comparison stopped matching and the handler fell through to the `unexpected error` branch — skipping the `setIsDirty`/save retry that seeds a document for a new user.

Caught in Chrome on a fresh install, same path on both builds:

| | full SDK | lite, before this fix |
|---|---|---|
| Message | `Missing or insufficient permissions.` | `Request failed with error: Missing or …` |
| Branch | `handled error` → seed document | **`unexpected error` → nothing** |

Now matched on `error.code === 'permission-denied'`, which is stable across both builds. The predicates moved to a new `firestoreErrors` module rather than living in `external.ts`, so they can be tested directly — `external.ts` pulls in the Redux slices, which touch `window` at module load.

## Evidence

| Gate | Result |
|---|---|
| `tsc --noEmit` | clean |
| `npm test` | **74/74** (9 new) |
| `npm run build` | clean |
| `prettier --check src/` | clean |
| `npm audit` | 0 vulnerabilities |

Reverting the fix to the old message compare **fails 2 of the 9 new tests** — the lite-wording case and the false-positive guard. Both wordings are pinned in the suite so this can't regress silently in either direction.

**E2E in Chrome against real Firestore**, on the *pruned* artifact that actually ships, from a genuinely fresh install:

- Anonymous auth → `accounts:signUp` 200
- Document seeded on first run → `commit` 200
- Session written with real tab URLs
- Read back into a new instance with `chrome.storage.local` **empty** — session returned with its original timestamp, tabs and favicons
- Release workflow's remote-code prune still matches this bundle shape; the CI guard passes

## Note for reviewers

The first read races anonymous sign-in and is rejected, then retries once auth lands (three 403s, then all 200s, ~150ms).

**This race is not new.** The full SDK hits the same rejection on a fresh install — it just surfaces inside a WebChannel 200 rather than an HTTP 403. Lite only makes it visible in the network panel. Worth fixing separately by gating the initial read on `onAuthStateChanged`, but that's a startup-sequencing change and doesn't belong here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)