### PR TITLE
Allow the release workflow to be dry-run without cutting a tag

### DIFF
--- a/.github/workflows/build_and_release_artifact.yaml
+++ b/.github/workflows/build_and_release_artifact.yaml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual dry run. Lets the whole release path - build, remote-code prune,
+  # and the verification that no remotely hosted URLs survive - be exercised
+  # without cutting a tag. Nothing here publishes: the job only uploads an
+  # artifact, so a dispatch run is side-effect free.
+  workflow_dispatch:
 
 jobs:
   build:
@@ -66,5 +71,8 @@ jobs:
       - name: Upload release zip file ready for Chrome Web Store
         uses: actions/upload-artifact@v7
         with:
-          name: tab-keeper-react-chrome-extension-v${{steps.version.outputs.prop}}
+          # A dry run builds the same artifact but is not a release, so mark it
+          # to keep it from being mistaken for the package that goes to the
+          # Web Store. github.event_name is a trusted context value.
+          name: tab-keeper-react-chrome-extension-v${{steps.version.outputs.prop}}${{ github.event_name == 'workflow_dispatch' && '-dryrun' || '' }}
           path: ./dist/


### PR DESCRIPTION
## Why

The release workflow only fires on a `v*` tag push. Since #116 rewrote its remote-code prune step, that step **has never executed on a runner** — so the next release would be the first real test of the path that decides whether the Web Store package ships remotely hosted script URLs.

I verified the prune locally by extracting both `run` blocks verbatim and executing them under `bash -e` (the guard correctly fails on an unpruned bundle and on a renamed URL shape). But the literal GNU `sed -i` line can't run on macOS — I had to bridge it with a shim. That's the gap this closes.

## What

`workflow_dispatch`, so the whole path — build → prune → verify-no-remote-URLs — can be run on demand.

**Nothing in this job publishes.** It builds and uploads an artifact; it does not create a tag, a release, or touch the Web Store. A dispatch run is side-effect free.

Dry-run artifacts get a `-dryrun` suffix so they can't be mistaken for the real package. `github.event_name` is a trusted context value, not user input.

## Note

`workflow_dispatch` only becomes runnable once it's on the default branch, so this has to merge before the first dry run. I'll run it immediately after and report what the prune and verify steps actually do on a real runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)