### PR TITLE
Bump version to 1.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,21 @@ Tab Keeper is an intuitive Chrome extension crafted to redefine the way users sa
 
 ## Changelog
 
-### v.1.3.2 (Latest)
+### v.1.3.3 (Latest)
+
+#### Fixes
+
+- Saving a suspended tab now stores the real page instead of the suspending extension's placeholder address. Sessions already saved this way are repaired automatically the next time they are restored
+- Restoring a window now opens its first tab at the correct address
+- The popup no longer overflows or shows scrollbars at browser zoom levels other than 100%
+
+#### Improvements
+
+- The extension is roughly a quarter smaller, so the popup opens faster
+- A sync status message that always appeared in English is now translated
+- Dependent packages updated to latest versions
+
+### v.1.3.2
 
 #### Improvements
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tab-keeper-react-chrome-extension",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tab-keeper-react-chrome-extension",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Justine George",
   "description": "Efficiently save and synchronize tabs across devices without the need for personal logins.",
   "private": true,
-  "version": "1.3.2",
+  "version": "1.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "1.3.2",
+  "version": "1.3.3",
   "name": "Tab Keeper - Chrome Tab Manager & Sync Tool",
   "description": "Efficiently save and synchronize tabs across devices without the need for personal logins.",
   "action": {


### PR DESCRIPTION
Cuts 1.3.3. Everything merged since the `v1.3.2` tag has been sitting unreleased — including a P0 and a data-loss fix.

## What ships

Verified with `git log v1.3.2..main`:

| PR | Change | User-facing |
|---|---|---|
| #112 | responsive popup layout (KAN-30) | ✅ |
| #113 | dependency refresh + localized a hardcoded English toast | ✅ |
| #114 | suspended tabs store the real page (KAN-29, KAN-19) | ✅ |
| #117 | `firestore/lite` — bundle 201 → 149 kB gzip vs 1.3.2 | ✅ |
| #111, #115, #116, #118 | workflow and tooling | — |

## Changelog

Added a `v.1.3.3` section to the README in the existing voice, and moved `(Latest)` off 1.3.2. The version badge reads `package.json` dynamically, so it needs no edit.

One claim worth flagging as verified rather than assumed: the changelog says already-saved suspended-tab sessions are **repaired when restored**. `resolveTabUrl` runs on the restore path (`tabContainerDataStateSlice.ts:156`), not only on save, so previously-corrupted sessions do get fixed.

## Release confidence

The release workflow's remote-code prune was silently no-opping before #116 and would have shipped three live remote-script URLs into Web Store review. That's fixed and now guarded — and #118 let me dry-run the whole path on a real runner ([run 33362677930](https://github.com/justine-george/tab-keeper-react-chrome-extension/actions/runs/33362677930)):

- GNU `sed -i` ran clean under `bash -e` — the one thing not testable on macOS
- Verify step printed "No remotely hosted script URLs remain in the bundle."
- Node resolved to v22.23.2, satisfying Vite 8 and Vitest 4
- Downloaded the artifact and confirmed the URLs are **blanked**, not merely absent

So tagging this is a repeat of a known-good run, not a first attempt.

## Gates

`npm test` 74/74 · `npm audit` 0 vulnerabilities · build clean · versions synced (`package.json` and `manifest.json` both 1.3.3)

## After merge

Tag with `npm run release-artifact`, then submit the artifact to the Web Store. Once it publishes, clear `pending-release` on KAN-19, KAN-29 and KAN-30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)