### PR TITLE
Fix import validators crashing on null, and make lint gate CI

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,5 +12,13 @@ module.exports = {
   rules: {
     'react-refresh/only-export-components': 'warn',
     'prettier/prettier': 'error',
+    // @typescript-eslint/recommended sets this to 'error'. Nothing in the
+    // project ever opted into that, and combined with --max-warnings 0 and no
+    // lint step in CI it produced a script that could not pass and that nobody
+    // ran. Downgraded deliberately so real errors gate CI while the remaining
+    // `any`s stay visible. They are mostly boundary code where `unknown` plus a
+    // type guard is the right answer - see isValidTabMasterContainer in
+    // utils/functions/local.ts for the pattern to follow when clearing them.
+    '@typescript-eslint/no-explicit-any': 'warn',
   },
 };

--- a/.github/workflows/build_before_merge.yaml
+++ b/.github/workflows/build_before_merge.yaml
@@ -22,6 +22,12 @@ jobs:
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
 
+      # Fails on lint errors only; `any` and exhaustive-deps are warnings and
+      # are reported without blocking. Without this step the lint script was
+      # never run by anything, so violations accumulated unnoticed.
+      - name: Run lint
+        run: npm run lint
+
       - name: Run tests
         run: npm run test
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test-build": "npm run test && npm run build",
     "pretty": "npx prettier -w .",
     "pretty-build": "npm run pretty && npm run build",
-    "lint": "eslint src --ext ts,tsx --max-warnings 0",
+    "lint": "eslint src --ext ts,tsx",
     "sync-versions": "node ./scripts/package_to_manifest.cjs",
     "bump-version": "node ./scripts/bump_version.cjs",
     "create-tag": "git tag v$(node -p \"require('./package.json').version\")",

--- a/src/components/home/rightpane/TabGroupDetailsContainer.tsx
+++ b/src/components/home/rightpane/TabGroupDetailsContainer.tsx
@@ -101,7 +101,7 @@ export default function TabGroupDetailsContainer() {
         </div>
       ) : (
         <div css={filledContainerStyle}>
-          {selectedTabGroup.windows.map(({ windowId, title, tabs }, _) => {
+          {selectedTabGroup.windows.map(({ windowId, title, tabs }) => {
             return (
               <div>
                 <WindowEntryContainer

--- a/src/tests/utils/functions/local.test.ts
+++ b/src/tests/utils/functions/local.test.ts
@@ -295,6 +295,32 @@ describe('isValidTabMasterContainer', () => {
     expect(isValidTabMasterContainer(validData)).toBe(true);
   });
 
+  // A .json file containing any of these is valid JSON, so the import path can
+  // hand them straight to the validator. It must reject them, not throw - the
+  // caller shows error.message to the user, so a TypeError leaks
+  // "Cannot read properties of null" instead of "Invalid JSON structure."
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a number', 42],
+    ['a string', 'not an object'],
+    ['a boolean', true],
+    ['an array', []],
+  ])('should return false for %s rather than throwing', (_label, input) => {
+    expect(() => isValidTabMasterContainer(input)).not.toThrow();
+    expect(isValidTabMasterContainer(input)).toBe(false);
+  });
+
+  test('should return false when a nested tab group is null', () => {
+    const invalidData = {
+      lastModified: Date.now(),
+      selectedTabGroupId: null,
+      tabGroups: [null],
+    };
+    expect(() => isValidTabMasterContainer(invalidData)).not.toThrow();
+    expect(isValidTabMasterContainer(invalidData)).toBe(false);
+  });
+
   test('should return false for invalid TabMasterContainer structure', () => {
     const invalidData = {
       selectedTabGroupId: 'sample-id',

--- a/src/utils/functions/local.ts
+++ b/src/utils/functions/local.ts
@@ -310,11 +310,22 @@ export function resolveFaviconUrl(favicon: string, pageUrl: string): string {
   return url.toString();
 }
 
+// These validators run on whatever JSON a user hands the import dialog, so the
+// input is genuinely unknown rather than merely untyped. Taking `unknown` is
+// what forces the null check below: `typeof null.lastModified` throws, and the
+// import handler prints error.message straight to a toast, so a missing guard
+// surfaced as "Cannot read properties of null" instead of "Invalid JSON
+// structure." Arrays are excluded too - every field lookup on one is undefined,
+// so they would fall through as merely invalid rather than the wrong shape.
+const isRecord = (data: unknown): data is Record<string, unknown> =>
+  typeof data === 'object' && data !== null && !Array.isArray(data);
+
 // validate import JSON structure - TabMasterContainer
 export const isValidTabMasterContainer = (
-  data: any
+  data: unknown
 ): data is TabMasterContainer => {
   return (
+    isRecord(data) &&
     typeof data.lastModified === 'number' &&
     (typeof data.selectedTabGroupId === 'string' ||
       data.selectedTabGroupId === null) &&
@@ -324,8 +335,9 @@ export const isValidTabMasterContainer = (
 };
 
 // validate import JSON structure - tabContainerData
-const isValidTabContainerData = (data: any): data is tabContainerData => {
+const isValidTabContainerData = (data: unknown): data is tabContainerData => {
   return (
+    isRecord(data) &&
     typeof data.tabGroupId === 'string' &&
     typeof data.title === 'string' &&
     typeof data.createdTime === 'string' &&
@@ -339,8 +351,9 @@ const isValidTabContainerData = (data: any): data is tabContainerData => {
 };
 
 // validate import JSON structure - windowGroupData
-const isValidWindowGroupData = (data: any): data is windowGroupData => {
+const isValidWindowGroupData = (data: unknown): data is windowGroupData => {
   return (
+    isRecord(data) &&
     typeof data.windowId === 'string' &&
     typeof data.tabCount === 'number' &&
     typeof data.title === 'string' &&
@@ -350,8 +363,9 @@ const isValidWindowGroupData = (data: any): data is windowGroupData => {
 };
 
 // validate import JSON structure - tabData
-const isValidTabData = (data: any): data is tabData => {
+const isValidTabData = (data: unknown): data is tabData => {
   return (
+    isRecord(data) &&
     typeof data.tabId === 'string' &&
     typeof data.favicon === 'string' &&
     typeof data.title === 'string' &&


### PR DESCRIPTION
## The lint script has never passed

31 errors against `--max-warnings 0`, and nothing ever ran it — CI only runs `test` and `build`. So violations accumulated unnoticed; **#117 added five more yesterday** without either of us catching it.

30 of the 31 were `no-explicit-any`, which nobody opted into. It arrives as `error` from `@typescript-eslint/recommended` (v6.12.0 — verified by introspecting the preset); `.eslintrc.cjs` sets only two rules and that isn't one of them.

## Typing the validators properly found a real bug

The import validators read fields straight off their `any` argument:

```ts
export const isValidTabMasterContainer = (data: any): data is TabMasterContainer =>
  typeof data.lastModified === 'number' && ...
```

A `.json` file containing just `null` is **valid JSON**, so `JSON.parse` returns `null` and this throws a TypeError instead of returning `false`. The import handler prints `error.message` to a toast, so:

| | Message shown to the user |
|---|---|
| Intended | `Error restoring tabs: Invalid JSON structure.` |
| Actual | `Error restoring tabs: Cannot read properties of null (reading 'lastModified')` |

Arrays had the same shape of problem — every field lookup is `undefined`, so they fell through as merely invalid rather than the wrong type.

Fixed with an `isRecord` guard covering `null`, `undefined`, primitives and arrays, and all four validators now take `unknown`. Taking `unknown` is what *forces* the guard — that's the point of the change rather than a side effect.

## The rest

- `no-explicit-any` → `'warn'`, set **explicitly** in `.eslintrc.cjs` as a project decision rather than an inherited default, with a comment pointing at the validators as the pattern for clearing the rest
- Dropped `--max-warnings 0` so the script can actually pass
- Removed the one real `no-unused-vars` (an unused `.map()` index)
- **Added a lint step to `build_before_merge`** so errors gate PRs

The 26 remaining `any`s are visible but non-blocking. They're mostly boundary code where `unknown` + a guard is the right answer; `loadFromLocalStorage(): any` feeding 8 call sites is the next one worth doing, but it changes the sync path so it wants its own PR and E2E.

## Evidence

| Gate | Result |
|---|---|
| `npm run lint` | **exit 0** — 0 errors, 29 warnings (was 31 errors) |
| `tsc --noEmit` | clean |
| `npm test` | **81/81** (8 new) |
| `npm run build` | clean |
| `prettier --check` | clean |

Reverting just the `isRecord` guard **fails 3 of the new tests** (`null`, `undefined`, and a nested null tab group). Primitives already returned `false` harmlessly, and the tests distinguish those cases.

**E2E in Chrome** on the built extension: Settings → Data Management → Restore App Data from File, with a file containing `null` → toast reads **"Error restoring tabs: Invalid JSON structure."**

🤖 Generated with [Claude Code](https://claude.com/claude-code)