### PR TITLE
Make the sync conflict modal keyboard-accessible (KAN-31)

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -53,6 +53,8 @@
   "Saved sessions": "Saved sessions",
   "Saved session": "Saved session",
   "Cloud Data": "Cloud Data",
+  "SyncConflictHeader": "Sync conflict: choose which copy of your sessions to keep",
+  "SyncConflictDismissLabel": "Dismiss and decide later",
   "Back": "Back",
   "Display": "Display",
   "Sync & Privacy": "Sync & Privacy",

--- a/src/components/modals/ConflictModal.tsx
+++ b/src/components/modals/ConflictModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { css } from '@emotion/react';
@@ -19,6 +20,8 @@ import {
 import { useTranslation } from 'react-i18next';
 import { getStringDate } from '../../utils/functions/local';
 
+const TITLE_ID = 'conflict-modal-title';
+
 interface ConflictModalProps {
   style?: string;
 }
@@ -28,6 +31,8 @@ export const ConflictModal: React.FC<ConflictModalProps> = ({ style }) => {
   const FONT_FAMILY = useFontFamily();
   const { t } = useTranslation();
   const dispatch: AppDispatch = useDispatch();
+
+  const dialogRef = useRef<HTMLDialogElement>(null);
 
   const isConflictModalOpen = useSelector(
     (state: RootState) => state.globalState.isConflictModalOpen
@@ -45,61 +50,89 @@ export const ConflictModal: React.FC<ConflictModalProps> = ({ style }) => {
     (state: RootState) => state.globalState.hasSyncedBefore
   );
 
-  if (!isConflictModalOpen) return null;
+  const hasConflictToResolve =
+    isConflictModalOpen && tabDataLocal !== null && tabDataCloud !== null;
 
-  const isLocalRecent = tabDataLocal!.lastModified > tabDataCloud!.lastModified;
+  // showModal() is what makes this modal rather than merely visible: the
+  // browser moves the dialog to the top layer, confines Tab to the controls
+  // inside it, marks the panes behind it inert so a screen reader cannot walk
+  // into UI the user can neither see nor use, and closes it on Escape.
+  // Rendering the element with the `open` attribute instead would give none of
+  // that. The effect must sit above the early return to keep hook order fixed.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog && !dialog.open) {
+      dialog.showModal();
+    }
+  }, [hasConflictToResolve]);
 
-  const tabDataLocalLength = tabDataLocal!.tabGroups.length;
-  const tabDataCloudLength = tabDataCloud!.tabGroups.length;
+  // Narrowing rather than asserting: both fields really are
+  // `TabMasterContainer | null`, and there is nothing to show without them.
+  // This is what lets the body below read them without `!`.
+  if (!hasConflictToResolve) return null;
+
+  const isLocalRecent = tabDataLocal.lastModified > tabDataCloud.lastModified;
+
+  const tabDataLocalLength = tabDataLocal.tabGroups.length;
+  const tabDataCloudLength = tabDataCloud.tabGroups.length;
 
   const handleChooseLocalData = () => {
-    dispatch(replaceState(tabDataLocal!));
+    dispatch(replaceState(tabDataLocal));
     dispatch(setIsDirty());
     dispatch(saveToFirestoreIfDirty());
     if (!hasSyncedBefore) {
       // reset presentState in the undoRedoState
-      dispatch(setPresentStartup({ tabContainerDataState: tabDataLocal! }));
+      dispatch(setPresentStartup({ tabContainerDataState: tabDataLocal }));
       dispatch(setHasSyncedBefore());
     }
     dispatch(closeConflictModal());
   };
 
   const handleChooseCloudData = () => {
-    dispatch(replaceState(tabDataCloud!));
+    dispatch(replaceState(tabDataCloud));
     dispatch(setIsNotDirty());
     if (!hasSyncedBefore) {
       // reset presentState in the undoRedoState
-      dispatch(setPresentStartup({ tabContainerDataState: tabDataCloud! }));
+      dispatch(setPresentStartup({ tabContainerDataState: tabDataCloud }));
       dispatch(setHasSyncedBefore());
     }
     dispatch(closeConflictModal());
   };
 
-  const overlayStyle = css`
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.8);
-    z-index: 999;
-    font-family: ${FONT_FAMILY};
-    font-size: 0.9rem;
-    ${style && style}
-  `;
+  // Leaving the conflict unresolved writes nothing; the next sync re-offers it.
+  const handleDismiss = () => {
+    dispatch(closeConflictModal());
+  };
 
-  const modalContentStyle = css`
+  const dialogStyle = css`
+    /* The UA gives <dialog> its own box; reset it back to the modal's geometry. */
     position: fixed;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+    margin: 0;
+    padding: 0;
+    width: 80%;
+    height: 50%;
+    max-width: none;
+    max-height: none;
     background-color: ${COLORS.PRIMARY_COLOR};
     color: ${COLORS.LABEL_L1_COLOR};
     border: 1px solid ${COLORS.BORDER_COLOR};
-    width: 80%;
-    height: 50%;
-    z-index: 1000;
-    display: flex;
+    font-family: ${FONT_FAMILY};
+    font-size: 0.9rem;
+
+    /* Scoped to [open] so the dialog stays hidden until showModal() runs,
+       rather than flashing as a non-modal box for a frame. */
+    &[open] {
+      display: flex;
+    }
+
+    &::backdrop {
+      background: rgba(0, 0, 0, 0.8);
+    }
+
+    ${style && style}
   `;
 
   const paneStyle = css`
@@ -110,7 +143,13 @@ export const ConflictModal: React.FC<ConflictModalProps> = ({ style }) => {
     width: 50%;
     height: 100%;
     padding: 20px;
+    margin: 0;
     border: 1px solid ${COLORS.BORDER_COLOR};
+    background: none;
+    color: inherit;
+    font-family: inherit;
+    font-size: inherit;
+    text-align: left;
     cursor: pointer;
     transition:
       background-color 0.2s,
@@ -119,6 +158,40 @@ export const ConflictModal: React.FC<ConflictModalProps> = ({ style }) => {
     &:hover {
       background-color: ${COLORS.SELECTION_COLOR};
       color: ${COLORS.CONTRAST_COLOR};
+    }
+
+    /* TEXT_COLOR is the theme's foreground, so it contrasts with every pane
+       background by construction, hover included. Inset so the ring is not
+       clipped by the neighbouring pane's border. */
+    &:focus-visible {
+      outline: 2px solid ${COLORS.TEXT_COLOR};
+      outline-offset: -4px;
+    }
+  `;
+
+  const closeButtonStyle = css`
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    background: none;
+    border: none;
+    color: ${COLORS.TEXT_COLOR};
+    font-family: inherit;
+    cursor: pointer;
+
+    &:hover {
+      background-color: ${COLORS.HOVER_COLOR};
+    }
+
+    &:focus-visible {
+      outline: 2px solid ${COLORS.TEXT_COLOR};
+      outline-offset: -2px;
     }
   `;
 
@@ -145,69 +218,105 @@ export const ConflictModal: React.FC<ConflictModalProps> = ({ style }) => {
     margin-right: 4px;
   `;
 
-  const h2Style = css`
+  // Deliberately not iconStyle: that carries a margin-right to space the pane
+  // glyphs from their headings, which would push this one off-centre.
+  const closeIconStyle = css`
+    font-size: 1.5rem;
+  `;
+
+  // Was an <h2>, which is invalid inside a <button>. The UA's h2 sizing
+  // (1.5em of the dialog's 0.9rem) is restated here so the panes look unchanged.
+  const paneHeadingStyle = css`
+    font-size: 1.35rem;
     font-weight: 500;
   `;
 
-  return (
-    <div css={overlayStyle}>
-      <div css={modalContentStyle}>
-        <div css={paneStyle} onClick={handleChooseLocalData}>
-          <div css={topRowStyle}>
-            <span css={iconStyle} className="material-symbols-outlined">
-              storage
-            </span>
-            <h2 css={h2Style}>{t('Local Data')}</h2>
-            {isLocalRecent && (
-              <Tag value={t('LATEST')} style={latestTagStyle} />
-            )}
-          </div>
-          <NormalLabel
-            value={`${t('Last updated')}: ${getStringDate(
-              new Date(tabDataLocal!.lastModified)
-            )}`}
-            size="0.9rem"
-            color={COLORS.TEXT_COLOR}
-            style="margin-top: 40px; align-self: flex-start;"
-          />
-          <NormalLabel
-            value={`${tabDataLocalLength} ${
-              tabDataLocalLength > 1 ? t('Saved sessions') : t('Saved session')
-            }`}
-            size="0.9rem"
-            color={COLORS.TEXT_COLOR}
-            style="margin-top: 40px; align-self: flex-start;"
-          />
-        </div>
+  // Names the dialog for assistive tech without altering the visual layout.
+  const visuallyHiddenStyle = css`
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  `;
 
-        <div css={paneStyle} onClick={handleChooseCloudData}>
-          <div css={topRowStyle}>
-            <span css={iconStyle} className="material-symbols-outlined">
-              cloud
-            </span>
-            <h2 css={h2Style}>{t('Cloud Data')}</h2>
-            {!isLocalRecent && (
-              <Tag value={t('LATEST')} style={latestTagStyle} />
-            )}
-          </div>
-          <NormalLabel
-            value={`${t('Last updated')}: ${getStringDate(
-              new Date(tabDataCloud!.lastModified)
-            )}`}
-            size="0.9rem"
-            color={COLORS.TEXT_COLOR}
-            style="margin-top: 40px;  align-self: flex-start;"
-          />
-          <NormalLabel
-            value={`${tabDataCloudLength} ${
-              tabDataCloudLength > 1 ? t('Saved sessions') : t('Saved session')
-            }`}
-            size="0.9rem"
-            color={COLORS.TEXT_COLOR}
-            style="margin-top: 40px; align-self: flex-start;"
-          />
+  return (
+    <dialog
+      ref={dialogRef}
+      css={dialogStyle}
+      aria-labelledby={TITLE_ID}
+      onCancel={handleDismiss}
+    >
+      <h2 id={TITLE_ID} css={visuallyHiddenStyle}>
+        {t('SyncConflictHeader')}
+      </h2>
+
+      <button
+        type="button"
+        css={closeButtonStyle}
+        onClick={handleDismiss}
+        aria-label={t('SyncConflictDismissLabel')}
+      >
+        <span css={closeIconStyle} className="material-symbols-outlined">
+          close
+        </span>
+      </button>
+
+      <button type="button" css={paneStyle} onClick={handleChooseLocalData}>
+        <div css={topRowStyle}>
+          <span css={iconStyle} className="material-symbols-outlined">
+            storage
+          </span>
+          <span css={paneHeadingStyle}>{t('Local Data')}</span>
+          {isLocalRecent && <Tag value={t('LATEST')} style={latestTagStyle} />}
         </div>
-      </div>
-    </div>
+        <NormalLabel
+          value={`${t('Last updated')}: ${getStringDate(
+            new Date(tabDataLocal.lastModified)
+          )}`}
+          size="0.9rem"
+          color={COLORS.TEXT_COLOR}
+          style="margin-top: 40px; align-self: flex-start;"
+        />
+        <NormalLabel
+          value={`${tabDataLocalLength} ${
+            tabDataLocalLength > 1 ? t('Saved sessions') : t('Saved session')
+          }`}
+          size="0.9rem"
+          color={COLORS.TEXT_COLOR}
+          style="margin-top: 40px; align-self: flex-start;"
+        />
+      </button>
+
+      <button type="button" css={paneStyle} onClick={handleChooseCloudData}>
+        <div css={topRowStyle}>
+          <span css={iconStyle} className="material-symbols-outlined">
+            cloud
+          </span>
+          <span css={paneHeadingStyle}>{t('Cloud Data')}</span>
+          {!isLocalRecent && <Tag value={t('LATEST')} style={latestTagStyle} />}
+        </div>
+        <NormalLabel
+          value={`${t('Last updated')}: ${getStringDate(
+            new Date(tabDataCloud.lastModified)
+          )}`}
+          size="0.9rem"
+          color={COLORS.TEXT_COLOR}
+          style="margin-top: 40px;  align-self: flex-start;"
+        />
+        <NormalLabel
+          value={`${tabDataCloudLength} ${
+            tabDataCloudLength > 1 ? t('Saved sessions') : t('Saved session')
+          }`}
+          size="0.9rem"
+          color={COLORS.TEXT_COLOR}
+          style="margin-top: 40px; align-self: flex-start;"
+        />
+      </button>
+    </dialog>
   );
 };


### PR DESCRIPTION
Fixes [KAN-31](https://justinegeo96.atlassian.net/browse/KAN-31).

## The problem

Both choice panes were plain `div`s with `onClick` and nothing else — no `tabIndex`, no `role`, no key handler, with `:hover` as the only affordance. `closeConflictModal()` was dispatched solely from those two handlers, so there was no Escape, no close button and no backdrop dismiss.

A keyboard or assistive-technology user hitting a sync conflict could not focus either option, could not activate either option, and could not leave. The modal covers the UI and there is no other route to resolve the conflict, so the extension was unusable from that point — on the one screen in the app that discards a set of saved sessions.

## The approach

Render the modal as a native `<dialog>` opened with `showModal()` rather than a fixed-position `div`. The browser then supplies what would otherwise be hand-rolled focus-trap code: the dialog moves to the top layer, Tab is confined to its controls, Escape closes it, and everything behind it is made **inert**, so a screen reader cannot walk into UI the overlay is visually blocking.

That last part is why this is a `<dialog>` and not a `div` with `role="dialog"`. A hand-rolled trap can intercept Tab, but it cannot stop assistive technology reaching the panes underneath without also applying `inert` to every sibling in `MainContainer`.

`closedby` is deliberately **not** used. It is unavailable in this repo's types (absent from both TS 5.3's `lib.dom.d.ts` and `@types/react` 18.2's `DialogHTMLAttributes`), so attaching it would need a cast, and accidental backdrop dismissal on a destructive either/or prompt is a misfeature anyway. Escape and an explicit close button are the two ways out.

Both panes become real `<button>`s, so Enter and Space activate them and `:focus-visible` gives them a ring in `COLORS.TEXT_COLOR` — the theme foreground, which contrasts with every pane background by construction, hover included.

## Notable details

- **`<h2>` inside `<button>` is invalid HTML**, so each pane heading becomes a `span`. `h2Style` only set `font-weight: 500`, so the UA's `1.5em` sizing is restated explicitly (`1.35rem` against the dialog's `0.9rem`) to keep the panes looking unchanged.
- **Six `!` assertions are removed, not relocated.** `tabDataLocal` and `tabDataCloud` really are `TabMasterContainer | null`; guarding on them up front lets the body read them directly. `tsc` confirms the narrowing holds.
- **The `useEffect`/`useRef` sit above the early return** to keep hook order fixed.
- **Dismissing does not resolve the conflict**, which is safe — nothing is written until a choice is made, so the next sync re-offers it.
- **Two new keys go to the `en` locale only**, per the #113 precedent of letting the other nine fall back.

## Verification

No component test infrastructure exists (no jsdom, no RTL — KAN-2), so this was verified end-to-end against real Firestore with a staged two-device conflict, driving the popup by keyboard only and asserting on the accessibility tree.

| Check | Before (`1863bae`) | After |
|---|---|---|
| `<dialog>` in DOM | absent | present, announced `modal` |
| Pane semantics | `heading` + bare `StaticText` | `button` |
| Pane `tabIndex` | `-1`, `role: null` | focusable |
| Background controls focusable while open | **29 / 29** | **0 / 32** |
| Escape | modal still on screen | closes |
| Enter on Local pane | — | resolves, `documents:commit [200]` |
| Space on Cloud pane | — | resolves, stale local discarded |

Tab order is close → Local → Cloud → (browser chrome) → close. The hop through browser chrome is unavoidable and correct for any modal; what matters is that it never lands on app content, which the 0/32 figure demonstrates directly.

Escape's safety, against Enter on identical staging:

```
Escape:  translation.json, accounts:lookup, documents:batchGet         <- reads only
         localStorage lastModified 1788163556674, 2 sessions, unchanged
         reload -> conflict re-offered

Enter:   translation.json, accounts:lookup, documents:batchGet,
         documents:commit [200]                                        <- write fired
```

Reverting the change and re-running the same probes reproduces the original failure in full: no dialog element, panes exposed as `heading`/`StaticText` with `tabIndex -1`, all 29 background controls focusable, Escape leaving the modal on screen.

Gate: `tsc` clean, lint 0 errors / 29 warnings (unchanged from `1863bae`), 81/81 tests, prettier clean. Bundle 149.92 kB gzip, up 0.58 kB.

## What is not covered

- **No automated regression test.** The revert check above was done by hand. Blocked on KAN-2.
- **Screen-reader semantics verified via the accessibility tree, not real VoiceOver.**
- **Only the LIGHT theme was inspected visually.** The focus ring uses `COLORS.TEXT_COLOR`, so it contrasts in all five by construction, but the other four were not eyeballed.

Related: [KAN-4](https://justinegeo96.atlassian.net/browse/KAN-4) (session preview in this modal) and [KAN-32](https://justinegeo96.atlassian.net/browse/KAN-32) (auto-merge, which keeps this modal as its rare-case fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)