### PR TITLE
Stop recolouring the conflict pane text on hover (KAN-34)

### DIFF
--- a/src/components/modals/ConflictModal.tsx
+++ b/src/components/modals/ConflictModal.tsx
@@ -151,13 +151,15 @@ export const ConflictModal: React.FC<ConflictModalProps> = ({ style }) => {
     font-size: inherit;
     text-align: left;
     cursor: pointer;
-    transition:
-      background-color 0.2s,
-      color 0.2s;
+    transition: background-color 0.2s;
 
+    /* Only the background shifts on hover. Recolouring the text here used to
+       set CONTRAST_COLOR, which is an accent value rather than a foreground:
+       it does not track each theme's light/dark polarity, so the heading and
+       icon dropped to 1.32-1.56:1 in every theme except LIGHT. Inheriting
+       LABEL_L1_COLOR instead keeps them at 5.13:1 or better everywhere. */
     &:hover {
       background-color: ${COLORS.SELECTION_COLOR};
-      color: ${COLORS.CONTRAST_COLOR};
     }
 
     /* TEXT_COLOR is the theme's foreground, so it contrasts with every pane


### PR DESCRIPTION
Fixes [KAN-34](https://justinegeo96.atlassian.net/browse/KAN-34).

## The problem

`paneStyle`'s hover rule set the text colour to `CONTRAST_COLOR` over a `SELECTION_COLOR` background. The pane heading ("Local Data" / "Cloud Data") and its `storage`/`cloud` glyph inherit it, and **`CONTRAST_COLOR` is not a foreground value** — its per-theme definitions (`#FBFAE8` cream, `#F06292` pink, `#1A1A1A` near-black on a *dark* theme) are accents that don't track each theme's light/dark polarity the way `TEXT_COLOR` and `LABEL_L1_COLOR` do.

| Theme | Before | After | |
|---|---|---|---|
| LIGHT | 7.29 | 5.46 | was already passing |
| WARM_LIGHT | **1.32** | 6.07 | |
| BB_PINK | **1.52** | 7.14 | |
| DARKENHEIMER | **1.55** | 5.17 | |
| BLUE | **1.56** | 5.13 | |

WCAG 2.2 SC 1.4.3 requires 3:1 for large text (1.35rem at weight 500). Four of five themes failed. **LIGHT passed only by coincidence**, because its `CONTRAST_COLOR` happens to be dark — which is exactly why this survived review on #121, where LIGHT was the only theme checked.

The body text was never affected: `NormalLabel` takes an explicit `color={COLORS.TEXT_COLOR}` rather than inheriting, so only the heading and icon washed out.

## The fix

Drop the `color` override and let the heading keep the `LABEL_L1_COLOR` it inherits from the dialog. The background change alone still signals hover, and the worst case across every theme becomes 5.13:1.

The `color 0.2s` transition goes with it, since nothing animates colour any more.

`CONTRAST_COLOR` now has **no consumers anywhere in `src/`**. I've left it defined in `useThemeColors.tsx` rather than deleting it from all five theme objects — removing a shared token felt wider than this fix warrants. Worth a follow-up if you'd rather not carry a dead token.

## Scope

Contained to one rule. `CONTRAST_COLOR` had exactly one consumer. `SELECTION_COLOR` is used elsewhere (`TabGroupEntry.tsx:86,132,147`, `SettingsCategoryContainer.tsx:60`) but always with `TEXT_COLOR` or `LABEL_L1_COLOR` over it, which pass.

## Verification

Built the real artifact and checked in the loaded extension across all five themes:

- **Read the hover rule out of the CSSOM** rather than racing a live `:hover` between tool calls — `anyHoverRuleSetsColor: false` across every stylesheet in the document. The pane's rule is now `background-color` only.
- **Confirmed the heading resolves to `LABEL_L1_COLOR`** (`rgb(80, 77, 65)` = `#504D41` in WARM_LIGHT).
- **Visually checked WARM_LIGHT (worst case) and DARKENHEIMER** with a pane hovered. "Cloud Data" is legible in both; previously it nearly vanished in WARM_LIGHT.
- **Re-ran KAN-31's keyboard path** afterwards, since this touches the same rule block: the dialog still reports `modal`, Tab reaches both panes, and Enter still resolves the conflict.

Gate: `tsc` exit 0, lint 0 errors / 29 warnings (unchanged), 81/81 tests, prettier clean.

## What is not covered

Same standing gaps as #121: no automated regression test (KAN-2), and contrast was computed from the resolved colours rather than sampled from rendered pixels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)