### PR TITLE
Restore lazy-loaded tabs from a service worker, not the popup (KAN-36)

### DIFF
--- a/.github/workflows/build_and_release_artifact.yaml
+++ b/.github/workflows/build_and_release_artifact.yaml
@@ -48,20 +48,21 @@ jobs:
 
       - name: Prune unused remotely hosted Firebase JS SDK calls
         run: |
-          INDEX_FILE=$(find ./dist/assets -name 'index-*.js')
           # Firebase Auth carries script URLs for sign-in flows this extension
           # never uses (Google popup, phone/reCAPTCHA). Manifest V3 forbids
           # remotely hosted code, so blank them out. The trailing [^`"]* absorbs
           # any query string the SDK appends, which differs between versions.
-          sed -i \
+          #
+          # Every emitted chunk is scanned, not just the popup entry: the build
+          # is code-split, and which chunk Firebase lands in is Rollup's choice.
+          find ./dist -name '*.js' -print0 | xargs -0 sed -i \
             -e 's|https://apis\.google\.com/js/api\.js[^`"]*||g' \
-            -e 's|https://www\.google\.com/recaptcha/[^`"]*||g' \
-            "$INDEX_FILE"
+            -e 's|https://www\.google\.com/recaptcha/[^`"]*||g'
 
       - name: Verify no remotely hosted code remains
         run: |
-          INDEX_FILE=$(find ./dist/assets -name 'index-*.js')
-          if grep -oE 'https://(apis\.google\.com|www\.google\.com/recaptcha)[^`"]*' "$INDEX_FILE"; then
+          if grep -rEo --include='*.js' \
+            'https://(apis\.google\.com|www\.google\.com/recaptcha)[^`"]*' ./dist; then
             echo "::error::Remotely hosted script URLs survived the prune step above."
             echo "::error::A Firebase upgrade likely changed their shape. Update the sed patterns."
             exit 1

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,6 +8,10 @@
     "default_icon": "icons/icon128.png",
     "default_title": "Tab Keeper - Chrome Tab Manager & Sync Tool"
   },
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
   "permissions": ["tabs", "storage", "favicon"],
   "icons": {
     "16": "icons/icon16.png",

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,0 +1,20 @@
+import { placeholderTarget } from './utils/functions/local';
+
+// Lazy load restores every tab past the first as a placeholder document, and
+// something has to turn that placeholder into the real page when the user
+// finally opens it. The popup cannot: restoring focuses the new window, Chrome
+// destroys the popup, and any listener it registered dies with it well before
+// the user clicks anything. A service worker outlives the popup, and Chrome
+// revives it per event, so the swap also survives a browser restart.
+chrome.tabs.onActivated.addListener(({ tabId }) => {
+  chrome.tabs.get(tabId, (tab) => {
+    // The tab can be gone by the time this runs. Reading a closed tab sets
+    // lastError, and leaving it unread logs an unchecked-error warning.
+    if (chrome.runtime.lastError || !tab?.url) return;
+
+    const target = placeholderTarget(tab.url);
+    if (target) {
+      chrome.tabs.update(tabId, { url: target });
+    }
+  });
+});

--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -111,21 +111,6 @@ export const initialState: TabMasterContainer = {
   tabGroups: [],
 };
 
-function setupTabActivationListener(isLazyLoad: boolean) {
-  if (!isLazyLoad) return;
-  chrome.tabs.onActivated.addListener(({ tabId }) => {
-    const tabData = tabURLMap[tabId];
-    if (tabData) {
-      chrome.tabs.update(tabId, { url: tabData.url });
-      delete tabURLMap[tabId];
-    }
-  });
-}
-
-const tabURLMap: {
-  [key: number]: { url: string; title: string; favicon: string };
-} = {};
-
 function createWindowWithRetries(
   tabs: tabData[],
   isFirstWindow: boolean,
@@ -176,22 +161,14 @@ function createWindowWithRetries(
             );
           }
 
-          chrome.tabs.create(
-            {
-              windowId: newWindow!.id,
-              url: isLazyLoad ? placeholder : decodedUrl,
-              active: false,
-            },
-            (tab) => {
-              if (isLazyLoad) {
-                tabURLMap[tab.id!] = {
-                  url: decodedUrl,
-                  title: tabInfo.title,
-                  favicon: tabInfo.favicon || '/images/favicon.ico',
-                };
-              }
-            }
-          );
+          // No record of what was opened is kept: the placeholder carries its
+          // own page, and the background worker reads it back when the user
+          // activates the tab. See placeholderTarget in utils/functions/local.
+          chrome.tabs.create({
+            windowId: newWindow!.id,
+            url: isLazyLoad ? placeholder : decodedUrl,
+            active: false,
+          });
         });
       }
     }
@@ -223,8 +200,6 @@ export const openTabsInAWindow = createAsyncThunk(
     );
 
     if (!windowGroup) return;
-
-    setupTabActivationListener(settingsDataState.isLazyLoad);
 
     const { tabs } = windowGroup;
 
@@ -260,8 +235,6 @@ export const openAllTabContainer = createAsyncThunk(
     );
 
     if (!tabGroup) return;
-
-    setupTabActivationListener(settingsDataState.isLazyLoad);
 
     let isFirstWindow = true;
 

--- a/src/tests/utils/functions/local.test.ts
+++ b/src/tests/utils/functions/local.test.ts
@@ -15,6 +15,7 @@ import {
   isValidPassword,
   isValidTabMasterContainer,
   loadFromLocalStorage,
+  placeholderTarget,
   saveToLocalStorage,
   stripEmbeddedFavicons,
   resolveFaviconUrl,
@@ -948,5 +949,57 @@ describe('resolveTabUrl', () => {
   test('should leave an ordinary url untouched', () => {
     expect(resolveTabUrl('https://example.com')).toBe('https://example.com');
     expect(resolveTabUrl('')).toBe('');
+  });
+});
+
+// The background service worker asks this of every tab the user activates, so
+// it has to be certain: a wrong "yes" navigates a tab the user was reading.
+describe('placeholderTarget', () => {
+  test('should give the real page for a lazy-load placeholder', () => {
+    const url = 'https://github.com/justine-george';
+    const placeholder = generatePlaceholderURL('title', 'favicon', url, 'go');
+    expect(placeholderTarget(placeholder)).toBe(url);
+  });
+
+  test('should give the final page for a placeholder around a suspended url', () => {
+    const page = 'https://example.com/deep?x=1&y=2';
+    const suspended = `chrome-extension://abc/suspended.html?url=${encodeURIComponent(
+      page
+    )}`;
+    const placeholder = generatePlaceholderURL('t', 'f', suspended, 'go');
+    expect(placeholderTarget(placeholder)).toBe(page);
+  });
+
+  // the common case by far - every ordinary tab switch reaches this
+  test('should return null for a page the user is actually reading', () => {
+    expect(placeholderTarget('https://example.com/article')).toBeNull();
+    expect(placeholderTarget('chrome://extensions/')).toBeNull();
+    expect(placeholderTarget('file:///Users/j/x.pdf')).toBeNull();
+    expect(placeholderTarget('')).toBeNull();
+  });
+
+  // worst path: a data: tab that is not ours must never be navigated
+  test('should return null for a data url that is not a placeholder', () => {
+    const foreign = `data:text/html;base64,${btoa(
+      '<html><body>hello</body></html>'
+    )}`;
+    expect(placeholderTarget(foreign)).toBeNull();
+  });
+
+  test('should refuse a placeholder wrapping a non-http scheme', () => {
+    const hostile = generatePlaceholderURL(
+      't',
+      'f',
+      'javascript:alert(1)',
+      'go'
+    );
+    expect(placeholderTarget(hostile)).toBeNull();
+  });
+
+  test('should return null rather than throw on malformed base64', () => {
+    expect(placeholderTarget('data:text/html;base64,!!!not!!base64!!!')).toBe(
+      null
+    );
+    expect(placeholderTarget('data:text/html;base64,')).toBeNull();
   });
 });

--- a/src/utils/functions/local.ts
+++ b/src/utils/functions/local.ts
@@ -186,6 +186,10 @@ export const asPartialSettings = <T>(value: unknown): Partial<T> =>
     ? (value as Partial<T>)
     : {};
 
+// Every lazy-load placeholder is a base64 data document, and both the save path
+// and the background worker recognise one by this prefix.
+const PLACEHOLDER_URL_PREFIX = 'data:text/html;base64,';
+
 // generate placeholder URL for quicker session loads and lesser memory consumption
 export function generatePlaceholderURL(
   title: string,
@@ -195,13 +199,13 @@ export function generatePlaceholderURL(
 ) {
   const html = `<html> <head> <meta charset="UTF-8" /> <link rel="icon" type="image/x-icon" href="${faviconURL}" /> <meta name="viewport" content="width=device-width, initial-scale=1.0" /> <title>${title}</title> <style> body { background-color: #181818; color: #ffffff; font-family: "Libre Franklin", sans-serif; display: flex; margin: 20px; flex-direction: column; justify-content: flex-start; align-items: flex-start; height: 100vh; } #copyButton { cursor: pointer; background-color: #2c2c2c; padding: 10px 20px; border: none; border-radius: 10px; color: #ffffff; font-family: "Libre Franklin", sans-serif; font-size: 14px; transition: background-color 0.125s ease, color 0.125s ease; } #copyButton:hover { background-color: #77dd77; color: black; } h1,h2,p { margin: 10px 3px; } a { text-decoration: none; color: inherit; } p { font-size: 0.9rem; margin-bottom: 15px; } </style> </head> <body> <h2>${title}</h2> <a href="${url}"><p>${url}</p></a> <a href="${url}"><button id="copyButton">${goToURLText}</button></a> </body></html>`;
   const base64Html = Base64.encode(html);
-  return `data:text/html;base64,${base64Html}`;
+  return `${PLACEHOLDER_URL_PREFIX}${base64Html}`;
 }
 
 // decode dataurl before saving - bugfix to prevent saving base64 encoded urls
 export function decodeDataUrl(url: string): string {
-  if (url.startsWith('data:text/html;base64,')) {
-    const base64Data = url.replace('data:text/html;base64,', '');
+  if (url.startsWith(PLACEHOLDER_URL_PREFIX)) {
+    const base64Data = url.replace(PLACEHOLDER_URL_PREFIX, '');
     const decodedHtml = Base64.decode(base64Data);
 
     // extract the actual URL from the HTML content
@@ -285,6 +289,24 @@ export function resolveTabUrl(url: string): string {
   }
 
   return current;
+}
+
+// A lazy-load placeholder carries its own real page, so nothing has to remember
+// what a restore opened: the background worker reads the answer off the tab it
+// was handed. That matters because the popup is destroyed the moment the
+// restored window takes focus, taking any record it was holding with it.
+//
+// Returns null for everything that is not one of our placeholders. The worker
+// asks this of every tab the user activates, and a wrong answer would navigate
+// a page they were reading, so a foreign data: document, a decode that yields
+// nothing, and any non-http(s) target all decline.
+export function placeholderTarget(tabUrl: string): string | null {
+  if (!tabUrl.startsWith(PLACEHOLDER_URL_PREFIX)) return null;
+
+  const resolved = resolveTabUrl(tabUrl);
+  if (resolved === tabUrl) return null;
+
+  return isRestorablePageUrl(resolved) ? resolved : null;
 }
 
 // Firestore rejects any document larger than 1 MiB.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,28 @@
+import { resolve } from 'node:path';
+
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      // The popup is still the app; the service worker is a second entry point
+      // because the manifest names it by a fixed path, so it cannot carry the
+      // content hash the popup's chunks get.
+      input: {
+        index: resolve(__dirname, 'index.html'),
+        background: resolve(__dirname, 'src/background.ts'),
+      },
+      output: {
+        entryFileNames: (chunk) =>
+          chunk.name === 'background'
+            ? 'background.js'
+            : 'assets/[name]-[hash].js',
+      },
+    },
+  },
   test: {
     globals: true,
     setupFiles: ['vitest-localstorage-mock'],


### PR DESCRIPTION
## The bug

Lazy load is on by default (`isLazyLoad: true`), and every restored tab past the first opened as a placeholder that never became the real page. Users had to click **Go to URL** on each one — 37 clicks for a 40-tab session.

`setupTabActivationListener` registered `chrome.tabs.onActivated` **inside the popup**. `public/manifest.json` had no `background` key, so that listener was the popup's own. Restoring calls `chrome.windows.create({focused: true})`; Chrome destroys the popup when it loses focus; the listener died milliseconds later, long before anyone could click a tab. It has been dead code in every shipped build.

## Evidence it was dead

One variable isolated — same session, same restore, same activation, differing only in whether the popup page still existed:

| Popup | Activate a placeholder | Result |
|---|---|---|
| alive | tab 60 | → `https://example.org/` |
| closed | tab 61 | stayed `data:text/html;base64,…` |

Tab 61 re-read after 2s: `{"url":"data:text/html;base64,…","title":"Placeholder Three","visibility":"visible"}` — visible, activated, still a placeholder. Reopening the popup and moving focus elsewhere made it vanish from the target list, which is the step that kills the listener in normal use.

## The fix

The listener moves to an MV3 service worker (`src/background.ts`, 0.21 kB built), which outlives the popup and is revived per event.

**It keeps no `tabURLMap`.** The placeholder already carries its own page — that is how `decodeDataUrl` recovers it when saving — so `placeholderTarget` reads the answer off the tab it is handed. Porting the map would have carried a second defect with it: the map was filled from the `chrome.tabs.create` callbacks, which run in the popup that is already dying, so a worker-side map would have been just as empty. Statelessness also makes it work on placeholders left from an earlier session, and across worker restarts.

`placeholderTarget` answers for every tab the user activates, so it declines by default: anything without the placeholder prefix, any decode yielding nothing, and any non-http(s) target.

## Verification

**Unit — 178 → 184 tests**, `tsc` clean, 0 lint errors (29 → 28 warnings, from the deleted code).

Mutation-tested rather than assumed:

| Mutation | Test that caught it |
|---|---|
| scheme guard removed | `should refuse a placeholder wrapping a non-http scheme` |
| prefix + no-op guards removed | `should return null for a page the user is actually reading` |

**End to end against the built artifact**, restored from the real popup with the popup then closed:

| Case | Before | After |
|---|---|---|
| activate placeholder, popup dead | stayed `data:…` | → `https://example.org/` |
| second placeholder | stayed `data:…` | → `https://example.net/` |
| untouched placeholder | placeholder | placeholder — lazy load still defers |

After an extension reload, on tabs the worker never saw created: placeholder → `https://example.net/`; `javascript:` target **refused**; foreign `data:` document **left alone**. No worker console errors.

## Release workflow hardening

The second entry point makes the build code-split, which quietly widened a hole: the workflow pruned and verified remotely hosted Firebase URLs in `index-*.js` alone. Both steps now cover every emitted chunk.

The gap was real — a URL planted in the new shared chunk is **missed** by the old check and **caught** by the new one. Today's build carries them only in `index-*.js`, so this is pre-emptive, not a live leak.

## Notes

- **No new permissions.** `background` is a manifest addition only.
- **Cost worth naming:** the worker wakes on every tab activation. It does a string-prefix check and exits, but it is not free — that is the price of holding no state.
- Origin: reviewing a downstream fork that hit the same bug. Its fix put a redirect script inside the placeholder page; that approach relies on `visibilitychange`, which cannot be measured under CDP (attachment forces background tabs visible and focused), so this takes the route whose correctness is provable.
- Tracked as **KAN-36**, linked to KAN-19 as *Relates*. Adjacent but distinct: KAN-19 was the first tab of a restored window opening wrong; this is every other tab never resolving at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
