### PR TITLE
Escape interpolated values in the lazy-load placeholder (KAN-21)

### DIFF
--- a/src/tests/utils/functions/local.test.ts
+++ b/src/tests/utils/functions/local.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, describe, expect, test } from 'vitest';
+import { Base64 } from 'js-base64';
 import {
   classifyStoredToken,
   decodeDataUrl,
+  escapeHtml,
   filterTabGroups,
   isUsableToken,
   resolveTabUrl,
+  unescapeHtml,
   unwrapSuspendedUrl,
   generatePlaceholderURL,
   getPrettyDate,
@@ -252,6 +255,133 @@ describe('placeholderURL', () => {
 
   test('should load url properly even if it is not encoded', () => {
     expect(decodeDataUrl(url)).toBe(url);
+  });
+});
+
+describe('placeholder HTML escaping', () => {
+  const PREFIX = 'data:text/html;base64,';
+
+  function decodePlaceholder(placeholder: string): string {
+    return Base64.decode(placeholder.slice(PREFIX.length));
+  }
+
+  // A page picks its own <title>, and Chrome hands it to us verbatim.
+  test('neutralises a script tag injected through the tab title', () => {
+    const hostileTitle = '</h2><script>alert(1)</script>';
+    const html = decodePlaceholder(
+      generatePlaceholderURL(hostileTitle, 'f', 'https://example.com', 'go')
+    );
+
+    expect(html).not.toContain('<script>');
+    expect(html).not.toContain('</h2><script>');
+    expect(html).toContain('&lt;/h2&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  test('stops a title from breaking out of the <title> element', () => {
+    const html = decodePlaceholder(
+      generatePlaceholderURL(
+        '</title><img src=x onerror=alert(1)>',
+        'f',
+        'https://example.com',
+        'go'
+      )
+    );
+
+    expect(html).not.toContain('</title><img');
+    expect(html).not.toContain('onerror=alert(1)>');
+  });
+
+  test('stops a url from escaping the href attribute', () => {
+    const html = decodePlaceholder(
+      generatePlaceholderURL(
+        't',
+        'f',
+        'https://example.com/"><script>x</script>',
+        'go'
+      )
+    );
+
+    expect(html).not.toContain('"><script>');
+    expect(html).toContain('&quot;&gt;');
+  });
+
+  test('escapes the favicon url, which is also attacker supplied', () => {
+    const html = decodePlaceholder(
+      generatePlaceholderURL(
+        't',
+        'https://e.com/i.ico" onload="alert(1)',
+        'https://example.com',
+        'go'
+      )
+    );
+
+    expect(html).not.toContain('onload="alert(1)"');
+    expect(html).toContain('&quot; onload=&quot;alert(1)');
+  });
+
+  // Escaping the href would corrupt every query string if the read side did
+  // not undo it -- a worse bug than the one being fixed.
+  test('round-trips a url whose query string contains an ampersand', () => {
+    const withAmpersand = 'https://example.com/search?a=1&b=2&c=3';
+    const placeholder = generatePlaceholderURL('t', 'f', withAmpersand, 'go');
+
+    expect(decodeDataUrl(placeholder)).toBe(withAmpersand);
+  });
+
+  // The path the service worker actually uses when the user activates a
+  // lazily-restored tab.
+  test('placeholderTarget returns an ampersand url unchanged', () => {
+    const withAmpersand = 'https://example.com/search?a=1&b=2';
+    const placeholder = generatePlaceholderURL('t', 'f', withAmpersand, 'go');
+
+    expect(placeholderTarget(placeholder)).toBe(withAmpersand);
+  });
+
+  test('round-trips a url containing a literal escaped entity', () => {
+    const tricky = 'https://example.com/?q=a&amp;b';
+    const placeholder = generatePlaceholderURL('t', 'f', tricky, 'go');
+
+    expect(decodeDataUrl(placeholder)).toBe(tricky);
+  });
+
+  // Placeholders written before escaping existed carry raw hrefs. Unescaping a
+  // string with no entities in it is a no-op, so they still decode.
+  test('still decodes a placeholder written before escaping existed', () => {
+    const legacyHtml =
+      '<html> <body> <a href="https://example.com/x?a=1&b=2"><p>x</p></a> </body></html>';
+    const legacy = PREFIX + Base64.encode(legacyHtml);
+
+    expect(decodeDataUrl(legacy)).toBe('https://example.com/x?a=1&b=2');
+  });
+
+  describe('escapeHtml / unescapeHtml', () => {
+    test('replaces the ampersand first, so entities are not double escaped', () => {
+      expect(escapeHtml('<')).toBe('&lt;');
+      expect(escapeHtml('&')).toBe('&amp;');
+      expect(escapeHtml('&<')).toBe('&amp;&lt;');
+    });
+
+    test('escapes every character that can break markup', () => {
+      expect(escapeHtml(`<>&"'`)).toBe('&lt;&gt;&amp;&quot;&#39;');
+    });
+
+    test('unescapes the ampersand last, mirroring the escape order', () => {
+      expect(unescapeHtml('&amp;lt;')).toBe('&lt;');
+    });
+
+    test('is a round trip for anything escapeHtml produced', () => {
+      const raw = `a<b>c&d"e'f&amp;g`;
+      expect(unescapeHtml(escapeHtml(raw))).toBe(raw);
+    });
+
+    test('leaves a string with nothing to escape untouched', () => {
+      expect(escapeHtml('https://example.com/plain')).toBe(
+        'https://example.com/plain'
+      );
+      expect(unescapeHtml('https://example.com/plain')).toBe(
+        'https://example.com/plain'
+      );
+    });
   });
 });
 

--- a/src/utils/functions/local.ts
+++ b/src/utils/functions/local.ts
@@ -190,6 +190,41 @@ export const asPartialSettings = <T>(value: unknown): Partial<T> =>
 // and the background worker recognise one by this prefix.
 const PLACEHOLDER_URL_PREFIX = 'data:text/html;base64,';
 
+// A page controls its own title, and the title is interpolated straight into
+// the placeholder document. Unescaped, a title of `</h2><script>...</script>`
+// closes the heading and runs as markup. Escaping is applied to every
+// interpolated value rather than only the obviously hostile ones, because
+// which values are attacker-controlled is not a property worth tracking
+// per-field.
+//
+// `&` must be replaced first: doing it later would re-escape the ampersands
+// introduced by the other replacements.
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// The inverse, needed because the placeholder's href is not just markup -- it
+// is where decodeDataUrl and placeholderTarget read the real page back from.
+// Escaping the href without unescaping it here would hand every caller a URL
+// with `&amp;` in place of `&`, corrupting every query string the moment it
+// round-tripped.
+//
+// `&amp;` must be replaced last, mirroring escapeHtml: undoing it first would
+// turn `&amp;lt;` into `<` rather than the literal `&lt;` it stands for.
+export function unescapeHtml(value: string): string {
+  return value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
 // generate placeholder URL for quicker session loads and lesser memory consumption
 export function generatePlaceholderURL(
   title: string,
@@ -197,7 +232,12 @@ export function generatePlaceholderURL(
   url: string,
   goToURLText: string
 ) {
-  const html = `<html> <head> <meta charset="UTF-8" /> <link rel="icon" type="image/x-icon" href="${faviconURL}" /> <meta name="viewport" content="width=device-width, initial-scale=1.0" /> <title>${title}</title> <style> body { background-color: #181818; color: #ffffff; font-family: "Libre Franklin", sans-serif; display: flex; margin: 20px; flex-direction: column; justify-content: flex-start; align-items: flex-start; height: 100vh; } #copyButton { cursor: pointer; background-color: #2c2c2c; padding: 10px 20px; border: none; border-radius: 10px; color: #ffffff; font-family: "Libre Franklin", sans-serif; font-size: 14px; transition: background-color 0.125s ease, color 0.125s ease; } #copyButton:hover { background-color: #77dd77; color: black; } h1,h2,p { margin: 10px 3px; } a { text-decoration: none; color: inherit; } p { font-size: 0.9rem; margin-bottom: 15px; } </style> </head> <body> <h2>${title}</h2> <a href="${url}"><p>${url}</p></a> <a href="${url}"><button id="copyButton">${goToURLText}</button></a> </body></html>`;
+  const safeTitle = escapeHtml(title);
+  const safeFaviconURL = escapeHtml(faviconURL);
+  const safeUrl = escapeHtml(url);
+  const safeGoToURLText = escapeHtml(goToURLText);
+
+  const html = `<html> <head> <meta charset="UTF-8" /> <link rel="icon" type="image/x-icon" href="${safeFaviconURL}" /> <meta name="viewport" content="width=device-width, initial-scale=1.0" /> <title>${safeTitle}</title> <style> body { background-color: #181818; color: #ffffff; font-family: "Libre Franklin", sans-serif; display: flex; margin: 20px; flex-direction: column; justify-content: flex-start; align-items: flex-start; height: 100vh; } #copyButton { cursor: pointer; background-color: #2c2c2c; padding: 10px 20px; border: none; border-radius: 10px; color: #ffffff; font-family: "Libre Franklin", sans-serif; font-size: 14px; transition: background-color 0.125s ease, color 0.125s ease; } #copyButton:hover { background-color: #77dd77; color: black; } h1,h2,p { margin: 10px 3px; } a { text-decoration: none; color: inherit; } p { font-size: 0.9rem; margin-bottom: 15px; } </style> </head> <body> <h2>${safeTitle}</h2> <a href="${safeUrl}"><p>${safeUrl}</p></a> <a href="${safeUrl}"><button id="copyButton">${safeGoToURLText}</button></a> </body></html>`;
   const base64Html = Base64.encode(html);
   return `${PLACEHOLDER_URL_PREFIX}${base64Html}`;
 }
@@ -209,9 +249,14 @@ export function decodeDataUrl(url: string): string {
     const decodedHtml = Base64.decode(base64Data);
 
     // extract the actual URL from the HTML content
+    //
+    // The href is HTML-escaped by generatePlaceholderURL, so it has to be
+    // unescaped here to give back the URL that went in. Placeholders written
+    // before escaping existed are unaffected: unescaping a string with no
+    // entities in it is a no-op.
     const urlMatch = decodedHtml.match(/<a href="([^"]+)">/);
     if (urlMatch && urlMatch[1]) {
-      return urlMatch[1];
+      return unescapeHtml(urlMatch[1]);
     }
   }
   return url;


### PR DESCRIPTION
`generatePlaceholderURL` interpolated the tab title, URL and favicon URL straight into an HTML string. A page controls its own `<title>` and Chrome hands it to us verbatim, so a title of `</h2><script>…` closed the heading and became markup in the restored placeholder document.

Every interpolated value is now escaped — not only the obviously hostile ones, since which values are attacker-controlled is not a property worth tracking per-field.

## The half that would have been a worse bug

Escaping the href alone would have broken more than it fixed. `decodeDataUrl` and `placeholderTarget` read the real page back **out of that href** with `/<a href="([^"]+)">/`, so `&` → `&amp;` would have corrupted every query string the moment a placeholder round-tripped: the service worker would navigate to a URL containing `&amp;`, and saving a placeholder tab would store the corrupted form.

`decodeDataUrl` now unescapes symmetrically. Placeholders written before this change are unaffected — unescaping a string with no entities in it is a no-op.

## Measured severity

The ticket cites `data:` CSP as a "mitigating factor" without pinning it down. Measured against the **pre-fix** document in this Chrome:

| Probe | Result |
|---|---|
| Markup injection | **Real** — the crafted title produced a live `<img>` element (`injectedImgCount: 1`) |
| Inline `onerror` handler | **Did not run** — blocked by the CSP Chrome applies to `data:` URLs |
| `javascript:` href, clicked | **Did not execute** — same reason |
| Network request from injected markup | **Works** — see the table below |

So this is **HTML injection, not script execution**. An attacker who controls a page title can put arbitrary visible content and links into a placeholder the user opened deliberately, and can cause a request to a server of their choosing — a phishing and tracking surface, not code execution. Escaping is the complete fix; no scheme guard on the href is needed.

That last row reverses an earlier measurement in this work which concluded there was no network side channel. The first probe pointed at `example.com/favicon.ico`, which **404s**, so "did not render" was misread as "blocked by CSP". A negative result from a probe aimed at a resource that does not exist proves nothing, so the re-test uses three live hosts, each with a cache-busting query so a cache hit cannot explain the result, plus a negative control:

| Host (cache-busted) | Status | `naturalWidth` |
|---|---|---|
| `developer.mozilla.org` | **200** | 48 |
| `en.wikipedia.org` | **200** | 48 |
| `www.bing.com` | **200** | 32 |
| *nonexistent host* (control) | `ERR_NAME_NOT_RESOLVED` | 0 |

The control failing is what makes the other three meaningful — the probe discriminates rather than always reporting success. The ticket has been re-labelled `[P2] HTML injection` (Medium) on the strength of the corrected picture.

## Favicons are unaffected

Worth stating explicitly, since escaping an attribute that feeds a network request is exactly where a regression would hide:

- The favicon href is the one interpolated value **never read back** out of the document — the sole extraction regex matches the `<a>` element, not `<link rel="icon">`.
- The HTML parser decodes entities in attribute values, so a favicon URL containing `&` parses back byte-identical.

Verified with `https://www.google.com/s2/favicons?domain=example.com&sz=32` — stored as `&amp;sz=32`, `link.href` reads back as `&sz=32` (identical to the original), and the request went out and followed its 301.

## Verification

End to end in the built extension. Restoring a session whose second tab carried the crafted title:

| Assertion | Result |
|---|---|
| Injected elements | `injectedImgCount: 0` (was 1 pre-fix) |
| `<h2>` contents | 0 child elements; payload present as literal text |
| Handler fired | `data-xss` attribute `null` |
| Link href, parsed | `https://example.com/search?a=1&b=2&c=3` — real ampersands |
| Activating the tab | worker navigated to `https://example.com/search?a=1&b=2&c=3` |

That last row is the round trip: the symmetric unescape works through the real service worker, not just in unit tests.

**225 tests** (13 new), `tsc` clean, lint 0 errors / 28 warnings (baseline). Four mutations — no-op escape, ampersand escaped last, missing unescape on read, ampersand unescaped first — each fail the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

