### PR TITLE
Add a React error boundary so a render crash is not a blank popup (KAN-17)

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  message: string;
+}
+
+// The popup has one job when a render throws: not be a blank rectangle. Before
+// this, any unhandled render error unmounted the whole tree and left the user
+// with nothing to click and no way to tell a crash from a slow start.
+//
+// Deliberately mounted OUTSIDE the Redux and i18n providers, and deliberately
+// self-contained: no hooks, no theme tokens, no translated strings. A fallback
+// that reads from the store or calls t() can throw while rendering, and React
+// does not catch an error thrown by a boundary's own fallback -- it unmounts
+// the tree and produces exactly the blank screen this exists to prevent. The
+// cost is that the message is English-only, which is the right trade for a
+// screen the user should only ever see when something is already broken.
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false, message: '' };
+
+  static getDerivedStateFromError(error: unknown): ErrorBoundaryState {
+    // `error` is typed unknown because a throw can carry any value, not only
+    // an Error -- reading .message off a thrown string would throw again.
+    const message =
+      error instanceof Error && error.message
+        ? error.message
+        : 'An unexpected error occurred.';
+
+    return { hasError: true, message };
+  }
+
+  componentDidCatch(error: unknown, errorInfo: React.ErrorInfo) {
+    // Kept so the stack survives in the popup's console for anyone debugging
+    // a report. There is nowhere else to send it: the extension has no error
+    // reporting backend, and inventing one is not this fix's job.
+    console.error('Tab Keeper: render error caught by ErrorBoundary', {
+      error,
+      componentStack: errorInfo.componentStack,
+    });
+  }
+
+  private handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+
+    return (
+      <div
+        role="alert"
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-start',
+          justifyContent: 'center',
+          gap: '12px',
+          padding: '24px',
+          minHeight: '200px',
+          fontFamily: 'sans-serif',
+          fontSize: '14px',
+          color: '#1a1a1a',
+          backgroundColor: '#ffffff',
+        }}
+      >
+        <h1 style={{ margin: 0, fontSize: '1.1rem', fontWeight: 600 }}>
+          Something went wrong
+        </h1>
+        <p style={{ margin: 0, lineHeight: 1.5 }}>
+          Tab Keeper hit an unexpected error and could not finish loading. Your
+          saved sessions are stored separately and have not been changed.
+        </p>
+        <p
+          style={{
+            margin: 0,
+            fontFamily: 'monospace',
+            fontSize: '12px',
+            color: '#666666',
+            overflowWrap: 'anywhere',
+          }}
+        >
+          {this.state.message}
+        </p>
+        <button
+          type="button"
+          onClick={this.handleReload}
+          style={{
+            padding: '8px 16px',
+            border: '1px solid #1a1a1a',
+            borderRadius: '4px',
+            background: '#ffffff',
+            color: '#1a1a1a',
+            fontFamily: 'inherit',
+            fontSize: 'inherit',
+            cursor: 'pointer',
+          }}
+        >
+          Reload
+        </button>
+      </div>
+    );
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,13 +8,18 @@ import ReactDOM from 'react-dom/client';
 import i18n from './config/i18n.tsx';
 import App from './App.tsx';
 import { store } from './redux/store.tsx';
+import { ErrorBoundary } from './components/ErrorBoundary.tsx';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <Provider store={store}>
-      <I18nextProvider i18n={i18n}>
-        <App />
-      </I18nextProvider>
-    </Provider>
+    {/* Outermost, so a throw anywhere below it -- including in a provider --
+        still renders something the user can act on. */}
+    <ErrorBoundary>
+      <Provider store={store}>
+        <I18nextProvider i18n={i18n}>
+          <App />
+        </I18nextProvider>
+      </Provider>
+    </ErrorBoundary>
   </React.StrictMode>
 );

--- a/src/tests/components/ErrorBoundary.test.ts
+++ b/src/tests/components/ErrorBoundary.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest';
+
+import { ErrorBoundary } from '../../components/ErrorBoundary';
+
+// There is no jsdom or React Testing Library in this project (KAN-2), so the
+// rendered fallback is verified by driving the real popup in Chrome. What is
+// unit-testable without a DOM is the decision itself: getDerivedStateFromError
+// is a static pure function, and it is the piece that decides whether the user
+// sees a fallback or a blank rectangle.
+describe('ErrorBoundary.getDerivedStateFromError', () => {
+  test('switches into the fallback for a thrown Error', () => {
+    const state = ErrorBoundary.getDerivedStateFromError(
+      new Error('MainContainer exploded')
+    );
+
+    expect(state.hasError).toBe(true);
+    expect(state.message).toBe('MainContainer exploded');
+  });
+
+  // A throw can carry any value. Reading .message off a string would itself
+  // throw, inside the boundary, which React does not catch.
+  test.each([
+    ['a thrown string', 'boom'],
+    ['a thrown object', { code: 500 }],
+    ['null', null],
+    ['undefined', undefined],
+    ['an Error with an empty message', new Error('')],
+  ])('still shows the fallback for %s', (_label, thrown) => {
+    const state = ErrorBoundary.getDerivedStateFromError(thrown);
+
+    expect(state.hasError).toBe(true);
+    expect(state.message).toBe('An unexpected error occurred.');
+  });
+
+  test('never reports a non-string message', () => {
+    const state = ErrorBoundary.getDerivedStateFromError({
+      message: { nested: true },
+    });
+
+    expect(typeof state.message).toBe('string');
+  });
+});


### PR DESCRIPTION
There was no `ErrorBoundary` anywhere in the tree, so any unhandled render error unmounted everything and left the user with an empty rectangle — no message, no way to tell a crash from a slow start, and nothing to click.

## Placement is the design decision

The boundary is mounted **outermost**, wrapping the Redux and i18n providers rather than sitting inside them, and its fallback is deliberately self-contained: no hooks, no theme tokens, no translated strings.

React does not catch an error thrown by a boundary's *own fallback* — it unmounts the tree. So a fallback that read from the store or called `t()` could reproduce the exact blank screen this exists to prevent. The cost is an English-only message on a screen that should only ever appear when something is already broken; that seemed the right trade.

`getDerivedStateFromError` types the thrown value as `unknown` rather than `Error`, because a throw can carry anything — reading `.message` off a thrown string would throw again, inside the boundary.

## Verification

Measured in the built extension with a temporary probe that threw during `MainContainer`'s render. The probe was added, measured, and removed — `MainContainer` is byte-identical to `main` in this branch.

| Build | Result |
|---|---|
| **With** the boundary | `role="alert"` live region, "Something went wrong" heading, the error message, working Reload button |
| **Without** it, same crash | `#root` had **0 children and 0 bytes of innerHTML**; body rendered no text at all — the blank popup from the ticket |

No jsdom or React Testing Library exists in this project (KAN-2), so the rendered fallback is covered by that browser check rather than a unit test. What *is* unit-testable without a DOM is the decision itself: **7 tests** over `getDerivedStateFromError`, including thrown strings, objects, `null`, `undefined`, and an `Error` with an empty message — all of which must still produce a fallback rather than a second crash.

**219 tests**, `tsc` clean, lint 0 errors / 28 warnings (baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
