### PR TITLE
Release 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,26 @@ Tab Keeper is an intuitive Chrome extension crafted to redefine the way users sa
 
 ## Changelog
 
-### v.1.3.3 (Latest)
+### v.1.4.0 (Latest)
+
+#### Features
+
+- A new Switch action on each saved session opens that session and clears your other windows out of the way. Whatever was open is saved as a session first, so nothing is lost — and if those windows were already saved, no duplicate is created
+
+#### Improvements
+
+- Sync no longer stops to ask which device is right. Changes made on different devices are merged automatically, and a session you delete on one device stays deleted on the others
+- The session Restore button is now called Open, and both it and Switch say in their tooltip what will happen to the windows you already have
+
+#### Fixes
+
+- Lazy-loaded tabs now open the page they stand for as soon as you click them. Previously every tab after the first in a restored window stayed on a placeholder and had to be opened by hand
+- If something goes wrong, the popup now shows an explanation and a reload button instead of appearing empty
+- A page whose title contains unusual characters no longer breaks the placeholder shown for a lazy-loaded tab
+- Damaged saved data is now spotted before syncing rather than surfacing later as a confusing error
+- Restoring sessions repeatedly no longer leaves unused listeners behind
+
+### v.1.3.3
 
 #### Fixes
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Justine George",
   "description": "Efficiently save and synchronize tabs across devices without the need for personal logins.",
   "private": true,
-  "version": "1.3.3",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "1.3.3",
+  "version": "1.4.0",
   "name": "Tab Keeper - Chrome Tab Manager & Sync Tool",
   "description": "Efficiently save and synchronize tabs across devices without the need for personal logins.",
   "action": {


### PR DESCRIPTION
Bumps to **1.4.0**, not 1.3.4. This carries a new feature and a changed sync behaviour, not only fixes:

- **KAN-37** adds focus mode — a new Switch action per session
- **KAN-32** replaced the sync conflict prompt with automatic merging, removing that modal entirely
- **KAN-37** also renames the session Restore button to Open

Under semver that's a MINOR bump. The seven other tickets are genuine patches.

## What ships

Ten tickets, all merged after the `v1.3.3` tag — each confirmed with `git merge-base --is-ancestor <sha> v1.3.3` returning false:

KAN-15, KAN-17, KAN-20, KAN-21, KAN-31, KAN-32, KAN-33, KAN-34, KAN-36, KAN-37

**Two are deliberately absent from the changelog.** KAN-31 (conflict modal keyboard access) and KAN-34 (its hover contrast) both fixed a modal that KAN-32 then deleted. Their commits ship, so their `pending-release` labels clear with this release — but listing them as user-facing improvements would be false.

## Version lives in two files

- `package.json` — the README badge reads it
- `public/manifest.json` — the **release workflow** reads it (`build_and_release_artifact.yaml:33-36`) to name the artifact

Both bumped. Edited surgically rather than via `json.dump`, which reformatted the manifest's `permissions` array into eight lines of diff noise on the first attempt.

## Changelog

Added to `README.md` and mirrored into the wiki's `Changelog.md`. The two blocks were compared **programmatically**, not by eye — they are byte-identical. A `#### Features` heading is new; earlier entries only ever needed Fixes and Improvements.

The wiki is a separate repo and is **not** pushed by this PR — that happens alongside the tag.

## Verification

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npm test -- --run` | **232 passed** |
| `npm run lint` | 0 errors, 28 warnings (baseline) |
| `npm audit --production` | **0 vulnerabilities** |
| `dist/manifest.json` after build | **1.4.0** |

## Before publishing

The release workflow's remote-code prune now has to handle **three** chunks (`index-*.js`, `background.js`, shared `windows-*.js`). It globs every `*.js`, so this is covered — but it has never run against a code-split build, so watch that step. It fails loudly if any remotely hosted URL survives, so the worst case is a red job rather than a bad artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
