### PR TITLE
Keep the window title when only its tabs match a search (KAN-23)

### DIFF
--- a/src/tests/utils/functions/local.test.ts
+++ b/src/tests/utils/functions/local.test.ts
@@ -196,7 +196,9 @@ describe('filterTabGroups', () => {
             windowOffsetTop: 25,
             windowOffsetLeft: 0,
             tabCount: 2,
-            title: 'Unit testing Chrome Extensions - Chrome for Developers',
+            // KAN-23: the window keeps the title it was captured with; this
+            // previously asserted the first matched tab's title instead
+            title: 'Test Group',
             tabs: [
               {
                 tabId: '410ef43b-4726-4f5c-8746-3832327ba5ea',
@@ -217,6 +219,57 @@ describe('filterTabGroups', () => {
       },
     ];
     expect(filterTabGroups('chrome', tabGroups)).toEqual(filteredTabGroups);
+  });
+
+  // KAN-23: a window's title is its identity and is user-editable, so a search
+  // must not replace it with the title of whichever tab happened to match. The
+  // counts alongside it are derived view values and are expected to narrow.
+  test('should keep the window title when only its tabs match', () => {
+    const tabGroups = [
+      {
+        tabGroupId: 'e6b1a5b8-0000-4000-8000-000000000001',
+        title: 'Research',
+        createdTime: '2026-08-31 09:00:00',
+        windowCount: 1,
+        tabCount: 2,
+        isAutoSave: false,
+        isSelected: true,
+        windows: [
+          {
+            windowId: 'e6b1a5b8-0000-4000-8000-000000000002',
+            windowHeight: 1080,
+            windowWidth: 1920,
+            windowOffsetTop: 0,
+            windowOffsetLeft: 0,
+            tabCount: 2,
+            title: 'Morning reading',
+            tabs: [
+              {
+                tabId: 'e6b1a5b8-0000-4000-8000-000000000003',
+                favicon: '',
+                title: 'Kagi Search',
+                url: 'https://kagi.com/',
+              },
+              {
+                tabId: 'e6b1a5b8-0000-4000-8000-000000000004',
+                favicon: '',
+                title: 'Hacker News',
+                url: 'https://news.ycombinator.com/',
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    // 'kagi' matches neither the session title nor the window title, so the
+    // filter descends to the tabs and rebuilds the window from the one match.
+    const [matchedGroup] = filterTabGroups('kagi', tabGroups);
+    const [matchedWindow] = matchedGroup.windows;
+
+    expect(matchedWindow.title).toBe('Morning reading');
+    expect(matchedWindow.tabs.map((tab) => tab.title)).toEqual(['Kagi Search']);
+    expect(matchedWindow.tabCount).toBe(1);
   });
 });
 

--- a/src/utils/functions/local.ts
+++ b/src/utils/functions/local.ts
@@ -118,11 +118,13 @@ export const filterTabGroups = (
             );
 
             if (matchedTabs.length) {
+              // the counts narrow to describe the filtered view, but the window
+              // keeps its own title: it is the identity the user recognises and
+              // renames, not a value derived from whichever tab matched
               windowAcc.push({
                 ...window,
                 tabs: matchedTabs,
                 tabCount: matchedTabs.length,
-                title: matchedTabs[0].title,
               });
             }
           }


### PR DESCRIPTION
## What was wrong

`filterTabGroups` rebuilt a partially-matched window with `title: matchedTabs[0].title`, so a search replaced the window's own title with the title of whichever tab matched first. The window row then rendered the same string as the tab row directly beneath it.

The window title is **identity**, not a derived value — captured from the active tab at save time, and user-editable thereafter via `updateWindowGroupTitle`. The counts beside it (`tabCount`, and the session-level `windowCount`/`tabCount`) *are* derived and still narrow to describe the filtered view. Treating the title like one of those counts is the mistake.

Removing the key is the whole fix: object-spread ordering means the later `title:` was shadowing the spread's own, so deleting it lets `...window` supply the real title again.

## Severity: cosmetic, not data-corrupting

I checked whether a user could overwrite a real window title with a tab's. They can't — the rename affordance in `WindowEntryContainer.tsx` sits inside a `!isEditing && !isSearchPanel` guard, so editing is unreachable while searching. If the ticket is labelled P1 on the assumption that this corrupts saved data, it's really a P2.

## The existing test asserted the bug

`local.test.ts` expected `'Unit testing Chrome Extensions - Chrome for Developers'` where the source fixture's window title was `'Test Group'` — the defect was locked in by its own coverage. That expectation is corrected here, and a focused regression test added alongside it, because the assertion is one line buried in a ~120-line captured fixture and would be easy to re-break.

## Evidence

- **233 tests pass** (232 before, +1 new), `tsc --noEmit` clean, lint **0 errors / 28 warnings** — the exact baseline.
- **Reverted the single line and watched both tests fail:**
  ```
  × should return filtered tab groups
  × should keep the window title when only its tabs match
  Tests  2 failed | 101 passed (103)
  ```
- **E2E against the built-and-stripped artifact** (`npm run build` + the release remote-code strip), loaded in Chrome, with a seeded session: window `"Morning reading"` containing tabs `"Kagi Search"` and `"Hacker News"`. Searching `kagi` narrows to `1 Window - 1 Tab` and the window row still reads **"Morning reading"**.
- **Negative control** — rebuilt with the bug restored, same seed, same search: the window row reads **"Kagi Search"**, duplicating the tab row below it. A passing E2E means nothing without showing the harness can produce the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)