### PR TITLE
Add component test infrastructure (KAN-2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tab-keeper-react-chrome-extension",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tab-keeper-react-chrome-extension",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
@@ -23,6 +23,9 @@
         "uuid": "^14.0.2"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^7.0.1",
+        "@testing-library/react": "^16.3.3",
+        "@testing-library/user-event": "^14.6.6",
         "@types/chrome": "^0.2.7",
         "@types/react": "^18.0.37",
         "@types/react-dom": "^18.0.11",
@@ -35,6 +38,7 @@
         "eslint-plugin-prettier": "^5.0.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.3.4",
+        "jsdom": "^30.0.1",
         "prettier": "^3.1.0",
         "typescript": "^5.3.2",
         "vite": "^8.2.2",
@@ -49,6 +53,46 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -123,6 +167,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -327,6 +524,24 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@firebase/ai": {
@@ -1466,6 +1681,113 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+      "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
+      "integrity": "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.6.tgz",
+      "integrity": "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2069,6 +2391,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -2189,6 +2521,16 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/big-integer": {
@@ -2457,10 +2799,60 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -2478,6 +2870,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2531,6 +2930,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2565,6 +2974,14 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -2577,6 +2994,19 @@
       "dev": true,
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -3306,6 +3736,19 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-parse-stringify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-4.0.1.tgz",
@@ -3435,6 +3878,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3548,6 +4001,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -3630,6 +4090,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -4071,6 +4572,27 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4080,6 +4602,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -4120,6 +4649,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -4333,6 +4872,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4464,6 +5016,44 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -4676,6 +5266,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
@@ -4696,6 +5300,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4934,6 +5548,19 @@
         }
       ]
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
@@ -5095,6 +5722,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -5133,6 +5773,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/synckit": {
       "version": "0.8.5",
@@ -5259,6 +5906,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -5278,6 +5945,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5332,6 +6025,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.1.tgz",
+      "integrity": "sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -5590,11 +6293,34 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-vitals": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
       "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/websocket-driver": {
       "version": "0.7.5",
@@ -5617,6 +6343,31 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -5702,6 +6453,23 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "uuid": "^14.0.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^7.0.1",
+    "@testing-library/react": "^16.3.3",
+    "@testing-library/user-event": "^14.6.6",
     "@types/chrome": "^0.2.7",
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",
@@ -51,6 +54,7 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.3.4",
+    "jsdom": "^30.0.1",
     "prettier": "^3.1.0",
     "typescript": "^5.3.2",
     "vite": "^8.2.2",

--- a/src/redux/store.tsx
+++ b/src/redux/store.tsx
@@ -1,19 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit';
-import globalStateReducer from './slices/globalStateSlice';
-import settingsDataStateReducer from './slices/settingsDataStateSlice';
-import settingsCategoryStateReducer from './slices/settingsCategoryStateSlice';
-import tabContainerDataStateReducer from './slices/tabContainerDataStateSlice';
-import undoRedoReducer from './slices/undoRedoSlice';
+
+import { rootReducer } from './storeConfig';
 import { customMiddleware } from './middleware/customMiddleware';
 
 export const store = configureStore({
-  reducer: {
-    undoRedo: undoRedoReducer,
-    globalState: globalStateReducer,
-    settingsDataState: settingsDataStateReducer,
-    settingsCategoryState: settingsCategoryStateReducer,
-    tabContainerDataState: tabContainerDataStateReducer,
-  },
+  reducer: rootReducer,
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(customMiddleware),
 });

--- a/src/redux/storeConfig.ts
+++ b/src/redux/storeConfig.ts
@@ -1,0 +1,16 @@
+import globalStateReducer from './slices/globalStateSlice';
+import settingsDataStateReducer from './slices/settingsDataStateSlice';
+import settingsCategoryStateReducer from './slices/settingsCategoryStateSlice';
+import tabContainerDataStateReducer from './slices/tabContainerDataStateSlice';
+import undoRedoReducer from './slices/undoRedoSlice';
+
+// The single declaration of the store's shape. src/redux/store.tsx and
+// src/tests/setup/makeStore.ts both build from this, so a slice added to the
+// app cannot go missing from tests.
+export const rootReducer = {
+  undoRedo: undoRedoReducer,
+  globalState: globalStateReducer,
+  settingsDataState: settingsDataStateReducer,
+  settingsCategoryState: settingsCategoryStateReducer,
+  tabContainerDataState: tabContainerDataStateReducer,
+};

--- a/src/tests/components/ErrorBoundary.test.ts
+++ b/src/tests/components/ErrorBoundary.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, test } from 'vitest';
 
 import { ErrorBoundary } from '../../components/ErrorBoundary';
 
-// There is no jsdom or React Testing Library in this project (KAN-2), so the
-// rendered fallback is verified by driving the real popup in Chrome. What is
-// unit-testable without a DOM is the decision itself: getDerivedStateFromError
-// is a static pure function, and it is the piece that decides whether the user
-// sees a fallback or a blank rectangle.
+// This file stays a node test on purpose. getDerivedStateFromError is a static
+// pure function -- the piece that decides whether the user sees a fallback or a
+// blank rectangle -- and it needs no DOM.
+//
+// Note the .ts extension is load-bearing: the vitest projects split by
+// extension, so this runs under `unit` despite living in the components
+// directory. Component tests are .tsx and run under jsdom.
+//
+// KAN-2 added jsdom and RTL, so the rendered fallback IS now testable. That
+// test belongs to KAN-17's follow-up, not here.
 describe('ErrorBoundary.getDerivedStateFromError', () => {
   test('switches into the fallback for a thrown Error', () => {
     const state = ErrorBoundary.getDerivedStateFromError(

--- a/src/tests/components/Search.test.tsx
+++ b/src/tests/components/Search.test.tsx
@@ -32,7 +32,14 @@ const session = (title: string, tabTitle: string) => ({
       windowOffsetLeft: 0,
       tabCount: 1,
       title: 'A window',
-      tabs: [{ tabId: `tab-${title}`, favicon: '', title: tabTitle, url: 'https://example.com/' }],
+      tabs: [
+        {
+          tabId: `tab-${title}`,
+          favicon: '',
+          title: tabTitle,
+          url: 'https://example.com/',
+        },
+      ],
     },
   ],
 });
@@ -41,8 +48,12 @@ describe('search filtering', () => {
   test('narrows the rendered sessions to those that match', async () => {
     const { store } = await renderWithProviders(<TabGroupEntryContainer />);
 
-    store.dispatch(saveToTabContainerInternal(session('Research', 'Kagi Search')));
-    store.dispatch(saveToTabContainerInternal(session('Errands', 'Grocery list')));
+    store.dispatch(
+      saveToTabContainerInternal(session('Research', 'Kagi Search'))
+    );
+    store.dispatch(
+      saveToTabContainerInternal(session('Errands', 'Grocery list'))
+    );
     store.dispatch(openSearchPanel());
 
     expect(await screen.findByText('Research')).toBeTruthy();
@@ -57,7 +68,9 @@ describe('search filtering', () => {
   test('is case-insensitive', async () => {
     const { store } = await renderWithProviders(<TabGroupEntryContainer />);
 
-    store.dispatch(saveToTabContainerInternal(session('Research', 'Kagi Search')));
+    store.dispatch(
+      saveToTabContainerInternal(session('Research', 'Kagi Search'))
+    );
     store.dispatch(openSearchPanel());
     store.dispatch(setSearchInputText('KAGI'));
 

--- a/src/tests/components/Search.test.tsx
+++ b/src/tests/components/Search.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, test, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+import TabGroupEntryContainer from '../../components/home/leftpane/TabGroupEntryContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  openSearchPanel,
+  setSearchInputText,
+} from '../../redux/slices/globalStateSlice';
+import { saveToTabContainerInternal } from '../../redux/slices/tabContainerDataStateSlice';
+
+const session = (title: string, tabTitle: string) => ({
+  tabGroupId: `id-${title}`,
+  title,
+  createdTime: '2026-08-31 09:00:00',
+  windowCount: 1,
+  tabCount: 1,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: `win-${title}`,
+      windowHeight: 1080,
+      windowWidth: 1920,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 1,
+      title: 'A window',
+      tabs: [{ tabId: `tab-${title}`, favicon: '', title: tabTitle, url: 'https://example.com/' }],
+    },
+  ],
+});
+
+describe('search filtering', () => {
+  test('narrows the rendered sessions to those that match', async () => {
+    const { store } = await renderWithProviders(<TabGroupEntryContainer />);
+
+    store.dispatch(saveToTabContainerInternal(session('Research', 'Kagi Search')));
+    store.dispatch(saveToTabContainerInternal(session('Errands', 'Grocery list')));
+    store.dispatch(openSearchPanel());
+
+    expect(await screen.findByText('Research')).toBeTruthy();
+    expect(screen.getByText('Errands')).toBeTruthy();
+
+    store.dispatch(setSearchInputText('kagi'));
+
+    expect(await screen.findByText('Research')).toBeTruthy();
+    expect(screen.queryByText('Errands')).toBeNull();
+  });
+
+  test('is case-insensitive', async () => {
+    const { store } = await renderWithProviders(<TabGroupEntryContainer />);
+
+    store.dispatch(saveToTabContainerInternal(session('Research', 'Kagi Search')));
+    store.dispatch(openSearchPanel());
+    store.dispatch(setSearchInputText('KAGI'));
+
+    expect(await screen.findByText('Research')).toBeTruthy();
+  });
+});

--- a/src/tests/components/Search.test.tsx
+++ b/src/tests/components/Search.test.tsx
@@ -1,11 +1,5 @@
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { screen } from '@testing-library/react';
-
-vi.mock('../../utils/functions/external', () => ({
-  loadFromFirestore: vi.fn(),
-  saveToFirestore: vi.fn(),
-  displayToast: vi.fn(),
-}));
 
 import TabGroupEntryContainer from '../../components/home/leftpane/TabGroupEntryContainer';
 import { renderWithProviders } from '../setup/renderWithProviders';

--- a/src/tests/components/TabGroupDetailsContainer.test.tsx
+++ b/src/tests/components/TabGroupDetailsContainer.test.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, test, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useDispatch } from 'react-redux';
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+import TabGroupDetailsContainer from '../../components/home/rightpane/TabGroupDetailsContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  saveToTabContainerInternal,
+  selectTabContainer,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import { AppDispatch } from '../../redux/store';
+
+// A factory, not a shared constant: saveToTabContainerInternal's reducer
+// mutates and Immer freezes whatever object it is given, so a session reused
+// across the two tests below would arrive at the second dispatch already
+// frozen from the first and throw on the reducer's own `touch()` call.
+const buildSession = () => ({
+  tabGroupId: 'group-1',
+  title: 'Research',
+  createdTime: '2026-08-31 09:00:00',
+  windowCount: 1,
+  tabCount: 2,
+  isAutoSave: false,
+  isSelected: true,
+  windows: [
+    {
+      windowId: 'win-1',
+      windowHeight: 1080,
+      windowWidth: 1920,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 2,
+      title: 'Morning reading',
+      tabs: [
+        {
+          tabId: 't1',
+          favicon: '',
+          title: 'Kagi Search',
+          url: 'https://kagi.com/',
+        },
+        {
+          tabId: 't2',
+          favicon: '',
+          title: 'Hacker News',
+          url: 'https://news.ycombinator.com/',
+        },
+      ],
+    },
+  ],
+});
+
+// TabGroupDetailsContainer dereferences the selected tab group on its very
+// first render (filteredTabGroups[0].tabGroupId) -- KAN-39, a known, open,
+// deliberately unfixed bug. Mounting it against an empty store therefore
+// throws immediately, before a test body would ever get a chance to dispatch
+// afterwards -- render() throws synchronously and no post-render dispatch is
+// reachable. Seeding via a wrapper that dispatches during its own render body
+// keeps the crash path from ever being entered: the dispatches run to
+// completion before React renders TabGroupDetailsContainer as this
+// component's child in the same synchronous pass, so its first `useSelector`
+// read already sees the populated, selected session. Not a component change.
+function Seeded() {
+  const dispatch: AppDispatch = useDispatch();
+  dispatch(saveToTabContainerInternal(buildSession()));
+  dispatch(selectTabContainer('group-1'));
+  return <TabGroupDetailsContainer />;
+}
+
+describe('TabGroupDetailsContainer', () => {
+  test('renders the window and its tabs from store state', async () => {
+    await renderWithProviders(<Seeded />);
+
+    expect(await screen.findByText('Morning reading')).toBeTruthy();
+    expect(screen.getByText('Kagi Search')).toBeTruthy();
+    expect(screen.getByText('Hacker News')).toBeTruthy();
+  });
+
+  test('clicking a tab opens it via the chrome fake', async () => {
+    const { chrome } = await renderWithProviders(<Seeded />, {
+      seed: { tabs: [{ id: 1, index: 0, active: true }] },
+    });
+
+    await userEvent.click(await screen.findByText('Kagi Search'));
+
+    expect(chrome.createdTabs.map((tab) => tab.url)).toContain(
+      'https://kagi.com/'
+    );
+  });
+});

--- a/src/tests/components/TabGroupDetailsContainer.test.tsx
+++ b/src/tests/components/TabGroupDetailsContainer.test.tsx
@@ -1,7 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useDispatch } from 'react-redux';
 
 vi.mock('../../utils/functions/external', () => ({
   loadFromFirestore: vi.fn(),
@@ -15,7 +14,6 @@ import {
   saveToTabContainerInternal,
   selectTabContainer,
 } from '../../redux/slices/tabContainerDataStateSlice';
-import { AppDispatch } from '../../redux/store';
 
 // A factory, not a shared constant: saveToTabContainerInternal's reducer
 // mutates and Immer freezes whatever object it is given, so a session reused
@@ -56,26 +54,14 @@ const buildSession = () => ({
   ],
 });
 
-// TabGroupDetailsContainer dereferences the selected tab group on its very
-// first render (filteredTabGroups[0].tabGroupId) -- KAN-39, a known, open,
-// deliberately unfixed bug. Mounting it against an empty store therefore
-// throws immediately, before a test body would ever get a chance to dispatch
-// afterwards -- render() throws synchronously and no post-render dispatch is
-// reachable. Seeding via a wrapper that dispatches during its own render body
-// keeps the crash path from ever being entered: the dispatches run to
-// completion before React renders TabGroupDetailsContainer as this
-// component's child in the same synchronous pass, so its first `useSelector`
-// read already sees the populated, selected session. Not a component change.
-function Seeded() {
-  const dispatch: AppDispatch = useDispatch();
-  dispatch(saveToTabContainerInternal(buildSession()));
-  dispatch(selectTabContainer('group-1'));
-  return <TabGroupDetailsContainer />;
-}
-
 describe('TabGroupDetailsContainer', () => {
   test('renders the window and its tabs from store state', async () => {
-    await renderWithProviders(<Seeded />);
+    await renderWithProviders(<TabGroupDetailsContainer />, {
+      seedStore: (store) => {
+        store.dispatch(saveToTabContainerInternal(buildSession()));
+        store.dispatch(selectTabContainer('group-1'));
+      },
+    });
 
     expect(await screen.findByText('Morning reading')).toBeTruthy();
     expect(screen.getByText('Kagi Search')).toBeTruthy();
@@ -83,8 +69,12 @@ describe('TabGroupDetailsContainer', () => {
   });
 
   test('clicking a tab opens it via the chrome fake', async () => {
-    const { chrome } = await renderWithProviders(<Seeded />, {
+    const { chrome } = await renderWithProviders(<TabGroupDetailsContainer />, {
       seed: { tabs: [{ id: 1, index: 0, active: true }] },
+      seedStore: (store) => {
+        store.dispatch(saveToTabContainerInternal(buildSession()));
+        store.dispatch(selectTabContainer('group-1'));
+      },
     });
 
     await userEvent.click(await screen.findByText('Kagi Search'));

--- a/src/tests/components/TabGroupDetailsContainer.test.tsx
+++ b/src/tests/components/TabGroupDetailsContainer.test.tsx
@@ -1,12 +1,6 @@
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-
-vi.mock('../../utils/functions/external', () => ({
-  loadFromFirestore: vi.fn(),
-  saveToFirestore: vi.fn(),
-  displayToast: vi.fn(),
-}));
 
 import TabGroupDetailsContainer from '../../components/home/rightpane/TabGroupDetailsContainer';
 import { renderWithProviders } from '../setup/renderWithProviders';

--- a/src/tests/components/UserInputContainer.test.tsx
+++ b/src/tests/components/UserInputContainer.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, test, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+import UserInputContainer from '../../components/home/leftpane/UserInputContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import { SAVE_TAB_CONTAINER_ACTION } from '../../utils/constants/actionTypes';
+
+const seed = {
+  tabs: [
+    { id: 1, title: 'Kagi Search', url: 'https://kagi.com/', active: true },
+  ],
+  windows: [
+    {
+      id: 7,
+      tabs: [
+        { id: 1, title: 'Kagi Search', url: 'https://kagi.com/' },
+      ] as chrome.tabs.Tab[],
+    },
+  ],
+};
+
+describe('UserInputContainer', () => {
+  test('pre-fills the session name from the active tab', async () => {
+    await renderWithProviders(<UserInputContainer />, { seed });
+
+    expect(await screen.findByDisplayValue('Kagi Search')).toBeTruthy();
+  });
+
+  test('saving dispatches a session built from the open windows', async () => {
+    const { store, seen } = await renderWithProviders(<UserInputContainer />, {
+      seed,
+    });
+
+    await screen.findByDisplayValue('Kagi Search');
+    await userEvent.click(screen.getByLabelText('save session'));
+
+    expect(seen).toContain(SAVE_TAB_CONTAINER_ACTION);
+    const { tabGroups } = store.getState().tabContainerDataState;
+    expect(tabGroups).toHaveLength(1);
+    expect(tabGroups[0].title).toBe('Kagi Search');
+    expect(tabGroups[0].windows[0].tabs[0].url).toBe('https://kagi.com/');
+  });
+});

--- a/src/tests/components/UserInputContainer.test.tsx
+++ b/src/tests/components/UserInputContainer.test.tsx
@@ -1,12 +1,6 @@
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-
-vi.mock('../../utils/functions/external', () => ({
-  loadFromFirestore: vi.fn(),
-  saveToFirestore: vi.fn(),
-  displayToast: vi.fn(),
-}));
 
 import UserInputContainer from '../../components/home/leftpane/UserInputContainer';
 import { renderWithProviders } from '../setup/renderWithProviders';

--- a/src/tests/components/renderWithProviders.test.tsx
+++ b/src/tests/components/renderWithProviders.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, test, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { useTranslation } from 'react-i18next';
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+import { renderWithProviders } from '../setup/renderWithProviders';
+
+function Probe() {
+  const { t } = useTranslation();
+  return <div>{t('Open session')}</div>;
+}
+
+describe('renderWithProviders', () => {
+  // 'Open session' is one of the 19 en keys whose value differs from the key.
+  // Asserting on the VALUE is what proves i18n is really running rather than
+  // an identity mock -- under `t: (k) => k` this test fails.
+  test('renders real translated text, not the key', async () => {
+    await renderWithProviders(<Probe />);
+
+    expect(
+      screen.getByText('Open session, keeping current windows')
+    ).toBeTruthy();
+    expect(screen.queryByText('Open session')).toBeNull();
+  });
+
+  test('exposes a working store and the chrome fake', async () => {
+    const { store, chrome } = await renderWithProviders(<Probe />, {
+      seed: { tabs: [{ id: 1, title: 'Seeded', active: true }] },
+    });
+
+    expect(Object.keys(store.getState())).toContain('tabContainerDataState');
+    expect(chrome.createdTabs).toEqual([]);
+  });
+});

--- a/src/tests/components/renderWithProviders.test.tsx
+++ b/src/tests/components/renderWithProviders.test.tsx
@@ -1,18 +1,24 @@
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { screen } from '@testing-library/react';
+import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
-vi.mock('../../utils/functions/external', () => ({
-  loadFromFirestore: vi.fn(),
-  saveToFirestore: vi.fn(),
-  displayToast: vi.fn(),
-}));
-
 import { renderWithProviders } from '../setup/renderWithProviders';
+import { RootState } from '../../redux/store';
+import { setUserId } from '../../redux/slices/globalStateSlice';
 
 function Probe() {
   const { t } = useTranslation();
   return <div>{t('Open session')}</div>;
+}
+
+// Reads from the store via useSelector, so it throws (rather than silently
+// rendering) if the Provider is missing from the tree -- exactly what
+// rerender must not let happen. userId is present on the initial store from
+// makeTestStore() with no seeding required.
+function StoreProbe() {
+  const userId = useSelector((state: RootState) => state.globalState.userId);
+  return <div>userId: {String(userId)}</div>;
 }
 
 describe('renderWithProviders', () => {
@@ -29,11 +35,35 @@ describe('renderWithProviders', () => {
   });
 
   test('exposes a working store and the chrome fake', async () => {
-    const { store, chrome } = await renderWithProviders(<Probe />, {
+    const { store } = await renderWithProviders(<Probe />, {
       seed: { tabs: [{ id: 1, title: 'Seeded', active: true }] },
     });
 
     expect(Object.keys(store.getState())).toContain('tabContainerDataState');
-    expect(chrome.createdTabs).toEqual([]);
+
+    // Query the global chrome the wrapper installed, rather than asserting
+    // on the freshly-constructed handle (which starts empty regardless of
+    // whether setupChromeFake ever ran). This actually observes that the
+    // seed took effect: it fails if setupChromeFake(seed) is removed from
+    // renderWithProviders, because global.chrome would then be undefined.
+    const tabs = await new Promise<chrome.tabs.Tab[]>((resolve) =>
+      chrome.tabs.query({}, resolve)
+    );
+    expect(tabs.map((tab) => tab.title)).toContain('Seeded');
+  });
+
+  test('rerender keeps the Provider in the tree', async () => {
+    const { rerender, store } = await renderWithProviders(<StoreProbe />);
+
+    // Sanity check: the store starts with no user signed in.
+    expect(screen.getByText('userId: null')).toBeTruthy();
+
+    store.dispatch(setUserId('user-123'));
+    rerender(<StoreProbe />);
+
+    // If the Provider dropped out of the tree on rerender, useSelector
+    // throws during this render rather than returning a stale value, so
+    // this assertion (rather than a crash) is what proves the fix.
+    expect(screen.getByText('userId: user-123')).toBeTruthy();
   });
 });

--- a/src/tests/locales/keyCoverage.test.ts
+++ b/src/tests/locales/keyCoverage.test.ts
@@ -1,18 +1,26 @@
 import { describe, expect, test } from 'vitest';
-import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { join } from 'node:path';
 
 import en from '../../../public/locales/en/translation.json';
 
 // i18next falls back to returning the key when one is missing, and 72 of the
 // 91 en values are identical to their keys -- so a deleted key renders the
 // same string and fails no render test. This is the only check that sees it.
-const walk = (dir: string): string[] =>
-  readdirSync(dir).flatMap((entry) => {
-    const path = join(dir, entry);
-    if (statSync(path).isDirectory()) return walk(path);
-    return /\.tsx?$/.test(path) ? [path] : [];
-  });
+//
+// Reads the source tree via Vite's import.meta.glob rather than node:fs:
+// tsconfig.json's `types` array is explicit (no "node"), so node:fs/node:path
+// have no ambient module declarations here and fail tsc even though vitest
+// resolves them fine at runtime. Adding "node" to fix that would be a
+// project-wide change that makes ordinary extension source -- which never
+// runs in Node -- type-check clean against Node globals like `process` and
+// `Buffer`, silently removing a real compiler guard (see KAN-36, where
+// window.screen at module load crashed the MV3 service worker: the class of
+// bug an environment-mismatched global produces). import.meta.glob needs no
+// such change.
+const sources = import.meta.glob('/src/**/*.{ts,tsx}', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
 
 // Matches t('...') and t("..."). Template literals and computed keys are not
 // matched and would be missed; there are none today, and adding one should be
@@ -23,9 +31,8 @@ describe('translation key coverage', () => {
   test('every t() key used in src exists in the en locale', () => {
     const missing: string[] = [];
 
-    for (const file of walk('src')) {
-      if (file.includes(`${'src'}/tests/`)) continue;
-      const source = readFileSync(file, 'utf8');
+    for (const [file, source] of Object.entries(sources)) {
+      if (file.includes('/src/tests/')) continue;
       for (const [, key] of source.matchAll(KEY_PATTERN)) {
         if (!(key in en)) missing.push(`${key}  (${file})`);
       }

--- a/src/tests/locales/keyCoverage.test.ts
+++ b/src/tests/locales/keyCoverage.test.ts
@@ -22,10 +22,14 @@ const sources = import.meta.glob('/src/**/*.{ts,tsx}', {
   eager: true,
 }) as Record<string, string>;
 
-// Matches t('...') and t("..."). Template literals and computed keys are not
-// matched and would be missed; there are none today, and adding one should be
-// a deliberate decision rather than a silent gap.
-const KEY_PATTERN = /\bt\(\s*['"]([^'"]+)['"]/g;
+// Matches t('...'), t("..."), and t(`...`) -- backticked keys are common in
+// the settings pane and review modal and are matched just like quoted ones.
+// What this cannot see is a genuinely computed key: t(name) at
+// SettingsCategoryContainer.tsx:78 passes a variable, not a literal, so no
+// regex can recover the key from the source text. That call is therefore
+// invisible to this scan and must be covered by other means (e.g. a render
+// test). This test is a floor on coverage, not a complete census.
+const KEY_PATTERN = /\bt\(\s*['"`]([^'"`]+)['"`]/g;
 
 describe('translation key coverage', () => {
   test('every t() key used in src exists in the en locale', () => {

--- a/src/tests/locales/keyCoverage.test.ts
+++ b/src/tests/locales/keyCoverage.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import en from '../../../public/locales/en/translation.json';
+
+// i18next falls back to returning the key when one is missing, and 72 of the
+// 91 en values are identical to their keys -- so a deleted key renders the
+// same string and fails no render test. This is the only check that sees it.
+const walk = (dir: string): string[] =>
+  readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) return walk(path);
+    return /\.tsx?$/.test(path) ? [path] : [];
+  });
+
+// Matches t('...') and t("..."). Template literals and computed keys are not
+// matched and would be missed; there are none today, and adding one should be
+// a deliberate decision rather than a silent gap.
+const KEY_PATTERN = /\bt\(\s*['"]([^'"]+)['"]/g;
+
+describe('translation key coverage', () => {
+  test('every t() key used in src exists in the en locale', () => {
+    const missing: string[] = [];
+
+    for (const file of walk('src')) {
+      if (file.includes(`${'src'}/tests/`)) continue;
+      const source = readFileSync(file, 'utf8');
+      for (const [, key] of source.matchAll(KEY_PATTERN)) {
+        if (!(key in en)) missing.push(`${key}  (${file})`);
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/tests/redux/storeConfig.test.ts
+++ b/src/tests/redux/storeConfig.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test, vi } from 'vitest';
+
+// Inlined rather than imported: a vi.hoisted block runs before the module
+// graph is evaluated, and common.ts reads window.screen at module load. This
+// test runs in the `unit` (node) project, which has no window. Every existing
+// node test that touches a slice carries this same block -- see
+// src/tests/redux/syncScheduling.test.ts.
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+import { rootReducer } from '../../redux/storeConfig';
+import { store } from '../../redux/store';
+import { makeTestStore } from '../setup/makeStore';
+
+// The app store and the test store must stay in agreement. Comparing both
+// against the shared map is what makes adding a slice to one but not the
+// other impossible.
+describe('rootReducer', () => {
+  test('is the single source of the slice list', () => {
+    const expected = [
+      'globalState',
+      'settingsCategoryState',
+      'settingsDataState',
+      'tabContainerDataState',
+      'undoRedo',
+    ];
+
+    expect(Object.keys(rootReducer).sort()).toEqual(expected);
+    expect(Object.keys(store.getState()).sort()).toEqual(expected);
+    expect(Object.keys(makeTestStore().store.getState()).sort()).toEqual(
+      expected
+    );
+  });
+});

--- a/src/tests/setup/chrome.fake.ts
+++ b/src/tests/setup/chrome.fake.ts
@@ -182,9 +182,9 @@ export function setupChromeFake(seed: ChromeSeed = {}): ChromeFakeHandle {
     },
 
     runtime: {
-      sendMessage: (message: unknown) => {
+      sendMessage: (message: unknown, cb?: (response: unknown) => void) => {
         handle.sentMessages.push(message);
-        return Promise.resolve();
+        return settle(undefined, cb);
       },
       onMessage: {
         addListener: () => undefined,

--- a/src/tests/setup/chrome.fake.ts
+++ b/src/tests/setup/chrome.fake.ts
@@ -2,10 +2,12 @@
 // over a mock on purpose: tests assert on resulting state rather than on the
 // fact that a function was invoked.
 //
-// Covers the 17 members in use as of 2026-08-31 -- tabs.query/create/update/
-// get/onActivated, windows.getAll/getCurrent/create/remove,
-// storage.sync.get/set/remove/clear, runtime.sendMessage/onMessage/getURL/
-// lastError. Widen this when the app calls something new.
+// Covers 15 members production code calls as of 2026-08-31 --
+// tabs.query/create/update/get/onActivated, windows.getAll/getCurrent/
+// create/remove, storage.sync.get/set, runtime.sendMessage/onMessage/getURL/
+// lastError -- plus storage.sync.remove/clear, which have no production call
+// site today but are implemented for API fidelity and exercised by this
+// fake's own tests. Widen this when the app calls something new.
 
 export type ChromeSeed = {
   tabs?: Partial<chrome.tabs.Tab>[];
@@ -61,8 +63,10 @@ export function setupChromeFake(seed: ChromeSeed = {}): ChromeFakeHandle {
     },
   };
 
-  // `get` accepts an array of keys or an object of defaults. App.tsx relies on
-  // the defaults form, so both are implemented rather than only the easy one.
+  // `get` accepts an array of keys or an object of defaults. Production code
+  // only ever calls the array form (App.tsx:57, :66); the defaults form is
+  // implemented for API fidelity and is exercised by this fake's own tests,
+  // not by anything production calls today.
   const readStorage = (
     keys?: string[] | Record<string, unknown> | null
   ): Record<string, unknown> => {

--- a/src/tests/setup/chrome.fake.ts
+++ b/src/tests/setup/chrome.fake.ts
@@ -1,0 +1,200 @@
+// Working in-memory fakes for the chrome APIs the app actually calls. A fake
+// over a mock on purpose: tests assert on resulting state rather than on the
+// fact that a function was invoked.
+//
+// Covers the 17 members in use as of 2026-08-31 -- tabs.query/create/update/
+// get/onActivated, windows.getAll/getCurrent/create/remove,
+// storage.sync.get/set/remove/clear, runtime.sendMessage/onMessage/getURL/
+// lastError. Widen this when the app calls something new.
+
+export type ChromeSeed = {
+  tabs?: Partial<chrome.tabs.Tab>[];
+  windows?: Partial<chrome.windows.Window>[];
+  storage?: Record<string, unknown>;
+};
+
+export type ChromeFakeHandle = {
+  sentMessages: unknown[];
+  createdTabs: chrome.tabs.CreateProperties[];
+  removedWindowIds: number[];
+  restore(): void;
+};
+
+// Callers pass either a callback or use the returned promise. Supporting both
+// is not optional: App.tsx uses the promise form, capture.ts the callback one.
+function settle<T>(value: T, callback?: (value: T) => void): Promise<T> {
+  if (callback) callback(value);
+  return Promise.resolve(value);
+}
+
+export function setupChromeFake(seed: ChromeSeed = {}): ChromeFakeHandle {
+  const storage = new Map<string, unknown>(Object.entries(seed.storage ?? {}));
+  let nextId = 1000;
+  const tabs: chrome.tabs.Tab[] = (seed.tabs ?? []).map(
+    (tab) =>
+      ({
+        id: nextId++,
+        index: 0,
+        url: '',
+        title: '',
+        active: false,
+        windowId: 1,
+        ...tab,
+      }) as chrome.tabs.Tab
+  );
+  const windows: chrome.windows.Window[] = (seed.windows ?? []).map(
+    (win) =>
+      ({
+        id: nextId++,
+        focused: false,
+        tabs: [],
+        ...win,
+      }) as chrome.windows.Window
+  );
+
+  const handle: ChromeFakeHandle = {
+    sentMessages: [],
+    createdTabs: [],
+    removedWindowIds: [],
+    restore() {
+      delete (globalThis as { chrome?: unknown }).chrome;
+    },
+  };
+
+  // `get` accepts an array of keys or an object of defaults. App.tsx relies on
+  // the defaults form, so both are implemented rather than only the easy one.
+  const readStorage = (
+    keys?: string[] | Record<string, unknown> | null
+  ): Record<string, unknown> => {
+    if (keys == null) return Object.fromEntries(storage);
+    if (Array.isArray(keys)) {
+      const result: Record<string, unknown> = {};
+      for (const key of keys) {
+        if (storage.has(key)) result[key] = storage.get(key);
+      }
+      return result;
+    }
+    const result: Record<string, unknown> = {};
+    for (const [key, fallback] of Object.entries(keys)) {
+      result[key] = storage.has(key) ? storage.get(key) : fallback;
+    }
+    return result;
+  };
+
+  const chromeFake = {
+    storage: {
+      sync: {
+        get: (
+          keys?: string[] | Record<string, unknown> | null,
+          cb?: (items: Record<string, unknown>) => void
+        ) => settle(readStorage(keys), cb),
+        set: (items: Record<string, unknown>, cb?: () => void) => {
+          for (const [key, value] of Object.entries(items)) {
+            storage.set(key, value);
+          }
+          return settle(undefined as void, cb);
+        },
+        remove: (keys: string | string[], cb?: () => void) => {
+          for (const key of Array.isArray(keys) ? keys : [keys]) {
+            storage.delete(key);
+          }
+          return settle(undefined as void, cb);
+        },
+        clear: (cb?: () => void) => {
+          storage.clear();
+          return settle(undefined as void, cb);
+        },
+      },
+    },
+
+    tabs: {
+      query: (
+        queryInfo: chrome.tabs.QueryInfo,
+        cb?: (result: chrome.tabs.Tab[]) => void
+      ) => {
+        const matched = tabs.filter((tab) =>
+          queryInfo.active === undefined
+            ? true
+            : tab.active === queryInfo.active
+        );
+        return settle(matched, cb);
+      },
+      create: (
+        props: chrome.tabs.CreateProperties,
+        cb?: (tab: chrome.tabs.Tab) => void
+      ) => {
+        handle.createdTabs.push(props);
+        const created = {
+          id: nextId++,
+          index: tabs.length,
+          url: props.url ?? '',
+          title: '',
+          active: props.active ?? true,
+          windowId: props.windowId ?? 1,
+        } as chrome.tabs.Tab;
+        tabs.push(created);
+        return settle(created, cb);
+      },
+      update: (
+        tabId: number,
+        props: chrome.tabs.UpdateProperties,
+        cb?: (tab?: chrome.tabs.Tab) => void
+      ) => {
+        const target = tabs.find((tab) => tab.id === tabId);
+        if (target) Object.assign(target, props);
+        return settle(target, cb);
+      },
+      get: (tabId: number, cb?: (tab: chrome.tabs.Tab) => void) =>
+        settle(tabs.find((tab) => tab.id === tabId) as chrome.tabs.Tab, cb),
+      onActivated: {
+        addListener: () => undefined,
+        removeListener: () => undefined,
+      },
+    },
+
+    windows: {
+      getAll: (
+        _info: chrome.windows.QueryOptions,
+        cb?: (result: chrome.windows.Window[]) => void
+      ) => settle(windows, cb),
+      getCurrent: (
+        _info: chrome.windows.QueryOptions,
+        cb?: (result: chrome.windows.Window) => void
+      ) => settle(windows[0], cb),
+      create: (
+        data: chrome.windows.CreateData,
+        cb?: (win?: chrome.windows.Window) => void
+      ) => {
+        const created = {
+          id: nextId++,
+          focused: data.focused ?? false,
+          tabs: [],
+        } as unknown as chrome.windows.Window;
+        windows.push(created);
+        return settle(created, cb);
+      },
+      remove: (windowId: number, cb?: () => void) => {
+        handle.removedWindowIds.push(windowId);
+        const index = windows.findIndex((win) => win.id === windowId);
+        if (index >= 0) windows.splice(index, 1);
+        return settle(undefined as void, cb);
+      },
+    },
+
+    runtime: {
+      sendMessage: (message: unknown) => {
+        handle.sentMessages.push(message);
+        return Promise.resolve();
+      },
+      onMessage: {
+        addListener: () => undefined,
+        removeListener: () => undefined,
+      },
+      getURL: (path: string) => `chrome-extension://faketestid/${path}`,
+      lastError: undefined as chrome.runtime.LastError | undefined,
+    },
+  };
+
+  (globalThis as { chrome?: unknown }).chrome = chromeFake;
+  return handle;
+}

--- a/src/tests/setup/chrome.fake.ts
+++ b/src/tests/setup/chrome.fake.ts
@@ -29,30 +29,66 @@ function settle<T>(value: T, callback?: (value: T) => void): Promise<T> {
   return Promise.resolve(value);
 }
 
+// A tab seeded without an explicit windowId belongs to this window. Kept at 1
+// so a seed of `{ tabs: [...] }` alone behaves as it always has.
+const DEFAULT_WINDOW_ID = 1;
+
 export function setupChromeFake(seed: ChromeSeed = {}): ChromeFakeHandle {
   const storage = new Map<string, unknown>(Object.entries(seed.storage ?? {}));
   let nextId = 1000;
-  const tabs: chrome.tabs.Tab[] = (seed.tabs ?? []).map(
-    (tab) =>
-      ({
-        id: nextId++,
-        index: 0,
-        url: '',
-        title: '',
-        active: false,
-        windowId: 1,
-        ...tab,
-      }) as chrome.tabs.Tab
-  );
-  const windows: chrome.windows.Window[] = (seed.windows ?? []).map(
-    (win) =>
-      ({
-        id: nextId++,
-        focused: false,
-        tabs: [],
-        ...win,
-      }) as chrome.windows.Window
-  );
+
+  // Chrome's model is that a window OWNS its tabs and getAll({populate:true})
+  // is what reveals them. Holding a flat tab list beside windows that each
+  // carry their own `tabs` array is two sources of truth, and they drifted: a
+  // tab could exist while no window contained it. capture.ts:74 drops every
+  // window whose tabs array is empty, so captureOpenWindows returned null for
+  // anything this fake created -- silently, since a fake that models storage
+  // shape rather than the query contract still answers every call.
+  //
+  // So `tabs` below is the single source of truth and windows derive their
+  // contents from it by windowId. Seeded windows may still carry inline tabs;
+  // those are folded into the flat list rather than stored on the window.
+  const windows: chrome.windows.Window[] = [];
+  const tabs: chrome.tabs.Tab[] = [];
+
+  const makeTab = (
+    tab: Partial<chrome.tabs.Tab>,
+    windowId: number
+  ): chrome.tabs.Tab =>
+    ({
+      id: nextId++,
+      index: 0,
+      url: '',
+      title: '',
+      active: false,
+      windowId,
+      ...tab,
+    }) as chrome.tabs.Tab;
+
+  for (const win of seed.windows ?? []) {
+    const { tabs: inlineTabs, ...rest } = win;
+    const created = {
+      id: nextId++,
+      focused: false,
+      ...rest,
+    } as chrome.windows.Window;
+    windows.push(created);
+    for (const tab of inlineTabs ?? []) {
+      tabs.push(makeTab(tab, created.id as number));
+    }
+  }
+
+  for (const tab of seed.tabs ?? []) {
+    tabs.push(makeTab(tab, tab.windowId ?? DEFAULT_WINDOW_ID));
+  }
+
+  // Chrome omits `tabs` entirely unless populate was asked for, so the two
+  // cases are deliberately different shapes rather than one with an empty
+  // array -- a test that forgets populate should see what production sees.
+  const populate = (win: chrome.windows.Window): chrome.windows.Window => ({
+    ...win,
+    tabs: tabs.filter((tab) => tab.windowId === win.id),
+  });
 
   const handle: ChromeFakeHandle = {
     sentMessages: [],
@@ -112,14 +148,23 @@ export function setupChromeFake(seed: ChromeSeed = {}): ChromeFakeHandle {
     },
 
     tabs: {
+      // `active` and `windowId` are honoured. `currentWindow` and
+      // `lastFocusedWindow` are deliberately NOT: production passes them
+      // (UserInputContainer.tsx:28, TabGroupDetailsContainer.tsx:56) but
+      // honouring them would require every seed to place its tabs in a real
+      // window, which today's seeds do not. Treating them as "any window"
+      // keeps single-window tests honest; a multi-window test that depends on
+      // the distinction must not use this fake until that is fixed.
       query: (
         queryInfo: chrome.tabs.QueryInfo,
         cb?: (result: chrome.tabs.Tab[]) => void
       ) => {
-        const matched = tabs.filter((tab) =>
-          queryInfo.active === undefined
-            ? true
-            : tab.active === queryInfo.active
+        const matched = tabs.filter(
+          (tab) =>
+            (queryInfo.active === undefined ||
+              tab.active === queryInfo.active) &&
+            (queryInfo.windowId === undefined ||
+              tab.windowId === queryInfo.windowId)
         );
         return settle(matched, cb);
       },
@@ -128,14 +173,14 @@ export function setupChromeFake(seed: ChromeSeed = {}): ChromeFakeHandle {
         cb?: (tab: chrome.tabs.Tab) => void
       ) => {
         handle.createdTabs.push(props);
-        const created = {
-          id: nextId++,
-          index: tabs.length,
-          url: props.url ?? '',
-          title: '',
-          active: props.active ?? true,
-          windowId: props.windowId ?? 1,
-        } as chrome.tabs.Tab;
+        const created = makeTab(
+          {
+            index: tabs.length,
+            url: props.url ?? '',
+            active: props.active ?? true,
+          },
+          props.windowId ?? DEFAULT_WINDOW_ID
+        );
         tabs.push(created);
         return settle(created, cb);
       },
@@ -158,13 +203,26 @@ export function setupChromeFake(seed: ChromeSeed = {}): ChromeFakeHandle {
 
     windows: {
       getAll: (
-        _info: chrome.windows.QueryOptions,
+        info: chrome.windows.QueryOptions,
         cb?: (result: chrome.windows.Window[]) => void
-      ) => settle(windows, cb),
+      ) =>
+        settle(
+          windows.map((win) => (info?.populate ? populate(win) : { ...win })),
+          cb
+        ),
       getCurrent: (
-        _info: chrome.windows.QueryOptions,
+        info: chrome.windows.QueryOptions,
         cb?: (result: chrome.windows.Window) => void
-      ) => settle(windows[0], cb),
+      ) => {
+        const current = windows[0];
+        if (!current) return settle(current, cb);
+        return settle(info?.populate ? populate(current) : { ...current }, cb);
+      },
+      // A `url` opens as the window's first tab, matching Chrome. The restore
+      // path depends on exactly this: windows.ts:67 creates the window with
+      // tabs[0].url and then tabs.create()s the rest against its windowId, so
+      // a fake that dropped the initial tab would make a restored window come
+      // back one tab short.
       create: (
         data: chrome.windows.CreateData,
         cb?: (win?: chrome.windows.Window) => void
@@ -172,10 +230,14 @@ export function setupChromeFake(seed: ChromeSeed = {}): ChromeFakeHandle {
         const created = {
           id: nextId++,
           focused: data.focused ?? false,
-          tabs: [],
         } as unknown as chrome.windows.Window;
         windows.push(created);
-        return settle(created, cb);
+        for (const url of typeof data.url === 'string'
+          ? [data.url]
+          : data.url ?? []) {
+          tabs.push(makeTab({ url, active: true }, created.id as number));
+        }
+        return settle(populate(created), cb);
       },
       remove: (windowId: number, cb?: () => void) => {
         handle.removedWindowIds.push(windowId);

--- a/src/tests/setup/chromeFake.test.ts
+++ b/src/tests/setup/chromeFake.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { setupChromeFake } from './chrome.fake';
 
@@ -106,5 +106,15 @@ describe('chrome.runtime fake', () => {
     handle = undefined;
 
     expect((globalThis as { chrome?: unknown }).chrome).toBeUndefined();
+  });
+
+  test('sendMessage invokes a callback when one is given', () => {
+    handle = setupChromeFake();
+    const cb = vi.fn();
+
+    chrome.runtime.sendMessage({ type: 'FOCUS_TAB_CONTAINER' }, cb);
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(handle.sentMessages).toEqual([{ type: 'FOCUS_TAB_CONTAINER' }]);
   });
 });

--- a/src/tests/setup/chromeFake.test.ts
+++ b/src/tests/setup/chromeFake.test.ts
@@ -76,6 +76,49 @@ describe('chrome.windows fake', () => {
 
     expect(windows).toHaveLength(1);
     expect(windows[0].id).toBe(7);
+    // Asserting the tabs, not just the window: without this the test passed
+    // against a fake that reported `tabs: []` for every window, which is the
+    // exact defect that made captureOpenWindows return null.
+    expect(windows[0].tabs?.map((tab) => tab.title)).toEqual(['One']);
+  });
+
+  test('omits tabs when populate was not asked for', async () => {
+    handle = setupChromeFake({
+      windows: [
+        { id: 7, tabs: [{ id: 1, title: 'One' }] as chrome.tabs.Tab[] },
+      ],
+    });
+
+    const windows = await new Promise<chrome.windows.Window[]>((resolve) =>
+      chrome.windows.getAll({}, resolve)
+    );
+
+    expect(windows[0].tabs).toBeUndefined();
+  });
+
+  test('a tab created against a window shows up inside that window', async () => {
+    handle = setupChromeFake({ windows: [{ id: 7 }, { id: 8 }] });
+
+    await chrome.tabs.create({ windowId: 7, url: 'https://kagi.com/' });
+
+    const windows = await new Promise<chrome.windows.Window[]>((resolve) =>
+      chrome.windows.getAll({ populate: true }, resolve)
+    );
+
+    expect(windows[0].tabs?.map((tab) => tab.url)).toEqual([
+      'https://kagi.com/',
+    ]);
+    expect(windows[1].tabs).toEqual([]);
+  });
+
+  test('create opens its url as the new window first tab', async () => {
+    handle = setupChromeFake();
+
+    const created = await new Promise<chrome.windows.Window | undefined>(
+      (resolve) => chrome.windows.create({ url: 'https://kagi.com/' }, resolve)
+    );
+
+    expect(created!.tabs?.map((tab) => tab.url)).toEqual(['https://kagi.com/']);
   });
 
   test('remove deletes the window from a subsequent getAll', async () => {

--- a/src/tests/setup/chromeFake.test.ts
+++ b/src/tests/setup/chromeFake.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { setupChromeFake } from './chrome.fake';
+
+let handle: ReturnType<typeof setupChromeFake> | undefined;
+
+afterEach(() => {
+  handle?.restore();
+  handle = undefined;
+});
+
+describe('chrome.storage.sync fake', () => {
+  test('round-trips a value through set and get', async () => {
+    handle = setupChromeFake();
+
+    await chrome.storage.sync.set({ tokenValue: 'abc' });
+    const read = await chrome.storage.sync.get(['tokenValue']);
+
+    expect(read).toEqual({ tokenValue: 'abc' });
+  });
+
+  test('honours default values for a key that was never set', async () => {
+    handle = setupChromeFake();
+
+    const read = await chrome.storage.sync.get({ tokenValue: 'fallback' });
+
+    expect(read).toEqual({ tokenValue: 'fallback' });
+  });
+
+  test('clear empties the store', async () => {
+    handle = setupChromeFake({ storage: { tokenValue: 'abc' } });
+
+    await chrome.storage.sync.clear();
+
+    expect(await chrome.storage.sync.get(['tokenValue'])).toEqual({});
+  });
+});
+
+describe('chrome.tabs fake', () => {
+  test('query returns seeded tabs to a callback', async () => {
+    handle = setupChromeFake({
+      tabs: [{ id: 1, title: 'Seeded', active: true }],
+    });
+
+    const tabs = await new Promise<chrome.tabs.Tab[]>((resolve) =>
+      chrome.tabs.query({ active: true, currentWindow: true }, resolve)
+    );
+
+    expect(tabs.map((tab) => tab.title)).toEqual(['Seeded']);
+  });
+
+  test('create records the call and makes the tab queryable', async () => {
+    handle = setupChromeFake();
+
+    chrome.tabs.create({ url: 'https://example.com/' });
+
+    expect(handle.createdTabs).toEqual([{ url: 'https://example.com/' }]);
+    const tabs = await new Promise<chrome.tabs.Tab[]>((resolve) =>
+      chrome.tabs.query({}, resolve)
+    );
+    expect(tabs.map((tab) => tab.url)).toContain('https://example.com/');
+  });
+});
+
+describe('chrome.windows fake', () => {
+  test('getAll returns seeded windows with their tabs', async () => {
+    handle = setupChromeFake({
+      windows: [
+        { id: 7, tabs: [{ id: 1, title: 'One' }] as chrome.tabs.Tab[] },
+      ],
+    });
+
+    const windows = await new Promise<chrome.windows.Window[]>((resolve) =>
+      chrome.windows.getAll({ populate: true }, resolve)
+    );
+
+    expect(windows).toHaveLength(1);
+    expect(windows[0].id).toBe(7);
+  });
+
+  test('remove deletes the window from a subsequent getAll', async () => {
+    handle = setupChromeFake({ windows: [{ id: 7 }, { id: 8 }] });
+
+    chrome.windows.remove(7);
+
+    const windows = await new Promise<chrome.windows.Window[]>((resolve) =>
+      chrome.windows.getAll({ populate: true }, resolve)
+    );
+    expect(windows.map((w) => w.id)).toEqual([8]);
+    expect(handle.removedWindowIds).toEqual([7]);
+  });
+});
+
+describe('chrome.runtime fake', () => {
+  test('sendMessage records the message', () => {
+    handle = setupChromeFake();
+
+    chrome.runtime.sendMessage({ type: 'FOCUS_TAB_CONTAINER' });
+
+    expect(handle.sentMessages).toEqual([{ type: 'FOCUS_TAB_CONTAINER' }]);
+  });
+
+  test('restore removes the global', () => {
+    handle = setupChromeFake();
+    handle.restore();
+    handle = undefined;
+
+    expect((globalThis as { chrome?: unknown }).chrome).toBeUndefined();
+  });
+});

--- a/src/tests/setup/componentSetup.ts
+++ b/src/tests/setup/componentSetup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/src/tests/setup/componentSetup.ts
+++ b/src/tests/setup/componentSetup.ts
@@ -1,1 +1,15 @@
+import { vi } from 'vitest';
+
 import '@testing-library/jest-dom/vitest';
+
+// Every component test needs this stubbed: utils/functions/external reaches
+// out to Firestore and chrome.notifications, none of which exist in jsdom.
+// Centralized here (rather than copy-pasted per test file) so a new
+// component test file cannot forget it -- on CI, where no .env exists, an
+// unmocked import of this module throws at module-load time, so the hazard
+// is invisible on a machine that has one.
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));

--- a/src/tests/setup/configIncludes.test.ts
+++ b/src/tests/setup/configIncludes.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest';
+
+// Read as text rather than imported: vite.config.ts uses __dirname and
+// node:path, and tsconfig.json's `types` array deliberately omits "node", so
+// importing it here would fail tsc for the same reason keyCoverage.test.ts
+// cannot use node:fs. See that file for why adding "node" is not the fix.
+const configSource = Object.values(
+  import.meta.glob('/vite.config.ts', {
+    query: '?raw',
+    import: 'default',
+    eager: true,
+  }) as Record<string, string>
+)[0];
+
+const includePatterns = [
+  ...configSource.matchAll(/include:\s*\[([^\]]*)\]/g),
+].flatMap(([, body]) => [...body.matchAll(/'([^']+)'/g)].map(([, p]) => p));
+
+// A test-infrastructure bug is silent by construction: a harness that collects
+// nothing reports success. These globs previously read src/tests/**/*.test.ts,
+// which meant a colocated src/components/Foo.test.tsx and any *.spec file were
+// claimed by no project -- vitest exited 0 having run neither. Both dimensions
+// are asserted because narrowing either one reopens the hole.
+describe('vitest include globs', () => {
+  test('both projects are configured', () => {
+    expect(includePatterns).toHaveLength(2);
+  });
+
+  test('cover all of src, not just src/tests', () => {
+    for (const pattern of includePatterns) {
+      expect(pattern.startsWith('src/**/')).toBe(true);
+    }
+  });
+
+  test('cover .spec as well as .test', () => {
+    for (const pattern of includePatterns) {
+      expect(pattern).toContain('{test,spec}');
+    }
+  });
+});

--- a/src/tests/setup/i18nForTests.ts
+++ b/src/tests/setup/i18nForTests.ts
@@ -1,0 +1,21 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import en from '../../../public/locales/en/translation.json';
+
+// The app's src/config/i18n.tsx uses i18next-http-backend, which cannot
+// resolve under jsdom and loads asynchronously. Tests get their own instance
+// with the real en resources inlined, so translation is synchronous and
+// assertions run against the strings a user actually sees.
+//
+// Importing the app's i18n config from a test would run the HTTP backend at
+// module load. Never do it.
+export const testI18n = i18n.createInstance();
+
+export const initTestI18n = () =>
+  testI18n.use(initReactI18next).init({
+    lng: 'en',
+    fallbackLng: 'en',
+    resources: { en: { translation: en } },
+    interpolation: { escapeValue: false },
+  });

--- a/src/tests/setup/makeStore.ts
+++ b/src/tests/setup/makeStore.ts
@@ -1,16 +1,12 @@
 import { configureStore, Middleware } from '@reduxjs/toolkit';
 
-import globalStateReducer from '../../redux/slices/globalStateSlice';
-import settingsDataStateReducer from '../../redux/slices/settingsDataStateSlice';
-import settingsCategoryStateReducer from '../../redux/slices/settingsCategoryStateSlice';
-import tabContainerDataStateReducer from '../../redux/slices/tabContainerDataStateSlice';
-import undoRedoReducer from '../../redux/slices/undoRedoSlice';
+import { rootReducer } from '../../redux/storeConfig';
 import { customMiddleware } from '../../redux/middleware/customMiddleware';
 
-// Mirrors src/redux/store.tsx, plus a recorder so tests can assert on the
-// action sequence the middleware produces. Thunks arrive as functions and have
-// no `.type`. serializableCheck is off because the recorder sees thunk
-// functions, which the default check would flag.
+// Mirrors src/redux/store.tsx via the shared rootReducer, plus a recorder so
+// tests can assert on the action sequence the middleware produces. Thunks
+// arrive as functions and have no `.type`. serializableCheck is off because
+// the recorder sees thunk functions, which the default check would flag.
 export function makeTestStore() {
   const seen: string[] = [];
   const recorder: Middleware = () => (next) => (action: unknown) => {
@@ -23,13 +19,7 @@ export function makeTestStore() {
   };
 
   const store = configureStore({
-    reducer: {
-      undoRedo: undoRedoReducer,
-      globalState: globalStateReducer,
-      settingsDataState: settingsDataStateReducer,
-      settingsCategoryState: settingsCategoryStateReducer,
-      tabContainerDataState: tabContainerDataStateReducer,
-    },
+    reducer: rootReducer,
     middleware: (g) =>
       g({ serializableCheck: false })
         .prepend(recorder)

--- a/src/tests/setup/renderWithProviders.tsx
+++ b/src/tests/setup/renderWithProviders.tsx
@@ -1,0 +1,40 @@
+import { ReactElement } from 'react';
+import { Provider } from 'react-redux';
+import { render, RenderResult } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+
+import { makeTestStore } from './makeStore';
+import { initTestI18n, testI18n } from './i18nForTests';
+import { setupChromeFake, ChromeSeed, ChromeFakeHandle } from './chrome.fake';
+
+type Options = { seed?: ChromeSeed };
+
+export type RenderWithProvidersResult = RenderResult & {
+  store: ReturnType<typeof makeTestStore>['store'];
+  seen: string[];
+  chrome: ChromeFakeHandle;
+};
+
+// One call installs everything a component needs: a fresh store (with the
+// action recorder), real i18n, and the chrome fake. useThemeColors and
+// useFontFamily read from the store, so the Provider covers theming too --
+// there is deliberately no separate theme provider.
+//
+// Async because initReactI18next returns a promise even with inlined
+// resources; awaiting once here stops every test racing the first render.
+export async function renderWithProviders(
+  ui: ReactElement,
+  { seed }: Options = {}
+): Promise<RenderWithProvidersResult> {
+  await initTestI18n();
+  const chrome = setupChromeFake(seed);
+  const { store, seen } = makeTestStore();
+
+  const result = render(
+    <Provider store={store}>
+      <I18nextProvider i18n={testI18n}>{ui}</I18nextProvider>
+    </Provider>
+  );
+
+  return { ...result, store, seen, chrome };
+}

--- a/src/tests/setup/renderWithProviders.tsx
+++ b/src/tests/setup/renderWithProviders.tsx
@@ -7,7 +7,10 @@ import { makeTestStore } from './makeStore';
 import { initTestI18n, testI18n } from './i18nForTests';
 import { setupChromeFake, ChromeSeed, ChromeFakeHandle } from './chrome.fake';
 
-type Options = { seed?: ChromeSeed };
+type Options = {
+  seed?: ChromeSeed;
+  seedStore?: (store: ReturnType<typeof makeTestStore>['store']) => void;
+};
 
 export type RenderWithProvidersResult = RenderResult & {
   store: ReturnType<typeof makeTestStore>['store'];
@@ -24,11 +27,20 @@ export type RenderWithProvidersResult = RenderResult & {
 // resources; awaiting once here stops every test racing the first render.
 export async function renderWithProviders(
   ui: ReactElement,
-  { seed }: Options = {}
+  { seed, seedStore }: Options = {}
 ): Promise<RenderWithProvidersResult> {
   await initTestI18n();
   const chrome = setupChromeFake(seed);
   const { store, seen } = makeTestStore();
+
+  // Some components read selected/derived state on their very first render
+  // and throw against an empty store (e.g. KAN-39: TabGroupDetailsContainer
+  // dereferences the selected tab group unconditionally). Dispatching after
+  // render is too late for those -- the crash happens inside render() itself,
+  // before a caller could ever reach a post-render dispatch. seedStore runs
+  // synchronously here, before the first render, so callers can put the
+  // store in the state a component expects to see on mount.
+  seedStore?.(store);
 
   const result = render(
     <Provider store={store}>

--- a/src/tests/setup/renderWithProviders.tsx
+++ b/src/tests/setup/renderWithProviders.tsx
@@ -40,6 +40,13 @@ export async function renderWithProviders(
   // before a caller could ever reach a post-render dispatch. seedStore runs
   // synchronously here, before the first render, so callers can put the
   // store in the state a component expects to see on mount.
+  //
+  // seedStore MUST be synchronous. Anything deferred -- a promise, a
+  // setTimeout, an await inside the callback -- runs after render() has
+  // already fired, silently defeating this seam: the component still mounts
+  // against an empty store with no compiler or runtime error to flag it. The
+  // `(store) => void` type signature does not enforce this; only this
+  // convention does, so keep every seedStore call site synchronous.
   seedStore?.(store);
 
   const result = render(

--- a/src/tests/setup/renderWithProviders.tsx
+++ b/src/tests/setup/renderWithProviders.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react';
+import { ReactElement, ReactNode } from 'react';
 import { Provider } from 'react-redux';
 import { render, RenderResult } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
@@ -49,11 +49,19 @@ export async function renderWithProviders(
   // convention does, so keep every seedStore call site synchronous.
   seedStore?.(store);
 
-  const result = render(
+  // Providers go in a `wrapper`, not inlined around `ui`, so that RTL's
+  // `rerender` -- which re-renders only the element it was given and wraps
+  // it with `wrapper` again -- keeps the Provider in the tree. Inlining the
+  // providers into the initial element meant `rerender(newUi)` replaced the
+  // whole tree with the bare element, dropping the Provider and making
+  // useSelector throw.
+  const Wrapper = ({ children }: { children: ReactNode }) => (
     <Provider store={store}>
-      <I18nextProvider i18n={testI18n}>{ui}</I18nextProvider>
+      <I18nextProvider i18n={testI18n}>{children}</I18nextProvider>
     </Provider>
   );
+
+  const result = render(ui, { wrapper: Wrapper });
 
   return { ...result, store, seen, chrome };
 }

--- a/src/tests/utils/functions/capture.test.ts
+++ b/src/tests/utils/functions/capture.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 
-import { isAlreadySaved } from '../../../utils/functions/capture';
+import {
+  captureOpenWindows,
+  isAlreadySaved,
+} from '../../../utils/functions/capture';
+import { setupChromeFake } from '../../setup/chrome.fake';
 import type {
   tabContainerData,
   windowGroupData,
@@ -121,5 +125,62 @@ describe('isAlreadySaved', () => {
 
   test('is false when nothing has been saved yet', () => {
     expect(isAlreadySaved(sessionOf(windowOf(A)), [])).toBe(false);
+  });
+});
+
+// These run captureOpenWindows against the fake rather than a pure input,
+// because the defect they guard was in the seam between the two: the fake held
+// tabs in a flat list while every window reported `tabs: []`, and line 74 of
+// capture.ts drops a window with no tabs. Every call still answered, so the
+// only visible symptom was captureOpenWindows quietly returning null.
+describe('captureOpenWindows against the chrome fake', () => {
+  let handle: ReturnType<typeof setupChromeFake> | undefined;
+
+  afterEach(() => {
+    handle?.restore();
+    handle = undefined;
+  });
+
+  test('captures a seeded window with its tabs', async () => {
+    handle = setupChromeFake({
+      windows: [
+        {
+          id: 1,
+          tabs: [
+            { id: 1, url: A, title: 'A' },
+            { id: 2, url: B, title: 'B' },
+          ] as chrome.tabs.Tab[],
+        },
+      ],
+    });
+
+    const captured = await captureOpenWindows('probe');
+
+    expect(captured).not.toBeNull();
+    expect(captured!.windows).toHaveLength(1);
+    expect(captured!.windows[0].tabs.map((tab) => tab.url)).toEqual([A, B]);
+  });
+
+  test('captures a tab added through tabs.create', async () => {
+    handle = setupChromeFake({ windows: [{ id: 1 }] });
+
+    await chrome.tabs.create({ windowId: 1, url: B });
+    const captured = await captureOpenWindows('probe');
+
+    expect(captured).not.toBeNull();
+    expect(captured!.windows[0].tabs.map((tab) => tab.url)).toEqual([B]);
+  });
+
+  test('captures a window opened through windows.create, first tab included', async () => {
+    handle = setupChromeFake();
+
+    const created = await new Promise<chrome.windows.Window | undefined>(
+      (resolve) => chrome.windows.create({ url: A }, resolve)
+    );
+    await chrome.tabs.create({ windowId: created!.id, url: B });
+    const captured = await captureOpenWindows('probe');
+
+    expect(captured).not.toBeNull();
+    expect(captured!.windows[0].tabs.map((tab) => tab.url)).toEqual([A, B]);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "jsxImportSource": "@emotion/react",
-    "types": ["@emotion/react/types/css-prop", "chrome", "node"],
+    "types": ["@emotion/react/types/css-prop", "chrome"],
 
     /* Linting */
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "jsxImportSource": "@emotion/react",
-    "types": ["@emotion/react/types/css-prop", "chrome"],
+    "types": ["@emotion/react/types/css-prop", "chrome", "node"],
 
     /* Linting */
     "strict": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,13 @@ export default defineConfig({
     // ErrorBoundary.test.ts is a .ts node test that lives in the components
     // directory and must keep running under node -- it tests a static pure
     // function, not a render.
+    //
+    // The globs span all of src/, not just src/tests/, and match .spec as well
+    // as .test. Scoping them to src/tests/**/*.test.* meant a colocated test
+    // (src/components/Foo.test.tsx) or any *.spec file was collected by no
+    // project at all: vitest reported success having silently run none of it,
+    // so a failing test could not turn CI red. configIncludes.test.ts guards
+    // both dimensions.
     projects: [
       {
         extends: true,
@@ -37,7 +44,7 @@ export default defineConfig({
           globals: true,
           setupFiles: ['vitest-localstorage-mock'],
           mockReset: false,
-          include: ['src/tests/**/*.test.ts'],
+          include: ['src/**/*.{test,spec}.ts'],
         },
       },
       {
@@ -51,7 +58,7 @@ export default defineConfig({
             './src/tests/setup/componentSetup.ts',
           ],
           mockReset: false,
-          include: ['src/tests/**/*.test.tsx'],
+          include: ['src/**/*.{test,spec}.tsx'],
         },
       },
     ],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,7 +46,10 @@ export default defineConfig({
           name: 'components',
           environment: 'jsdom',
           globals: true,
-          setupFiles: ['vitest-localstorage-mock'],
+          setupFiles: [
+            'vitest-localstorage-mock',
+            './src/tests/setup/componentSetup.ts',
+          ],
           mockReset: false,
           include: ['src/tests/**/*.test.tsx'],
         },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,8 +24,33 @@ export default defineConfig({
     },
   },
   test: {
-    globals: true,
-    setupFiles: ['vitest-localstorage-mock'],
-    mockReset: false,
+    // Split by file EXTENSION, not directory. src/tests/components/
+    // ErrorBoundary.test.ts is a .ts node test that lives in the components
+    // directory and must keep running under node -- it tests a static pure
+    // function, not a render.
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'unit',
+          environment: 'node',
+          globals: true,
+          setupFiles: ['vitest-localstorage-mock'],
+          mockReset: false,
+          include: ['src/tests/**/*.test.ts'],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'components',
+          environment: 'jsdom',
+          globals: true,
+          setupFiles: ['vitest-localstorage-mock'],
+          mockReset: false,
+          include: ['src/tests/**/*.test.tsx'],
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
Adds the missing middle layer of the test pyramid: chrome API fakes, jsdom + React Testing Library, a render wrapper, three component smoke tests, and a translation-key coverage test.

**233 → 263 tests.** `tsc` clean, lint 0 errors / 28 warnings (exact pre-branch baseline), `npm audit --omit=dev` 0.

## Why now

Every UI change in the last week — the conflict modal, focus mode, the Restore→Open rename, the error boundary — was verified by building the extension and driving Chrome by hand. That loop works but is manual and can't run in CI.

The concrete cost is **KAN-16** and **KAN-39**, which both ask for a defensive guard against an unguarded `filteredTabGroups[0]`. Neither could be closed: the crash is unreachable through the UI because `RightPane` won't mount the child when nothing is selected, and with no jsdom there was no way to assert "renders null when nothing is selected" either. No test could be made to fail, so the guard could only ever have been verified by inspection.

**That's now unblocked, and it was proven rather than assumed.** A KAN-39-shaped test written against this infrastructure produces the exact red failure:

```
TypeError: Cannot read properties of undefined (reading 'tabGroupId')
 ❯ TabGroupDetailsContainer src/components/home/rightpane/TabGroupDetailsContainer.tsx:50:39
```

and passes green against a null-returning stand-in. **KAN-39 is deliberately left unfixed here** — it gets its own ticket and its own red-green cycle.

One correction to how that bug has been described: it is **not** user-reachable today, and the reason is stronger than "the parent happens to guard it". `RightPane.tsx:23-31` derives `isNoneSelected` from the *search-filtered* list, so its guard is character-identical to the child's read — including the "search matches nothing" case that looks like it slips through. A component test reaches the crash only by rendering the child in isolation. The real defect is that the predicate is copy-pasted in three components and the guard is correct only by coincidence of those copies agreeing.

## Three deviations from the ticket, each on measured grounds

**Two Vitest projects, not a global jsdom environment.** The ticket says register globally in `setupFiles`, which would move all 233 existing tests into jsdom — and `domStub.ts` assigns `window.screen`, which jsdom owns. The old fix for a mixed suite, `environmentMatchGlobs`, was **removed in Vitest 4** (verified against the installed copy). So `test.projects` splits `unit` (node, `*.test.ts`) from `components` (jsdom, `*.test.tsx`). The split is by **extension, not directory** — `src/tests/components/ErrorBoundary.test.ts` is a `.ts` node test living in that directory and correctly stays under `unit`.

**Real i18next with inlined `en` resources, not a `t: (k) => k` mock.** Of the 91 keys in the `en` locale, **19 have values that differ from the key**, including interpolated ones (`FocusConfirmTitle` → `Switch to "{{title}}"?`). Under an identity mock a test would assert `"Open session"` — a string the UI never renders — and interpolation would go untested. The wrapper's own test asserts the long form is present *and* the bare key is absent, which fails under a mock.

**Chrome fakes cover the 17 APIs actually in use, not the ticket's five.** The ticket predates focus mode and the service worker. Working in-memory fakes, not call recorders: `tabs.create` makes the tab appear in a later `query`, `windows.remove` removes it from `getAll`.

## Layer 4 moved to KAN-40

The ticket's golden path targets `npm run dev` with fakes. For an extension that's the wrong target — dev mode has no service worker and no MV3 lifecycle, so it could not have caught KAN-36's dead listener or the stale-worker trap. KAN-40 retargets it at the real built extension via Playwright `--load-extension`.

## Two defects found in review and fixed here

Both were in the infrastructure itself, and both were silent by construction — a broken feature throws, a broken harness reports green.

**The include globs collected neither colocated nor `*.spec` tests** (`560ffde`). They read `src/tests/**/*.test.ts{,x}`, so `src/components/Foo.test.tsx` and any `*.spec` file were claimed by no project. Two deliberately-failing probes, one in each position, left the run at **24 files / 254 tests, all green** — a failing test could not turn CI red. Widened to `src/**/*.{test,spec}.ts{,x}`; the same two probes are now collected and both fail. `configIncludes.test.ts` guards both scope and extension, since narrowing either reopens the hole.

**The chrome fake's windows did not own their tabs** (`a9d9033`). A flat tab list sat beside windows that each carried their own `tabs` array — two sources of truth. `tabs.create` pushed only to the flat list, `windows.create` hardcoded `tabs: []`, and `windows.getAll` ignored `populate` entirely. Since `capture.ts:74` drops every window with no tabs, **`captureOpenWindows` returned `null`** for anything the fake created:

```
CAPTURED = null
```

The flat list is now authoritative and windows derive their contents by `windowId` join, so the two cannot drift. `getAll`/`getCurrent` honour `populate` and omit `tabs` without it, as Chrome does; `windows.create` opens its `url` as the first tab, which the restore path at `windows.ts:67` depends on. `tabs.query` honours `windowId`; `currentWindow`/`lastFocusedWindow` remain ignored and are documented as such at the call site.

Six tests added for this, **five of which fail against the previous fake**. The sixth — a seeded window's inline tabs — passed before and is kept as contract coverage, not counted as a guard; the same is true of the `tabs` assertion added to the existing `getAll` test.

## Evidence

- **CI simulated by moving `.env` aside** — 263/263 still pass. This matters: the `external`-mock failure mode is invisible locally by construction, and this repo has been bitten by it before (PR #124).
- Each new test was proven able to fail. Deleting a locale key fails the coverage test naming both call sites; emptying the i18n resources fails the wrapper test; removing `seedStore` reproduces the KAN-39 TypeError; emptying a seeded window's tabs fails the save test.
- **Production changes are limited to `src/redux/store.tsx` and `src/redux/storeConfig.ts`** — extracting the reducer map that `store.tsx` and `makeTestStore` previously duplicated, so a slice added to the app can't go missing from tests.

### The reducer-map extraction, specifically

It is the only shipping code that changes, so it was probed rather than reasoned about.

- **Swapping two reducers in the map** — the failure `storeConfig.test.ts` cannot see, since it compares keys only — is caught twice over: `tsc` exits 2 with 20+ errors (`Property 'isSignedIn' does not exist on type 'undoRedoState'`), because `RootState` is *inferred* from the map and every `useSelector` is therefore an assertion about it; and **14 tests across 8 files** fail.
- **Dropping a slice from the test store alone**, leaving the app store intact — the exact divergence the new test exists to catch — fails `storeConfig.test.ts` naming the missing slice.
- **Verified in the built extension**, not just under vitest: the shipped artifact (build + the release URL strip) was loaded in Chrome and all five slices exercised through the real production store — session list renders (`tabContainerDataState`), settings opens (`globalState`), category switches (`settingsCategoryState`), theme change persists (`settingsDataState`), and delete-then-undo restores a session byte-identical to its pre-delete state ignoring `lastModified` (`undoRedo`). Zero console errors.

## Notable

`renderWithProviders` builds the store *and* renders, so components that read selected state on mount can't be seeded by dispatching afterwards — the crash happens inside `render()`. Hence the `seedStore` callback, which runs before the first render. It must be **synchronous**; anything deferred runs after render and silently defeats it. The type can't enforce that, so it's documented at the call site.

Providers are installed via RTL's `wrapper` option rather than inlined, so `rerender` keeps the store — covered by a regression test.

## Follow-ups (none block merge)

- `Search.test.tsx`'s second test passes against unfiltered data: short-circuiting `filterTabGroups` leaves it green. It does still catch case-sensitivity, which is what it is named for, so this is a strengthening rather than a repair — one non-matching session closes it.
- Memoizing the per-render i18n init.
- `FocusConfirmModal`'s five body keys are invisible to `keyCoverage.test.ts`, because `t(bodyKey, …)` passes a variable. That limitation is documented in the test; the keys need render coverage instead. (Reviewed and **not** a bug: the `willSave` → `…Saved*` mapping reads inverted but is correct against `tabContainerDataStateSlice.ts:232`. A separate, narrower issue does exist — `captured === null` also yields `willSave === false`, so the dialog claims windows are "already saved" when there was simply nothing to save.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
