### PR TITLE
Extract selectVisibleTabGroups so the right pane agrees with itself (KAN-16, KAN-39)

### DIFF
--- a/src/components/home/rightpane/HeroContainerRight.tsx
+++ b/src/components/home/rightpane/HeroContainerRight.tsx
@@ -13,8 +13,8 @@ import { useThemeColors } from '../../../hooks/useThemeColors';
 import { AppDispatch, RootState } from '../../../redux/store';
 import {
   resolveTabUrl,
-  filterTabGroups,
   getPrettyDate,
+  selectVisibleTabGroups,
 } from '../../../utils/functions/local';
 import {
   addCurrWindowToTabGroup,
@@ -59,17 +59,25 @@ export default function HeroContainerRight() {
     });
   }, []);
 
-  let filteredTabGroups = tabContainerDataList.tabGroups.filter(
-    (tabGroup) => tabGroup.isSelected
-  );
-  if (isSearchPanel && searchInputText) {
-    filteredTabGroups = filterTabGroups(searchInputText, filteredTabGroups);
-  }
-  const selectedTabGroup = filteredTabGroups[0];
+  // the same list RightPane derives its mount guard from
+  const selectedTabGroup = selectVisibleTabGroups(
+    tabContainerDataList.tabGroups,
+    isSearchPanel,
+    searchInputText
+  )[0];
 
   useEffect(() => {
-    setEditableTitle(selectedTabGroup.title);
+    if (selectedTabGroup) setEditableTitle(selectedTabGroup.title);
   }, [selectedTabGroup]);
+
+  // Belt and braces: RightPane does not mount this component when the list is
+  // empty, so this should be unreachable -- but it is what makes the component
+  // safe on its own terms rather than safe because of its only caller (KAN-16).
+  // It sits below every hook deliberately. Moving it above the useEffect that
+  // seeds the editable title would change the hook count between the
+  // nothing-selected and selected renders, and React throws "Rendered more
+  // hooks than during the previous render" on that transition.
+  if (!selectedTabGroup) return null;
 
   const handleTabGroupTitleClick = () => {
     if (!isSearchPanel) {

--- a/src/components/home/rightpane/RightPane.tsx
+++ b/src/components/home/rightpane/RightPane.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 
 import { RootState } from '../../../redux/store';
 import HeroContainerRight from './HeroContainerRight';
-import { filterTabGroups } from '../../../utils/functions/local';
+import { selectVisibleTabGroups } from '../../../utils/functions/local';
 import TabGroupDetailsContainer from './TabGroupDetailsContainer';
 
 export default function RightPane() {
@@ -20,15 +20,16 @@ export default function RightPane() {
     (state: RootState) => state.globalState.searchInputText
   );
 
-  let filteredTabGroups = tabContainerDataList.tabGroups.filter(
-    (tabGroup) => tabGroup.isSelected
+  // the same list both children below read, so the guard here cannot disagree
+  // with what they find
+  const visibleTabGroups = selectVisibleTabGroups(
+    tabContainerDataList.tabGroups,
+    isSearchPanel,
+    searchInputText
   );
-  if (isSearchPanel && searchInputText) {
-    filteredTabGroups = filterTabGroups(searchInputText, filteredTabGroups);
-  }
 
   // to identify whether no tab groups are selected
-  const isNoneSelected = filteredTabGroups.length === 0;
+  const isNoneSelected = visibleTabGroups.length === 0;
 
   const containerStyle = css`
     display: flex;

--- a/src/components/home/rightpane/TabGroupDetailsContainer.tsx
+++ b/src/components/home/rightpane/TabGroupDetailsContainer.tsx
@@ -9,8 +9,8 @@ import WindowEntryContainer from './WindowEntryContainer';
 import { AppDispatch, RootState } from '../../../redux/store';
 import {
   resolveTabUrl,
-  filterTabGroups,
   isEmptyObject,
+  selectVisibleTabGroups,
 } from '../../../utils/functions/local';
 import {
   addCurrTabToWindow,
@@ -38,14 +38,19 @@ export default function TabGroupDetailsContainer() {
     (state: RootState) => state.globalState.searchInputText
   );
 
-  // filter the tab group list
-  let filteredTabGroups = tabContainerDataList.tabGroups.filter(
-    (tabGroup) => tabGroup.isSelected
-  );
-  if (isSearchPanel && searchInputText) {
-    filteredTabGroups = filterTabGroups(searchInputText, filteredTabGroups);
-  }
-  const selectedTabGroup = filteredTabGroups[0];
+  // the same list RightPane derives its mount guard from
+  const selectedTabGroup = selectVisibleTabGroups(
+    tabContainerDataList.tabGroups,
+    isSearchPanel,
+    searchInputText
+  )[0];
+
+  // Belt and braces: RightPane does not mount this component when the list is
+  // empty, so this should be unreachable -- but it is what makes the component
+  // safe on its own terms rather than safe because of its only caller (KAN-39).
+  // Must stay below every hook: an early return above one would change the hook
+  // count between renders and React would throw on the transition.
+  if (!selectedTabGroup) return null;
 
   const tabGroupId = selectedTabGroup.tabGroupId;
 

--- a/src/tests/components/HeroContainerRight.test.tsx
+++ b/src/tests/components/HeroContainerRight.test.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'vitest';
+import { screen } from '@testing-library/react';
+
+import HeroContainerRight from '../../components/home/rightpane/HeroContainerRight';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  openSearchPanel,
+  setSearchInputText,
+} from '../../redux/slices/globalStateSlice';
+import {
+  saveToTabContainerInternal,
+  selectTabContainer,
+} from '../../redux/slices/tabContainerDataStateSlice';
+
+// A factory rather than a shared constant: saveToTabContainerInternal's reducer
+// mutates what it is handed and Immer freezes it, so a session reused across
+// tests arrives at the second dispatch already frozen and throws.
+const buildSession = () => ({
+  tabGroupId: 'group-1',
+  title: 'Research',
+  createdTime: '2026-08-31 09:00:00',
+  windowCount: 1,
+  tabCount: 1,
+  isAutoSave: false,
+  isSelected: true,
+  windows: [
+    {
+      windowId: 'win-1',
+      windowHeight: 1080,
+      windowWidth: 1920,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 1,
+      title: 'Morning reading',
+      tabs: [
+        {
+          tabId: 't1',
+          favicon: '',
+          title: 'Kagi Search',
+          url: 'https://kagi.com/',
+        },
+      ],
+    },
+  ],
+});
+
+describe('HeroContainerRight', () => {
+  test('renders the selected session title', async () => {
+    await renderWithProviders(<HeroContainerRight />, {
+      seedStore: (store) => {
+        store.dispatch(saveToTabContainerInternal(buildSession()));
+        store.dispatch(selectTabContainer('group-1'));
+      },
+    });
+
+    expect(await screen.findByText('Research')).toBeTruthy();
+  });
+
+  // KAN-16. Unreachable through the app -- RightPane will not mount this
+  // component with nothing selected -- so the assertion is about the component
+  // standing on its own terms, not about a crash a user can currently reach.
+  test('renders nothing when no session is selected', async () => {
+    const { container } = await renderWithProviders(<HeroContainerRight />);
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  // The second way the list empties: a session IS selected, but the search
+  // filters it away. This is the path that would go live the day the parent's
+  // guard and this component's read stop agreeing.
+  test('renders nothing when the search filters the selected session away', async () => {
+    const { container } = await renderWithProviders(<HeroContainerRight />, {
+      seedStore: (store) => {
+        store.dispatch(saveToTabContainerInternal(buildSession()));
+        store.dispatch(selectTabContainer('group-1'));
+        store.dispatch(openSearchPanel());
+        store.dispatch(setSearchInputText('nothing matches this'));
+      },
+    });
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  // The guard has to sit below every hook. Returning null above the useEffect
+  // that seeds the editable title would change the hook count between these
+  // two renders, and React throws "Rendered more hooks than during the previous
+  // render" on the second one.
+  test('mounts the session when the store goes from nothing selected to selected', async () => {
+    const { store } = await renderWithProviders(<HeroContainerRight />);
+
+    store.dispatch(saveToTabContainerInternal(buildSession()));
+    store.dispatch(selectTabContainer('group-1'));
+
+    expect(await screen.findByText('Research')).toBeTruthy();
+  });
+});

--- a/src/tests/components/RightPane.test.tsx
+++ b/src/tests/components/RightPane.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'vitest';
+import { screen } from '@testing-library/react';
+
+import RightPane from '../../components/home/rightpane/RightPane';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  openSearchPanel,
+  setSearchInputText,
+} from '../../redux/slices/globalStateSlice';
+import {
+  saveToTabContainerInternal,
+  selectTabContainer,
+} from '../../redux/slices/tabContainerDataStateSlice';
+
+const buildSession = () => ({
+  tabGroupId: 'group-1',
+  title: 'Research',
+  createdTime: '2026-08-31 09:00:00',
+  windowCount: 1,
+  tabCount: 1,
+  isAutoSave: false,
+  isSelected: true,
+  windows: [
+    {
+      windowId: 'win-1',
+      windowHeight: 1080,
+      windowWidth: 1920,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 1,
+      title: 'Morning reading',
+      tabs: [
+        {
+          tabId: 't1',
+          favicon: '',
+          title: 'Kagi Search',
+          url: 'https://kagi.com/',
+        },
+      ],
+    },
+  ],
+});
+
+// RightPane decides whether its two children mount, and both children then read
+// element [0] of a list they derive themselves. These tests pin the agreement
+// between that decision and those reads: whenever the pane renders, the children
+// must find a session, and whenever it renders nothing, neither child mounted.
+describe('RightPane', () => {
+  test('renders both children when a session is selected', async () => {
+    await renderWithProviders(<RightPane />, {
+      seedStore: (store) => {
+        store.dispatch(saveToTabContainerInternal(buildSession()));
+        store.dispatch(selectTabContainer('group-1'));
+      },
+    });
+
+    // the session title comes from HeroContainerRight, the window title from
+    // TabGroupDetailsContainer -- one assertion each, so a child that failed to
+    // mount cannot hide behind its sibling
+    expect(await screen.findByText('Research')).toBeTruthy();
+    expect(screen.getByText('Morning reading')).toBeTruthy();
+  });
+
+  test('renders nothing when the store is empty', async () => {
+    const { container } = await renderWithProviders(<RightPane />);
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  // The state the empty store cannot express: sessions exist, but none of them
+  // is the selected one. selectTabContainer deselects every other group, so
+  // pointing it at an id no session has leaves them all unselected -- which is
+  // where the pane lands after the selected session is deleted.
+  test('renders nothing when sessions exist but none is selected', async () => {
+    const { container } = await renderWithProviders(<RightPane />, {
+      seedStore: (store) => {
+        store.dispatch(saveToTabContainerInternal(buildSession()));
+        store.dispatch(selectTabContainer('no-such-group'));
+      },
+    });
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  // The pane's guard checks the selected list AFTER the search filter, so a
+  // search matching nothing must keep the children unmounted. If the guard ever
+  // stopped applying the filter its children would mount against an empty list.
+  test('renders nothing when the search filters the selected session away', async () => {
+    const { container } = await renderWithProviders(<RightPane />, {
+      seedStore: (store) => {
+        store.dispatch(saveToTabContainerInternal(buildSession()));
+        store.dispatch(selectTabContainer('group-1'));
+        store.dispatch(openSearchPanel());
+        store.dispatch(setSearchInputText('nothing matches this'));
+      },
+    });
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  test('renders the session again when the search matches it', async () => {
+    await renderWithProviders(<RightPane />, {
+      seedStore: (store) => {
+        store.dispatch(saveToTabContainerInternal(buildSession()));
+        store.dispatch(selectTabContainer('group-1'));
+        store.dispatch(openSearchPanel());
+        store.dispatch(setSearchInputText('kagi'));
+      },
+    });
+
+    expect(await screen.findByText('Research')).toBeTruthy();
+  });
+});

--- a/src/tests/components/TabGroupDetailsContainer.test.tsx
+++ b/src/tests/components/TabGroupDetailsContainer.test.tsx
@@ -5,6 +5,10 @@ import userEvent from '@testing-library/user-event';
 import TabGroupDetailsContainer from '../../components/home/rightpane/TabGroupDetailsContainer';
 import { renderWithProviders } from '../setup/renderWithProviders';
 import {
+  openSearchPanel,
+  setSearchInputText,
+} from '../../redux/slices/globalStateSlice';
+import {
   saveToTabContainerInternal,
   selectTabContainer,
 } from '../../redux/slices/tabContainerDataStateSlice';
@@ -76,5 +80,35 @@ describe('TabGroupDetailsContainer', () => {
     expect(chrome.createdTabs.map((tab) => tab.url)).toContain(
       'https://kagi.com/'
     );
+  });
+
+  // KAN-39, the sibling of KAN-16 in the component rendered beside it. Not
+  // reachable through the app: RightPane will not mount this component with
+  // nothing selected. Rendering it in isolation is what proves it is safe on
+  // its own terms.
+  test('renders nothing when no session is selected', async () => {
+    const { container } = await renderWithProviders(
+      <TabGroupDetailsContainer />
+    );
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  // The other way the list empties: a session is selected but the search
+  // filters it away.
+  test('renders nothing when the search filters the selected session away', async () => {
+    const { container } = await renderWithProviders(
+      <TabGroupDetailsContainer />,
+      {
+        seedStore: (store) => {
+          store.dispatch(saveToTabContainerInternal(buildSession()));
+          store.dispatch(selectTabContainer('group-1'));
+          store.dispatch(openSearchPanel());
+          store.dispatch(setSearchInputText('nothing matches this'));
+        },
+      }
+    );
+
+    expect(container.innerHTML).toBe('');
   });
 });

--- a/src/tests/utils/functions/visibleTabGroups.test.ts
+++ b/src/tests/utils/functions/visibleTabGroups.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'vitest';
+
+import { selectVisibleTabGroups } from '../../../utils/functions/local';
+import { tabContainerData } from '../../../redux/slices/tabContainerDataStateSlice';
+
+const session = (
+  title: string,
+  isSelected: boolean,
+  tabTitle = 'Kagi Search'
+): tabContainerData => ({
+  tabGroupId: `id-${title}`,
+  title,
+  createdTime: '2026-08-31 09:00:00',
+  windowCount: 1,
+  tabCount: 1,
+  isAutoSave: false,
+  isSelected,
+  windows: [
+    {
+      windowId: `win-${title}`,
+      windowHeight: 1080,
+      windowWidth: 1920,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 1,
+      title: 'A window',
+      tabs: [
+        {
+          tabId: `tab-${title}`,
+          favicon: '',
+          title: tabTitle,
+          url: 'https://example.com/',
+        },
+      ],
+    },
+  ],
+});
+
+// This is the predicate the whole right pane agrees on: RightPane derives its
+// mount guard from the length of this list, and both of its children read
+// element [0] of it. The tests below are the contract those three share.
+describe('selectVisibleTabGroups', () => {
+  test('keeps only the selected sessions', () => {
+    const visible = selectVisibleTabGroups(
+      [session('Research', true), session('Errands', false)],
+      false,
+      ''
+    );
+
+    expect(visible.map((group) => group.title)).toEqual(['Research']);
+  });
+
+  test('narrows the selected session by the search text', () => {
+    const visible = selectVisibleTabGroups(
+      [session('Research', true, 'Kagi Search')],
+      true,
+      'kagi'
+    );
+
+    expect(visible.map((group) => group.title)).toEqual(['Research']);
+  });
+
+  test('ignores the search text while the search panel is closed', () => {
+    const visible = selectVisibleTabGroups(
+      [session('Research', true, 'Kagi Search')],
+      false,
+      'nothing matches this'
+    );
+
+    expect(visible.map((group) => group.title)).toEqual(['Research']);
+  });
+
+  // The state that makes [0] undefined for every caller. RightPane must read
+  // an empty list here too, or it would mount children that cannot render.
+  test('returns an empty list when the search matches no selected session', () => {
+    const visible = selectVisibleTabGroups(
+      [session('Research', true, 'Kagi Search')],
+      true,
+      'nothing matches this'
+    );
+
+    expect(visible).toEqual([]);
+  });
+
+  test('returns an empty list when nothing is selected at all', () => {
+    expect(
+      selectVisibleTabGroups([session('Research', false)], false, '')
+    ).toEqual([]);
+  });
+
+  test('does not mutate the list it is given', () => {
+    const groups = [session('Research', true), session('Errands', false)];
+
+    selectVisibleTabGroups(groups, true, 'kagi');
+
+    expect(groups.map((group) => group.title)).toEqual(['Research', 'Errands']);
+  });
+});

--- a/src/utils/functions/local.ts
+++ b/src/utils/functions/local.ts
@@ -150,6 +150,34 @@ export const filterTabGroups = (
   }, []);
 };
 
+// The sessions the right pane shows: the selected one, narrowed by the search
+// box while the search panel is open.
+//
+// This lives in one place because three components depend on it agreeing with
+// itself. RightPane derives its mount guard from the length of this list, and
+// both of the children it mounts read element [0] of it. While each of them
+// built the list itself, that agreement held only by coincidence of three
+// copies of the predicate matching -- and the day one copy changed (a pinned
+// sessions rule, a change to search behaviour) the parent would have mounted
+// children against an empty list and [0] would have been undefined. KAN-16 and
+// KAN-39 are that crash, found before it went live.
+//
+// It takes the state it needs rather than RootState so it stays pure and
+// node-testable, and so callers keep their existing useSelector subscriptions:
+// passing this to useSelector directly would return a new array on every store
+// update and re-render all three components on every unrelated action.
+export const selectVisibleTabGroups = (
+  tabGroups: tabContainerData[],
+  isSearchPanel: boolean,
+  searchInputText: string
+): tabContainerData[] => {
+  const selectedTabGroups = tabGroups.filter((tabGroup) => tabGroup.isSelected);
+
+  return isSearchPanel && searchInputText
+    ? filterTabGroups(searchInputText, selectedTabGroups)
+    : selectedTabGroups;
+};
+
 // save data to local storage
 export const saveToLocalStorage = (key: string, data: any): void => {
   try {


### PR DESCRIPTION
Closes KAN-16 and KAN-39.

## The defect

The "selected + search" predicate was copy-pasted into three components:

```ts
let filteredTabGroups = tabContainerDataList.tabGroups.filter((g) => g.isSelected);
if (isSearchPanel && searchInputText)
  filteredTabGroups = filterTabGroups(searchInputText, filteredTabGroups);
```

`RightPane` derived its mount guard from its copy. Both children it mounts — `HeroContainerRight` and `TabGroupDetailsContainer` — read `[0]` of theirs and immediately dereference it. That the guard protected those reads was a coincidence of three copies agreeing, enforced by nothing. Edit one and not the others — a pinned-sessions rule, a change to search behaviour — and the parent mounts children against an empty list. `ErrorBoundary` is at the root (`main.tsx:17`), so the whole popup blanks, not just the right pane.

**Zero user impact today.** `RightPane` is the sole render site for both children and will not mount them when the list is empty. This removes a latent trap; it does not fix a live bug.

## The fix

One pure `selectVisibleTabGroups()` in `local.ts`, called by all three. The early returns both tickets asked for are still here, but they are no longer the fix — they are what makes each child safe on its own terms rather than safe because of its only caller.

`TabGroupEntryContainer` looks like a fourth site and is untouched: it deliberately omits the `isSelected` pre-filter.

Two design notes:

- **It takes plain arguments, not `RootState`.** Passing it to `useSelector` would return a new array on every store update; `useSelector` compares by reference, so all three components would re-render on every unrelated action.
- **The guard sits below every hook.** In `HeroContainerRight` the natural spot is above the `useEffect` that seeds the editable title. Returning `null` there changes the hook count between the nothing-selected and selected renders, and React throws *"Rendered more hooks than during the previous render"*.

One correction to KAN-16's description: `HeroContainerRight` throws at the **destructure on line 91**, not the `useEffect` on line 71. Effects run after render commits, so render dies first.

## Evidence

**Red first.** 11 tests failed before the production change, with the TypeErrors both tickets describe:

```
TypeError: Cannot read properties of undefined (reading 'tabGroupId')
 ❯ TabGroupDetailsContainer .../TabGroupDetailsContainer.tsx:50:39
TypeError: Cannot destructure property 'tabGroupId' of 'selectedTabGroup' as it is undefined.
 ❯ HeroContainerRight ...
TypeError: selectVisibleTabGroups is not a function   (× 6, unit)
```

**Green.** `280 passed (280)` — up from 263. `tsc --noEmit` 0 errors, prettier clean.

**Three mutations, each caught:**

| Mutation | Caught by |
|---|---|
| Guard moved above the `useEffect` | `HeroContainerRight > mounts the session when the store goes from nothing selected to selected` → `Rendered more hooks than during the previous render`. The other three tests still passed, so that one test is all that stands between us and this regression. |
| Selector drops the search filter | 4 tests, incl. the `RightPane` parent-agreement test |
| Selector drops `isSelected` | 3 tests, incl. `RightPane > renders nothing when sessions exist but none is selected`, added specifically to close this gap at component level |

**E2E** against the built-and-stripped artifact loaded in Chrome:

- right pane renders both children (session title, window, tabs)
- search matching nothing → pane unmounts cleanly, no crash, no blank popup
- matching search → pane returns, narrowed to `1 Window - 1 Tab`
- rename input still seeded with the current title, so the null-guarded effect still runs
- console clean apart from the pre-existing `preload` warnings from the KAN-36 code-split

🤖 Generated with [Claude Code](https://claude.com/claude-code)
