### PR TITLE
Key the four mapped lists by stable id so rows keep their identity (KAN-28)

### DIFF
--- a/src/components/home/leftpane/TabGroupEntryContainer.tsx
+++ b/src/components/home/leftpane/TabGroupEntryContainer.tsx
@@ -82,7 +82,9 @@ export default function TabGroupEntryContainer() {
         <div css={filledContainerStyle}>
           {filteredTabGroups.map((tabGroupData, index) => {
             return (
-              <div>
+              // tabGroupId, not index: this list is filtered by search and
+              // reordered by save, so positions are not stable identities.
+              <div key={tabGroupData.tabGroupId}>
                 <TabGroupEntry
                   tabGroupData={tabGroupData}
                   onTabGroupClick={() => {

--- a/src/components/home/rightpane/TabGroupDetailsContainer.tsx
+++ b/src/components/home/rightpane/TabGroupDetailsContainer.tsx
@@ -108,7 +108,11 @@ export default function TabGroupDetailsContainer() {
         <div css={filledContainerStyle}>
           {selectedTabGroup.windows.map(({ windowId, title, tabs }) => {
             return (
-              <div>
+              // Keyed by windowId, not by index: WindowEntryContainer owns
+              // collapse and rename state, and an index key is identical to
+              // the positional default React already uses, so it would leave
+              // that state bleeding onto the wrong window after a deletion.
+              <div key={windowId}>
                 <WindowEntryContainer
                   title={title}
                   tabs={tabs}

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -331,7 +331,11 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
         <div css={childrenContainerStyle}>
           {tabs.map(({ tabId, favicon, title, url }, index) => {
             return (
+              // `index` below is hover bookkeeping against hoveredChildIndex,
+              // which is this component's own state -- it is not an identity
+              // for the row and must not be used as the key.
               <div
+                key={tabId}
                 css={childrenStyle}
                 onMouseEnter={() => setHoveredChildIndex(index)}
                 onMouseLeave={() => setHoveredChildIndex(null)}

--- a/src/components/settings/leftpane/SettingsCategoryContainer.tsx
+++ b/src/components/settings/leftpane/SettingsCategoryContainer.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react';
+
 import { useDispatch, useSelector } from 'react-redux';
 
 import { css } from '@emotion/react';
@@ -67,7 +69,11 @@ const SettingsCategoryContainer: React.FC = () => {
       {settingsCategoryList.map(
         ({ name, isSelected }: SettingsCategoryContainer) => {
           return (
-            <>
+            // A named Fragment, not <>: the shorthand cannot take a key, and
+            // this row is a div plus its Divider, so there is no single
+            // element to hang the key on. `name` is the SettingsCategory enum
+            // value, unique across the list by construction.
+            <Fragment key={name}>
               <div
                 css={selectableStyle(isSelected)}
                 onClick={() => handleSelectCategoryClick(name)}
@@ -81,7 +87,7 @@ const SettingsCategoryContainer: React.FC = () => {
                 />
               </div>
               <Divider />
-            </>
+            </Fragment>
           );
         }
       )}

--- a/src/tests/components/listKeys.test.tsx
+++ b/src/tests/components/listKeys.test.tsx
@@ -1,0 +1,201 @@
+import { describe, expect, test, vi } from 'vitest';
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import TabGroupDetailsContainer from '../../components/home/rightpane/TabGroupDetailsContainer';
+import TabGroupEntryContainer from '../../components/home/leftpane/TabGroupEntryContainer';
+import SettingsCategoryContainer from '../../components/settings/leftpane/SettingsCategoryContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  deleteTabContainerInternal,
+  deleteTabInternal,
+  deleteWindowInternal,
+  saveToTabContainerInternal,
+  selectTabContainer,
+} from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-28. These lists were rendered without `key`, so React fell back to
+// matching children by position. Every assertion below is about identity
+// surviving a deletion higher up the list -- deliberately NOT about React's
+// "unique key" console warning, which is satisfied just as well by a key={index}
+// that leaves the underlying bug completely intact.
+//
+// The mutation test for this file: swap any stable id below for the array
+// index. An index key IS the positional default, so all three tests must go
+// red again. If they stay green they are not testing identity.
+
+const buildWindow = (n: number, tabTitles: string[]) => ({
+  windowId: `win-${n}`,
+  windowHeight: 1080,
+  windowWidth: 1920,
+  windowOffsetTop: 0,
+  windowOffsetLeft: 0,
+  tabCount: tabTitles.length,
+  title: `Window ${n}`,
+  tabs: tabTitles.map((title, i) => ({
+    tabId: `w${n}-t${i}`,
+    favicon: '',
+    title,
+    url: `https://example.com/w${n}/t${i}`,
+  })),
+});
+
+// A factory rather than a shared constant, for the same reason as
+// TabGroupDetailsContainer.test.tsx: saveToTabContainerInternal mutates its
+// payload and Immer freezes it, so a reused object throws on the second
+// dispatch.
+const buildGroup = (n: number, windows: ReturnType<typeof buildWindow>[]) => ({
+  tabGroupId: `group-${n}`,
+  title: `Group ${n}`,
+  createdTime: `2026-09-01 09:0${n}:00`,
+  windowCount: windows.length,
+  tabCount: windows.reduce((sum, w) => sum + w.tabs.length, 0),
+  isAutoSave: false,
+  isSelected: false,
+  windows,
+});
+
+describe('list identity across deletions (KAN-28)', () => {
+  // The strongest of the three: collapse is local component state, so if the
+  // wrong instance survives a deletion the user watches a window they never
+  // touched fold itself shut.
+  test('a collapsed window stays collapsed when the window above it is deleted', async () => {
+    const { store } = await renderWithProviders(<TabGroupDetailsContainer />, {
+      seedStore: (s) => {
+        s.dispatch(
+          saveToTabContainerInternal(
+            buildGroup(1, [
+              buildWindow(1, ['Alpha Page']),
+              buildWindow(2, ['Bravo Page']),
+              buildWindow(3, ['Charlie Page']),
+            ])
+          )
+        );
+        s.dispatch(selectTabContainer('group-1'));
+      },
+    });
+
+    // All three start expanded, so every accordion icon reads "collapse".
+    const accordions = await screen.findAllByLabelText('collapse');
+    expect(accordions).toHaveLength(3);
+
+    // Collapse the middle window only.
+    await userEvent.click(accordions[1]);
+    expect(screen.queryByText('Bravo Page')).toBeNull();
+    expect(screen.getByText('Charlie Page')).toBeTruthy();
+
+    // Delete the window ABOVE the collapsed one. Window 2 slides into slot 0.
+    act(() => {
+      store.dispatch(
+        deleteWindowInternal({ tabGroupId: 'group-1', windowId: 'win-1' })
+      );
+    });
+
+    expect(screen.queryByText('Alpha Page')).toBeNull();
+    // Positional matching hands slot 0's expanded state to window 2, so
+    // unkeyed this row springs back open and Bravo Page reappears.
+    expect(screen.queryByText('Bravo Page')).toBeNull();
+    // ...and window 3 inherits slot 1's collapsed state, hiding a window the
+    // user never collapsed.
+    expect(screen.getByText('Charlie Page')).toBeTruthy();
+  });
+
+  // Tab rows carry no local state, so nothing bleeds -- but the DOM node is
+  // still recycled onto a different tab, which is the same defect one layer
+  // down (it costs focus, in-flight CSS transitions, and any state a future
+  // row gains).
+  test('a tab row keeps its DOM node when the tab above it is deleted', async () => {
+    const { store } = await renderWithProviders(<TabGroupDetailsContainer />, {
+      seedStore: (s) => {
+        s.dispatch(
+          saveToTabContainerInternal(
+            buildGroup(1, [
+              buildWindow(1, ['Alpha Page', 'Bravo Page', 'Charlie Page']),
+            ])
+          )
+        );
+        s.dispatch(selectTabContainer('group-1'));
+      },
+    });
+
+    const bravoNodeBefore = await screen.findByText('Bravo Page');
+
+    act(() => {
+      store.dispatch(
+        deleteTabInternal({
+          tabGroupId: 'group-1',
+          windowId: 'win-1',
+          tabId: 'w1-t0',
+        })
+      );
+    });
+
+    // Unkeyed, React rewrites slot 0's existing node to say "Bravo Page"
+    // instead of moving Bravo's own node up, so this is a different element.
+    expect(screen.getByText('Bravo Page')).toBe(bravoNodeBefore);
+  });
+
+  test('a tab group row keeps its DOM node when the group above it is deleted', async () => {
+    const { store } = await renderWithProviders(<TabGroupEntryContainer />, {
+      seedStore: (s) => {
+        s.dispatch(
+          saveToTabContainerInternal(buildGroup(1, [buildWindow(1, ['A'])]))
+        );
+        s.dispatch(
+          saveToTabContainerInternal(buildGroup(2, [buildWindow(2, ['B'])]))
+        );
+        s.dispatch(
+          saveToTabContainerInternal(buildGroup(3, [buildWindow(3, ['C'])]))
+        );
+        // Select the group we are NOT deleting, so the deletion cannot change
+        // selection and re-render the list for an unrelated reason.
+        s.dispatch(selectTabContainer('group-2'));
+      },
+    });
+
+    const groupTwoNodeBefore = await screen.findByText('Group 2');
+
+    // saveToTabContainerInternal unshifts, so the rendered order is
+    // [Group 3, Group 2, Group 1]. Group 3 is the row ABOVE Group 2 -- delete
+    // the tail (Group 1) instead and positional matching gets the right answer
+    // by accident, which is how the first draft of this test passed unkeyed.
+    act(() => {
+      store.dispatch(deleteTabContainerInternal('group-3'));
+    });
+
+    expect(screen.queryByText('Group 3')).toBeNull();
+    expect(screen.getByText('Group 2')).toBe(groupTwoNodeBefore);
+  });
+
+  // Deliberately weaker than the three above, and the comment says so rather
+  // than the test pretending otherwise.
+  //
+  // The settings category list cannot lose identity: it is five fixed enum
+  // members, and the only exported action on that slice is selectCategory,
+  // which flips isSelected in place. The slice does define a replaceState
+  // reducer, but it is not in the slice's export list, so nothing can dispatch
+  // it -- there is no reachable path that adds, removes, or reorders a
+  // category. A deletion test here would be theatre against a scenario the app
+  // cannot produce.
+  //
+  // So the warning IS the whole observable defect for this one, and asserting
+  // on it is honest here for the same reason it would be dishonest above.
+  test('the settings category list renders keyed', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    try {
+      await renderWithProviders(<SettingsCategoryContainer />);
+
+      expect(await screen.findByText('Display')).toBeTruthy();
+
+      const keyWarnings = consoleError.mock.calls.filter((args) =>
+        String(args[0]).includes('unique "key" prop')
+      );
+      expect(keyWarnings).toEqual([]);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
Closes KAN-28.

## What was wrong

All four `.map()` renders were unkeyed, so React matched children by position instead of identity.

Three of the four are hygiene. The fourth is a real user-visible bug: `WindowEntryContainer` owns `windowOpenState`, `isEditing`, `newTitle` and `isParentHovered`, so when `TabGroupDetailsContainer` renders those windows unkeyed, that local state stays with the *slot* rather than the window.

**The common trigger is adding a window, not deleting one.** `addCurrWindowToTabGroupInternal` does `windows.unshift(window)` — it prepends, so every existing window shifts down a slot and the whole list's state is displaced by one. (`addCurrTabToWindowInternal` prepends tabs the same way.)

## Evidence from the built extension

Loaded `dist` unpacked, seeded a three-window session, collapsed **window 2**, then clicked **add current window**. Same steps, two builds:

| build | accordion labels after | what the user sees |
|---|---|---|
| unkeyed (control) | `["collapse","expand","collapse","collapse"]` | **window 1** folds shut, window 2 pops open |
| keyed (this PR) | `["collapse","collapse","expand","collapse"]` | window 2 stays collapsed, window 1 untouched |

The deletion path was verified the same way (collapse window 2, delete window 1):

| build | accordion labels after | visible tab |
|---|---|---|
| unkeyed (control) | `["collapse", "expand"]` | `Window 2 Tab 0` |
| keyed (this PR) | `["expand", "collapse"]` | `Window 3 Tab 0` |

Bundle rebuilt and re-verified byte-identical (`index-BQVNW8Up.js`) after restoring the fix each time.

Settings pane re-checked in the same build: all five categories render and clicking *Language* still switches the right pane. Console clean of key warnings (only two pre-existing preload warnings remain).

## Scope of the impact

No data risk. Every callback (`onDeleteClick`, `onUpdateWindowGroupTitle`) is rebuilt in the map with the correct `windowId` and passed as a prop, and props always re-render correctly — only `useState` values persist onto the wrong instance. The delete button never acted on the wrong window; no stored session data was ever wrong. This is purely which window *looks* collapsed or is showing a rename box.

Per site:

| Site | User-visible change |
|---|---|
| `TabGroupDetailsContainer` (windows) | Real — collapse/rename state stops jumping to the wrong window |
| `TabGroupEntryContainer` (sessions) | Minor — `TabGroupEntry` only holds `isHovered`; action buttons could briefly appear on the wrong row |
| `WindowEntryContainer` (tabs) | Near zero — tab rows are stateless, so nothing bleeds |
| `SettingsCategoryContainer` | None — static list; removes console warnings only |

Search is plausibly another trigger, since `filterTabGroups` filters windows within a group. Not verified: `TabGroupEntryContainer` re-selects `filteredTabGroups[0]` on search change, and a changed `tabGroupId` resets `windowOpenState` via the effect at `WindowEntryContainer.tsx:67`, so it may mask itself.

## The fix

| File | Key |
|---|---|
| `TabGroupEntryContainer.tsx:87` | `key={tabGroupData.tabGroupId}` |
| `TabGroupDetailsContainer.tsx:115` | `key={windowId}` |
| `WindowEntryContainer.tsx:338` | `key={tabId}` |
| `SettingsCategoryContainer.tsx:76` | `<Fragment key={name}>` |

`SettingsCategoryContainer` needed a different shape: the row is a `<div>` plus its `<Divider />`, so there is no single element to key, and the `<>` shorthand cannot take one. `name` is the `SettingsCategory` enum value, unique by construction.

**No index keys.** An index key is precisely the positional default React already applies, so it silences the warning and changes nothing. `WindowEntryContainer` still destructures `index`, but that feeds `hoveredChildIndex` — hover bookkeeping, not an identity.

## Tests

Four new tests in `src/tests/components/listKeys.test.tsx`. Three assert identity, not the absence of a console warning:

- a collapsed window stays collapsed when the window above it is deleted (local component state)
- a tab row keeps its DOM node when the tab above it is deleted
- a tab group row keeps its DOM node when the group above it is deleted

**Mutation-tested:** swapping each stable id for `key={index}` turns all three red.

First draft of the tab-group test passed against the broken code — `saveToTabContainerInternal` unshifts, so deleting `group-1` removed the *last* row, which positional matching handles correctly. It now deletes the row genuinely above, and the comment records the trap.

The fourth test is deliberately weaker and says so: the settings list is five fixed enum members and `replaceState` is not exported from that slice, so nothing can add, remove or reorder a category. The warning is the entire observable defect there, so asserting on it is honest — a deletion test would be theatre against a scenario the app cannot produce.

284/284 tests pass (280 + 4), `tsc` clean, no new lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)