### PR TITLE
Refuse an imported backup that would not fit in a Firestore document (KAN-27)

### DIFF
--- a/src/components/settings/rightpane/SettingsDetailsContainer.tsx
+++ b/src/components/settings/rightpane/SettingsDetailsContainer.tsx
@@ -39,7 +39,7 @@ import {
   TabMasterContainer,
   restoreContainer,
 } from '../../../redux/slices/tabContainerDataStateSlice';
-import { isValidTabMasterContainer } from '../../../utils/functions/local';
+import { readImportedContainer } from '../../../utils/functions/local';
 import { SettingsCategory } from '../../../redux/slices/settingsCategoryStateSlice';
 import LoggedIn from './Account/LoggedIn';
 import NotLoggedIn from './Account/NotLoggedIn';
@@ -128,11 +128,11 @@ const SettingsDetailsContainer: React.FC = () => {
       reader.onload = (fileEvent) => {
         try {
           const content = fileEvent.target!.result as string;
-          const tabDataFromJSON: TabMasterContainer = JSON.parse(content);
-          // validate read JSON
-          if (!isValidTabMasterContainer(tabDataFromJSON)) {
-            throw new Error('Invalid JSON structure.');
-          }
+          // Parses, validates the structure, and refuses anything that would
+          // not fit in a Firestore document (KAN-27). Throws on every one of
+          // those, which the catch below turns into the error toast.
+          const tabDataFromJSON: TabMasterContainer =
+            readImportedContainer(content);
 
           // update timestamp
           tabDataFromJSON.lastModified = Date.now();

--- a/src/tests/components/importGuard.test.tsx
+++ b/src/tests/components/importGuard.test.tsx
@@ -1,0 +1,157 @@
+import { describe, expect, test, vi, afterEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import SettingsDetailsContainer from '../../components/settings/rightpane/SettingsDetailsContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  SettingsCategory,
+  selectCategory,
+} from '../../redux/slices/settingsCategoryStateSlice';
+import { TabMasterContainer } from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-27, the wiring half. local.test.ts proves readImportedContainer refuses an
+// oversized backup; these prove the import handler actually calls it, and that a
+// refusal leaves the store untouched rather than half-applied.
+//
+// Driving the real handler means intercepting the <input type="file"> it builds
+// on the fly: it is created, wired and clicked inside handleImportJSON and never
+// rendered, so there is nothing in the tree to select. Spying on createElement
+// is the only seam that does not require changing production code to be testable.
+const captureFileInput = () => {
+  const inputs: HTMLInputElement[] = [];
+  const real = document.createElement.bind(document);
+
+  vi.spyOn(document, 'createElement').mockImplementation(((
+    tagName: string,
+    options?: ElementCreationOptions
+  ) => {
+    const el = real(tagName, options);
+    if (tagName === 'input') {
+      // click() on a real file input would try to open the OS picker; the
+      // handler only calls it to prompt, so a no-op keeps jsdom quiet.
+      (el as HTMLInputElement).click = () => {};
+      inputs.push(el as HTMLInputElement);
+    }
+    return el;
+  }) as typeof document.createElement);
+
+  return inputs;
+};
+
+const dropFile = (input: HTMLInputElement, text: string) => {
+  const file = new File([text], 'backup.json', { type: 'application/json' });
+  // The handler reads `(event.target as HTMLInputElement).files![0]`, so the
+  // event only has to carry that much shape.
+  input.onchange?.({ target: { files: [file] } } as unknown as Event);
+};
+
+const renderDataManagement = () =>
+  renderWithProviders(<SettingsDetailsContainer />, {
+    seedStore: (store) => {
+      store.dispatch(selectCategory(SettingsCategory.DATA_MANAGEMENT));
+    },
+  });
+
+const buildOversizedBackup = (): string => {
+  const container: TabMasterContainer = {
+    lastModified: 1,
+    selectedTabGroupId: null,
+    tabGroups: [
+      {
+        tabGroupId: 'group-0',
+        // A title, not a favicon: favicons are stripped before measuring, so
+        // padding one would prove nothing about the guard.
+        title: 'x'.repeat(1_200_000),
+        createdTime: '2026-09-01 12:00:00',
+        windowCount: 0,
+        tabCount: 0,
+        isAutoSave: false,
+        isSelected: false,
+        windows: [],
+      },
+    ],
+  };
+  return JSON.stringify(container);
+};
+
+const buildSmallBackup = (): string =>
+  JSON.stringify({
+    lastModified: 1,
+    selectedTabGroupId: 'group-0',
+    tabGroups: [
+      {
+        tabGroupId: 'group-0',
+        title: 'Imported session',
+        createdTime: '2026-09-01 12:00:00',
+        windowCount: 1,
+        tabCount: 1,
+        isAutoSave: false,
+        isSelected: true,
+        windows: [
+          {
+            windowId: 'window-0',
+            windowHeight: 600,
+            windowWidth: 800,
+            windowOffsetTop: 0,
+            windowOffsetLeft: 0,
+            tabCount: 1,
+            title: 'Imported window',
+            tabs: [
+              {
+                tabId: 'tab-0',
+                favicon: '',
+                title: 'Imported tab',
+                url: 'https://example.com/',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  } satisfies TabMasterContainer);
+
+describe('import size guard (KAN-27)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('refuses an oversized backup and leaves the store untouched', async () => {
+    const inputs = captureFileInput();
+    const { store } = await renderDataManagement();
+
+    await userEvent.click(
+      await screen.findByText('Restore App Data from File')
+    );
+    dropFile(inputs[0], buildOversizedBackup());
+
+    await waitFor(() => {
+      expect(store.getState().globalState.toastText).toMatch(
+        /too large to sync/i
+      );
+    });
+
+    // The half-applied state this guard exists to prevent: restoreContainer
+    // writes localStorage synchronously, so a container that got that far would
+    // be persisted and would then wedge sync permanently.
+    expect(store.getState().tabContainerDataState.tabGroups).toHaveLength(0);
+    expect(store.getState().globalState.isDirty).toBe(false);
+  });
+
+  // The control. Without this, a guard that rejected every import would pass
+  // the test above.
+  test('still imports a backup that fits', async () => {
+    const inputs = captureFileInput();
+    const { store } = await renderDataManagement();
+
+    await userEvent.click(
+      await screen.findByText('Restore App Data from File')
+    );
+    dropFile(inputs[0], buildSmallBackup());
+
+    await waitFor(() => {
+      expect(store.getState().tabContainerDataState.tabGroups).toHaveLength(1);
+    });
+    expect(store.getState().globalState.toastText).toMatch(/successfully/i);
+  });
+});

--- a/src/tests/utils/functions/local.test.ts
+++ b/src/tests/utils/functions/local.test.ts
@@ -23,6 +23,8 @@ import {
   stripEmbeddedFavicons,
   resolveFaviconUrl,
   FIRESTORE_MAX_DOCUMENT_BYTES,
+  estimateFirestoreBytes,
+  readImportedContainer,
 } from '../../../utils/functions/local';
 import { TabMasterContainer } from '../../../redux/slices/tabContainerDataStateSlice';
 
@@ -1184,5 +1186,167 @@ describe('placeholderTarget', () => {
       null
     );
     expect(placeholderTarget('data:text/html;base64,')).toBeNull();
+  });
+});
+
+// KAN-27. The import dialog accepts any file the user picks, and Firestore
+// rejects a document over 1 MiB outright. Before this guard an oversized import
+// was persisted to localStorage, the toast said "Restored tabs successfully!",
+// and the write then failed -- leaving isDirty set against a document that can
+// never be written, so every later change failed to sync too.
+describe('estimateFirestoreBytes', () => {
+  const buildContainer = (
+    tabsPerWindow: number,
+    favicon: string,
+    title = (i: number) => `Repository ${i}`
+  ): TabMasterContainer => ({
+    lastModified: 1785312544441,
+    selectedTabGroupId: 'group-0',
+    tabGroups: [
+      {
+        tabGroupId: 'group-0',
+        title: 'Extensions',
+        createdTime: '2026-07-27 04:08:12',
+        windowCount: 1,
+        tabCount: tabsPerWindow,
+        isAutoSave: false,
+        isSelected: true,
+        windows: [
+          {
+            windowId: 'window-0',
+            windowHeight: 550,
+            windowWidth: 790,
+            windowOffsetTop: 0,
+            windowOffsetLeft: 0,
+            tabCount: tabsPerWindow,
+            title: 'first tab title',
+            tabs: Array.from({ length: tabsPerWindow }, (_, i) => ({
+              tabId: `tab-${i}`,
+              favicon,
+              title: title(i),
+              url: `https://github.com/user/repo-${i}`,
+            })),
+          },
+        ],
+      },
+    ],
+  });
+
+  // The whole reason the estimate is not just JSON.stringify(data).length:
+  // saveToFirestore strips embedded favicons before writing, so those bytes
+  // never reach the document and must not count against the limit.
+  test('should measure the container as saveToFirestore would write it', () => {
+    const heavyFavicon = 'data:image/png;base64,' + 'A'.repeat(12000);
+    const withFavicons = buildContainer(120, heavyFavicon);
+
+    expect(JSON.stringify(withFavicons).length).toBeGreaterThan(
+      FIRESTORE_MAX_DOCUMENT_BYTES
+    );
+    expect(estimateFirestoreBytes(withFavicons)).toBeLessThan(
+      FIRESTORE_MAX_DOCUMENT_BYTES
+    );
+  });
+
+  // Titles are user data and routinely non-ASCII. String.length counts UTF-16
+  // code units, so it under-reports the bytes Firestore actually stores and
+  // would let a document through that the write then rejects.
+  test('should count UTF-8 bytes rather than characters', () => {
+    const container = buildContainer(10, '', () => '日本語のタイトル');
+
+    expect(estimateFirestoreBytes(container)).toBeGreaterThan(
+      JSON.stringify(container).length
+    );
+  });
+});
+
+describe('readImportedContainer', () => {
+  const validContainer: TabMasterContainer = {
+    lastModified: 1785312544441,
+    selectedTabGroupId: null,
+    tabGroups: [],
+  };
+
+  test('should return the container for a valid backup', () => {
+    expect(readImportedContainer(JSON.stringify(validContainer))).toEqual(
+      validContainer
+    );
+  });
+
+  test('should throw the structure message for a valid-JSON non-container', () => {
+    expect(() => readImportedContainer('{"nope":true}')).toThrow(
+      'Invalid JSON structure.'
+    );
+  });
+
+  // Unchanged behaviour, pinned so the refactor cannot quietly swallow it:
+  // JSON.parse's own SyntaxError reaches the toast.
+  test('should let a JSON syntax error propagate', () => {
+    expect(() => readImportedContainer('{not json')).toThrow(SyntaxError);
+  });
+
+  test('should reject a backup that would exceed the Firestore limit', () => {
+    const huge: TabMasterContainer = {
+      lastModified: 1,
+      selectedTabGroupId: null,
+      tabGroups: [
+        {
+          tabGroupId: 'g',
+          title: 'x'.repeat(1_200_000),
+          createdTime: '2026-07-27 04:08:12',
+          windowCount: 0,
+          tabCount: 0,
+          isAutoSave: false,
+          isSelected: false,
+          windows: [],
+        },
+      ],
+    };
+
+    expect(() => readImportedContainer(JSON.stringify(huge))).toThrow(
+      /too large to sync/i
+    );
+  });
+
+  // The counterpart to the rejection test, and the reason the guard measures
+  // post-strip: a backup that is over the limit on disk but fits once favicons
+  // are dropped is a legitimate restore and must NOT be refused.
+  test('should accept a backup that only exceeds the limit before stripping', () => {
+    const heavyFavicon = 'data:image/png;base64,' + 'A'.repeat(12000);
+    const container: TabMasterContainer = {
+      lastModified: 1,
+      selectedTabGroupId: 'group-0',
+      tabGroups: [
+        {
+          tabGroupId: 'group-0',
+          title: 'Heavy',
+          createdTime: '2026-07-27 04:08:12',
+          windowCount: 1,
+          tabCount: 120,
+          isAutoSave: false,
+          isSelected: true,
+          windows: [
+            {
+              windowId: 'window-0',
+              windowHeight: 550,
+              windowWidth: 790,
+              windowOffsetTop: 0,
+              windowOffsetLeft: 0,
+              tabCount: 120,
+              title: 'w',
+              tabs: Array.from({ length: 120 }, (_, i) => ({
+                tabId: `tab-${i}`,
+                favicon: heavyFavicon,
+                title: `Repository ${i}`,
+                url: `https://github.com/user/repo-${i}`,
+              })),
+            },
+          ],
+        },
+      ],
+    };
+    const serialized = JSON.stringify(container);
+
+    expect(serialized.length).toBeGreaterThan(FIRESTORE_MAX_DOCUMENT_BYTES);
+    expect(readImportedContainer(serialized)).toEqual(container);
   });
 });

--- a/src/utils/functions/local.ts
+++ b/src/utils/functions/local.ts
@@ -409,6 +409,25 @@ export function stripEmbeddedFavicons(
   };
 }
 
+// How big this container would be as a Firestore document, in bytes.
+//
+// Measured AFTER stripEmbeddedFavicons because that is exactly what
+// saveToFirestore writes: an embedded favicon is 5-20KB on disk and 0 bytes in
+// the document, so measuring the raw container would refuse backups that
+// actually fit. TextEncoder, not String.length, because length counts UTF-16
+// code units -- a title in a non-Latin script is one character and three bytes,
+// and under-reporting is the failure that lets a doomed write through.
+//
+// This is an estimate, not Firestore's own accounting, which also charges for
+// field names and a per-document overhead. JSON's structural bytes (quotes,
+// colons, braces) stand in for that roughly, and the gap is nowhere near the
+// margin that matters here -- the case this exists to catch is a multi-megabyte
+// file, not one a kilobyte over.
+export function estimateFirestoreBytes(data: TabMasterContainer): number {
+  return new TextEncoder().encode(JSON.stringify(stripEmbeddedFavicons(data)))
+    .byteLength;
+}
+
 // Chrome keeps a favicon cache for pages the user has visited, reachable through
 // the `favicon` permission. Deriving the icon from the page URL costs no storage,
 // so a tab whose embedded favicon was dropped by stripEmbeddedFavicons still
@@ -463,6 +482,40 @@ export const isValidTabMasterContainer = (
     hasValidTombstones(data.deletedTabGroups)
   );
 };
+
+const bytesToMB = (bytes: number): string => (bytes / 1048576).toFixed(1);
+
+// Parse, validate and size-check the contents of an imported backup file.
+//
+// Every rejection throws, because the import handler already prints
+// error.message straight to a toast -- a caller that returned a result object
+// would need new UI for a path that already has one. JSON.parse's own
+// SyntaxError is deliberately left to propagate: it names the offending token,
+// which is more useful than anything this could say about a corrupt file.
+//
+// The size check is the KAN-27 guard, and it refuses rather than importing and
+// warning. An oversized container is persisted to localStorage by
+// restoreContainer and leaves isDirty set against a document Firestore will
+// never accept, so importing anyway does not just fail once -- it wedges sync
+// for every subsequent change until the user deletes sessions by hand.
+export function readImportedContainer(content: string): TabMasterContainer {
+  const parsed: unknown = JSON.parse(content);
+
+  if (!isValidTabMasterContainer(parsed)) {
+    throw new Error('Invalid JSON structure.');
+  }
+
+  const bytes = estimateFirestoreBytes(parsed);
+  if (bytes > FIRESTORE_MAX_DOCUMENT_BYTES) {
+    throw new Error(
+      `too large to sync (${bytesToMB(bytes)} MB of a ` +
+        `${bytesToMB(FIRESTORE_MAX_DOCUMENT_BYTES)} MB limit). ` +
+        `Remove some sessions from the backup and try again.`
+    );
+  }
+
+  return parsed;
+}
 
 // validate import JSON structure - tabContainerData
 const isValidTabContainerData = (data: unknown): data is tabContainerData => {


### PR DESCRIPTION
Closes KAN-27.

## What was wrong

`handleImportJSON` accepted any file that parsed and validated. An oversized one was persisted to localStorage by `restoreContainer` (which writes synchronously), the toast said *"Restored tabs successfully!"*, and the Firestore write then failed — leaving `isDirty` set against a document that can never be written. **One bad import wedged sync permanently**, not just once: every later change failed the same write.

## Two findings that changed the fix from what the ticket describes

**The failure is no longer fully silent.** `saveToFirestore` rethrows and `saveToFirestoreIfDirty.rejected` sets `syncStatus: 'error'` (`globalStateSlice.ts:333`) — that landed with the KAN-32-era work, after this ticket was written. What remains wrong is that the import toast reports success regardless, because the thunk is dispatched fire-and-forget outside the reach of its own `try/catch`.

**`FIRESTORE_MAX_DOCUMENT_BYTES` already existed** at `local.ts:388` with **zero production consumers** — only a test referenced it.

## The fix

Guards on **bytes**, not the group/tab counts the ticket suggests. Counts are a proxy that is wrong in both directions: 200 groups of long URLs can exceed 1MB while 600 small ones will not, and the exact constant was already sitting there unused.

```ts
estimateFirestoreBytes(data) =>
  new TextEncoder().encode(JSON.stringify(stripEmbeddedFavicons(data))).byteLength
```

Two deliberate choices in that one line:

- **After `stripEmbeddedFavicons`** — that is exactly what `saveToFirestore` writes. Embedded base64 favicons run 5–20KB each and become 0 bytes in the document, so measuring the raw file would refuse backups that actually fit. A false rejection blocks a legitimate restore, which is worse than the bug.
- **`TextEncoder`, not `String.length`** — length counts UTF-16 code units, so a non-Latin title is one character and three bytes. Under-reporting is the failure mode that lets a doomed write through.

`readImportedContainer` now owns parse + validate + size check, so the whole decision is pure and unit-testable and the component keeps only wiring. `JSON.parse`'s `SyntaxError` is deliberately left to propagate — it names the offending token, which beats anything generic.

**Rejects rather than importing-and-warning**, because importing anyway leaves the user in the wedged state above — that state *is* the defect.

The estimate is not Firestore's own accounting (which also charges for field names and per-document overhead). JSON's structural bytes stand in for that roughly, and the comment says so — the case this exists to catch is a multi-megabyte file, not one a kilobyte over.

## Verified in the built extension

Drove the real handler in the real bundle:

| import | toast | store |
|---|---|---|
| 1.2 MB backup | `Error restoring tabs: too large to sync (1.1 MB of a 1.0 MB limit). Remove some sessions from the backup and try again.` | untouched |
| valid backup | `Restored tabs successfully!` | imported |

The accept arm matters: a guard that rejected everything would pass the reject arm alone.

I did **not** run the unguarded build against the browser as a control here, unlike KAN-28 — doing so would persist a 1.2 MB document and push it to real Firestore, wedging sync exactly as described. The control came from the mutation test below instead, which exercises the same production path.

## Tests

Nine new — seven pure in `local.test.ts`, two driving the real handler in `importGuard.test.tsx` (intercepting the `<input type="file">` the handler builds on the fly, since it is never rendered).

**Mutation-tested**, each turning only the matching test red:

| mutation | result |
|---|---|
| drop `stripEmbeddedFavicons` from the estimate | 2 red |
| `String.length` instead of `TextEncoder` | 1 red |
| remove the size check | 1 red |
| revert the component to its old inline validation | 1 red |

That last one fails with `expected 'Restored tabs successfully!' to match /too large to sync/i` — the bug verbatim.

Honest note: the two component tests were written *after* the implementation, so their passing proves less on its own; the wiring mutation is what establishes they test anything. The seven pure tests were written first and watched fail.

293/293 tests pass (284 + 9), `tsc` clean, lint unchanged at 0 errors / 28 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)