### PR TITLE
Stop the theme switch animating, and let the scrollbar follow it (KAN-22)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -7,18 +7,33 @@ body {
   background-color: grey;
 }
 
+/* Suppresses every transition while the theme is being swapped (KAN-22).
+   useDocumentTheme sets this attribute on <html> in the same commit that
+   changes the colours and clears it once they have painted.
+
+   `!important` is load-bearing here rather than lazy: the transitions this has
+   to beat are declared in emotion classes, which are injected into the document
+   later than this stylesheet and so would otherwise win on order alone. */
+[data-theme-switching] * {
+  transition: none !important;
+}
+
 ::-webkit-scrollbar {
   width: 10px;
 }
 
+/* The custom properties come from useDocumentTheme, which reads the SCROLLBAR_*
+   tokens off the active theme. The fallbacks are the previous hardcoded values,
+   so the scrollbar still renders if the stylesheet is parsed before React has
+   published anything. */
 ::-webkit-scrollbar-track {
-  background: #f0f2f5;
+  background: var(--scrollbar-track, #f0f2f5);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #888;
+  background: var(--scrollbar-thumb, #888);
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #555;
+  background: var(--scrollbar-thumb-hover, #555);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import MainContainer from './components/MainContainer';
 import { AppDispatch, RootState } from './redux/store';
 import { setPresentStartup } from './redux/slices/undoRedoSlice';
 import { useThemeColors } from './hooks/useThemeColors';
+import { useDocumentTheme } from './hooks/useDocumentTheme';
 import { replaceState } from './redux/slices/tabContainerDataStateSlice';
 import {
   openRateAndReviewModal,
@@ -38,6 +39,13 @@ import {
 
 function App() {
   const COLORS = useThemeColors();
+
+  // Publishes the theme to <html>: scrollbar custom properties, and the flag
+  // that suppresses transitions while the colours change (KAN-22). Mounted at
+  // the root so it covers every route into a theme change, including a change
+  // arriving from settings sync rather than the swatches in Settings.
+  useDocumentTheme();
+
   const dispatch: AppDispatch = useDispatch();
   const isSignedIn = useSelector(
     (state: RootState) => state.globalState.isSignedIn

--- a/src/hooks/useDocumentTheme.ts
+++ b/src/hooks/useDocumentTheme.ts
@@ -1,0 +1,67 @@
+import { useLayoutEffect } from 'react';
+
+import { useThemeColors } from './useThemeColors';
+
+// The two parts of theming that emotion cannot reach, both driven by the same
+// change and both written to the document root (KAN-22).
+//
+// 1. Global pseudo-elements. `::-webkit-scrollbar` has no element to attach a
+//    css`` class to, so App.css styled it with literal hex values that never
+//    tracked the theme -- the scrollbar stayed light grey in all five, including
+//    the two dark ones. The SCROLLBAR_* tokens already existed on every theme
+//    and had no consumer; this publishes them as custom properties so the
+//    stylesheet can read them.
+//
+// 2. Transition suppression. Seven components declare
+//    `transition: background-color 0.2s` at the top level of their styles
+//    rather than inside `&:hover`, so a theme change animated every icon,
+//    button and row over 200ms and read as lag on the left pane.
+//
+//    The obvious fix -- move each transition inside `&:hover` -- is worse than
+//    the bug: a transition declared only in the hover rule stops existing the
+//    moment the pointer leaves, so the element fades in and snaps out. This
+//    suppresses transitions globally for the duration of the swap instead,
+//    which keeps hover symmetric and, being one rule, stays correct as
+//    components are added. FocusConfirmModal picked up the same pattern after
+//    KAN-22 was filed, which is the argument against fixing it per file.
+//
+// useLayoutEffect, not useEffect: the flag has to be on the element in the same
+// commit that changes the colours. One frame late and the transition has
+// already begun, which is the entire defect.
+export function useDocumentTheme(): void {
+  const COLORS = useThemeColors();
+
+  useLayoutEffect(() => {
+    const root = document.documentElement;
+
+    root.setAttribute('data-theme-switching', '');
+
+    root.style.setProperty('--scrollbar-track', COLORS.SCROLLBAR_TRACK);
+    root.style.setProperty('--scrollbar-thumb', COLORS.SCROLLBAR_THUMB);
+    root.style.setProperty(
+      '--scrollbar-thumb-hover',
+      COLORS.SCROLLBAR_THUMB_HOVER
+    );
+
+    // Two frames, not one: the first only guarantees the new styles are
+    // computed, the second that they have been painted. Releasing after one
+    // still let the tail of the change animate on slower frames.
+    let inner = 0;
+    const outer = requestAnimationFrame(() => {
+      inner = requestAnimationFrame(() =>
+        root.removeAttribute('data-theme-switching')
+      );
+    });
+
+    // Without this, unmounting mid-swap (closing the popup during a theme
+    // change) would leave the attribute set. It is on <html>, which outlives
+    // React, so every transition in the app would stay dead on the next mount.
+    return () => {
+      cancelAnimationFrame(outer);
+      cancelAnimationFrame(inner);
+      root.removeAttribute('data-theme-switching');
+    };
+    // COLORS is one of the frozen module-level theme objects, so this is a
+    // stable reference that changes only when the theme actually changes.
+  }, [COLORS]);
+}

--- a/src/tests/components/documentTheme.test.tsx
+++ b/src/tests/components/documentTheme.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, test, afterEach } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
+
+import { useDocumentTheme } from '../../hooks/useDocumentTheme';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import { setTheme, Theme } from '../../redux/slices/settingsDataStateSlice';
+import { DARKENHEIMER_THEME, LIGHT_THEME } from '../../hooks/useThemeColors';
+
+// KAN-22. Two theming jobs that CSS-in-JS cannot do, both keyed on the same
+// change, so both live in one hook on the document root:
+//
+//   1. Global pseudo-elements. ::-webkit-scrollbar cannot be styled from an
+//      emotion class, so App.css reads custom properties this hook publishes.
+//      The SCROLLBAR_* tokens already existed on all five themes and were
+//      consumed by nothing.
+//   2. Suppressing transitions during the switch. Seven components declare
+//      `transition: background-color 0.2s` at the top level of their styles,
+//      so changing theme animated every one of them over 200ms and read as lag.
+
+const Probe = () => {
+  useDocumentTheme();
+  return null;
+};
+
+describe('useDocumentTheme (KAN-22)', () => {
+  afterEach(() => {
+    const root = document.documentElement;
+    root.removeAttribute('data-theme-switching');
+    root.removeAttribute('style');
+  });
+
+  test('publishes the active theme scrollbar colours as custom properties', async () => {
+    await renderWithProviders(<Probe />);
+
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue('--scrollbar-track')).toBe(
+      LIGHT_THEME.SCROLLBAR_TRACK
+    );
+    expect(root.style.getPropertyValue('--scrollbar-thumb')).toBe(
+      LIGHT_THEME.SCROLLBAR_THUMB
+    );
+    expect(root.style.getPropertyValue('--scrollbar-thumb-hover')).toBe(
+      LIGHT_THEME.SCROLLBAR_THUMB_HOVER
+    );
+  });
+
+  // The bug the hardcoded #f0f2f5 / #888 caused: the scrollbar stayed light
+  // grey in every theme, including the two dark ones.
+  test('republishes them when the theme changes', async () => {
+    const { store } = await renderWithProviders(<Probe />);
+
+    act(() => {
+      store.dispatch(setTheme(Theme.DARKENHEIMER));
+    });
+
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue('--scrollbar-track')).toBe(
+      DARKENHEIMER_THEME.SCROLLBAR_TRACK
+    );
+    expect(root.style.getPropertyValue('--scrollbar-thumb')).toBe(
+      DARKENHEIMER_THEME.SCROLLBAR_THUMB
+    );
+  });
+
+  // The flag must be set in the SAME commit that changes the colours, not a
+  // frame later -- one frame late and the transition has already started, which
+  // is the whole defect.
+  test('marks the document as switching synchronously with the theme change', async () => {
+    const { store } = await renderWithProviders(<Probe />);
+
+    await waitFor(() => {
+      expect(
+        document.documentElement.hasAttribute('data-theme-switching')
+      ).toBe(false);
+    });
+
+    act(() => {
+      store.dispatch(setTheme(Theme.BLUE));
+    });
+
+    expect(document.documentElement.hasAttribute('data-theme-switching')).toBe(
+      true
+    );
+  });
+
+  // ...and must clear it again, or every hover transition in the app stays
+  // dead for the rest of the session -- a worse bug than the one being fixed.
+  test('clears the switching flag once the new colours have painted', async () => {
+    const { store } = await renderWithProviders(<Probe />);
+
+    act(() => {
+      store.dispatch(setTheme(Theme.BB_PINK));
+    });
+
+    await waitFor(() => {
+      expect(
+        document.documentElement.hasAttribute('data-theme-switching')
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes KAN-22.

## What was wrong

**The lag.** Seven components declare `transition: background-color 0.2s` at the top level of their styles rather than inside `&:hover`. That transition fires on *any* background-colour change — including a theme swap — so clicking a swatch animated every icon, button and row over 200ms.

**The scrollbar.** `App.css` styled `::-webkit-scrollbar` with literal hex values (`#f0f2f5`, `#888`, `#555`), so it stayed light grey in all five themes, including the two dark ones.

## Two things the ticket got wrong

**Its first suggested fix would have made things worse.** Moving each `transition` inside `&:hover` gives asymmetric hover: a transition declared only in the hover rule stops existing the moment the pointer leaves, so elements fade *in* and snap *out*. This takes the ticket's second option instead.

**It names three files; there are seven.** `SettingsCategoryContainer`, `Icon` and `Button` are named — but `WindowEntryContainer` (×2), `TabGroupEntry` and `FocusConfirmModal` also have it. `FocusConfirmModal.tsx:141` arrived with KAN-37, *after* this ticket was filed, which is the argument against fixing it per file: the pattern is still spreading. A per-file fix would also have missed theme changes arriving via **settings sync from another device**, which the five swatches are not the only source of.

## The fix

`useDocumentTheme` publishes the theme to `<html>` whenever it changes:

- the `SCROLLBAR_*` values as custom properties, which `App.css` now reads
- a `data-theme-switching` flag, which `[data-theme-switching] * { transition: none !important }` keys off

`useLayoutEffect`, not `useEffect`: the flag must land in the same commit as the colours — one frame late and the transition has already started, which is the entire defect. Released after a double `requestAnimationFrame`, and in the cleanup, because closing the popup mid-swap would otherwise leave the attribute on `<html>` and every transition in the app dead for the next mount.

`!important` is load-bearing rather than lazy: the transitions it has to beat live in emotion classes injected *after* this stylesheet, so they'd win on order alone.

**The `SCROLLBAR_TRACK` / `SCROLLBAR_THUMB` / `SCROLLBAR_THUMB_HOVER` tokens already existed on all five themes with zero consumers** — the same dead-constant situation as `FIRESTORE_MAX_DOCUMENT_BYTES` in KAN-27. This wires them up. The old hex values survive as `var()` fallbacks so the scrollbar still renders before React publishes anything.

## Evidence from the built extension

`MutationObserver` on `<html>` across a real theme switch, sampling a component that declares a transition:

| moment | flag | `transition-property` | `--scrollbar-track` |
|---|---|---|---|
| flag added | `true` | **`none`** | `#2A2A2A` (new theme, same commit) |
| flag removed, ~6ms later | `false` | `background-color` | `#2A2A2A` |
| settled | `false` | `background-color` | `#2A2A2A` |

Suppression is simultaneous with the colour change, and hover transitions are restored two frames later — the regression my objection to the ticket's first option was about. Before the change the same element read `transition-property: background-color` throughout, and `--scrollbar-track` did not exist.

## Tests

Four new in `src/tests/components/documentTheme.test.tsx`. **Mutation-tested**, each turning only the matching tests red:

| mutation | red |
|---|---|
| never set the switching flag | 1 |
| never clear it (leak the flag) | 2 |
| publish only the track, not the thumb | 2 |
| `[]` dependency — publish once, never update | 2 |

That last one is the original bug's shape, and two tests catch it.

## Deliberately out of scope

`body { background-color: grey }` (`App.css:6`) is still hardcoded. It sits behind the app, which covers it, and a custom property there would only apply after React's first paint — so it would not fix the flash it looks like it should. Left alone rather than half-fixed.

297/297 tests pass (293 + 4), `tsc` clean, lint unchanged at 0 errors / 28 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)