### PR TITLE
Key the settings panel so React stops recycling nodes across it (KAN-44)

### DIFF
--- a/src/components/settings/rightpane/SettingsDetailsContainer.tsx
+++ b/src/components/settings/rightpane/SettingsDetailsContainer.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react';
+
 import { useDispatch, useSelector } from 'react-redux';
 
 import { css } from '@emotion/react';
@@ -673,7 +675,25 @@ const SettingsDetailsContainer: React.FC = () => {
     );
   }
 
-  return <div css={containerStyle}>{settingsOptionsDiv}</div>;
+  // Keyed on the category so React remounts the panel instead of reconciling
+  // one against the next (KAN-44). The five branches above all render into this
+  // one position, so without a key React matched them element by element and
+  // handed the Display panel's first theme swatch <button> to Sync & Privacy's
+  // Auto Sync button. A swatch is hardcoded to LIGHT_THEME.PRIMARY_COLOR, and
+  // Button carries `transition: background-color 0.2s`, so on a dark theme the
+  // recycled node animated white -> black over 200ms.
+  //
+  // A Fragment rather than a wrapper div: this is a flex context and an extra
+  // element would change the layout. Fragments take a key as long as they are
+  // written out in full -- the <> shorthand cannot, the same constraint as
+  // SettingsCategoryContainer in KAN-28.
+  return (
+    <div css={containerStyle}>
+      <Fragment key={selectedSettingsCategory.name}>
+        {settingsOptionsDiv}
+      </Fragment>
+    </div>
+  );
 };
 
 export default SettingsDetailsContainer;

--- a/src/tests/components/settingsPanelIdentity.test.tsx
+++ b/src/tests/components/settingsPanelIdentity.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'vitest';
+import { act, screen } from '@testing-library/react';
+
+import SettingsDetailsContainer from '../../components/settings/rightpane/SettingsDetailsContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  SettingsCategory,
+  selectCategory,
+} from '../../redux/slices/settingsCategoryStateSlice';
+
+// KAN-44. SettingsDetailsContainer assigns settingsOptionsDiv in five if/else
+// branches and renders them all into one position, so nothing told React the
+// panels are different things. It reconciled Display against Sync & Privacy
+// instead of remounting, and recycled the first theme swatch's <button> into
+// the Auto Sync button.
+//
+// That was visible because a swatch is hardcoded to LIGHT_THEME.PRIMARY_COLOR
+// (#F5F7FA) -- a swatch shows its own theme, not the active one -- while
+// Button declares `transition: background-color 0.2s`. On a dark theme the
+// recycled node animated white -> black over 200ms.
+//
+// Asserting on node identity rather than on colour, deliberately: the colour is
+// only the symptom, it needs a dark theme to be visible at all, and sampling a
+// transition mid-flight in jsdom would be a timing test. Identity is the defect.
+
+const renderOnDisplay = () =>
+  renderWithProviders(<SettingsDetailsContainer />, {
+    seedStore: (store) => {
+      store.dispatch(selectCategory(SettingsCategory.DISPLAY));
+    },
+  });
+
+describe('settings panel identity (KAN-44)', () => {
+  test('does not recycle a theme swatch into the Auto Sync button', async () => {
+    const { store, container } = await renderOnDisplay();
+
+    // The five theme swatches are the only buttons on the Display panel.
+    const swatches = [...container.querySelectorAll('button')];
+    expect(swatches.length).toBeGreaterThan(0);
+    const firstSwatch = swatches[0];
+
+    act(() => {
+      store.dispatch(selectCategory(SettingsCategory.SYNC));
+    });
+
+    const autoSync = (await screen.findByText(/^(On|Off)$/)).closest('button');
+    expect(autoSync).not.toBeNull();
+
+    // Unkeyed, React matches <button> to <button> at the same position and
+    // hands the swatch's own node to Auto Sync, carrying its computed
+    // background with it.
+    expect(autoSync).not.toBe(firstSwatch);
+  });
+
+  // The general statement of the same defect: no node *inside* the panel should
+  // survive a category change, because the two panels are not the same panel.
+  // Without this, a fix that only special-cased buttons would still pass above.
+  //
+  // The component's own outer container is excluded on purpose -- it lives
+  // outside the keyed Fragment and is meant to persist. Asserting on every node
+  // in `container` instead was wrong and failed against the correct fix, with
+  // that one div as the sole survivor.
+  test('replaces the panel contents when the category changes', async () => {
+    const { store, container } = await renderOnDisplay();
+
+    const panelRoot = container.firstElementChild!;
+    const before = new Set(panelRoot.querySelectorAll('*'));
+    expect(before.size).toBeGreaterThan(0);
+
+    act(() => {
+      store.dispatch(selectCategory(SettingsCategory.SYNC));
+    });
+
+    const survivors = [...panelRoot.querySelectorAll('*')].filter((node) =>
+      before.has(node)
+    );
+
+    expect(survivors).toEqual([]);
+  });
+
+  // The control: keying the panel must not break the panel. A fix that
+  // remounted into an empty tree would satisfy both tests above.
+  test('still renders the Sync panel after the switch', async () => {
+    const { store } = await renderOnDisplay();
+
+    act(() => {
+      store.dispatch(selectCategory(SettingsCategory.SYNC));
+    });
+
+    expect(await screen.findByText('Auto Sync')).toBeTruthy();
+    expect(screen.getByText(/^(On|Off)$/)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes KAN-44. Reported by Justine: on a dark theme, moving from Settings → Display to Sync & Privacy makes the Auto Sync button flash white before settling to black.

## Root cause

React was handing the Display panel's **first theme swatch `<button>`** to the Sync panel's Auto Sync button.

`settingsOptionsDiv` is assigned in five `if/else` branches and rendered into a single position (`:676`), so nothing distinguished one panel from another. React reconciled the two subtrees element by element, matched `<button>` to `<button>`, and **recycled the DOM node**, swapping only its emotion class.

A swatch is hardcoded to `LIGHT_THEME.PRIMARY_COLOR` (`#F5F7FA`) — it must show *its own* theme, not the active one — and `Button.tsx:48` declares `transition: background-color 0.2s`. So the recycled node animated from near-white to the dark theme colour over 200ms.

## Evidence

Sampling `getComputedStyle(button).backgroundColor` per frame in the built extension, Darkenheimer theme:

| | frame 0 | frame 4 | frame 8 | frame 15–21 |
|---|---|---|---|---|
| **before** | `rgb(245,247,250)` ← Light swatch | `rgb(200,201,203)` | `rgb(128,129,130)` | `rgb(44,44,44)` |
| **after** | `rgb(42,42,42)` | `rgb(42,42,42)` | `rgb(42,42,42)` | `rgb(42,42,42)` |

The emotion class was constant at `css-sq4n1q` across every "before" sample — what a recycled node looks like.

**It only reproduced from Display**, which is what made it look like a Display bug:

| coming from | first painted background | flash |
|---|---|---|
| Display | `rgb(245,247,250)` | **yes** |
| Language / About / Data Management | `rgb(42,42,42)` | no |

Data Management renders buttons too and its node is recycled just the same — but its buttons already use `PRIMARY_COLOR`, so there's no colour delta to animate. **The identity problem was general; only the symptom was Display-specific.** A fix aimed at the Display panel would have left the real defect in place.

## The fix

A keyed `Fragment` on `selectedSettingsCategory.name`, so React unmounts the old panel and mounts a new one. A freshly mounted element has no previous computed value, so nothing transitions.

- **Not** suppressing the transition — that hides the recycling rather than stopping it.
- **Not** scoping `transition` inside `&:hover` — that gives asymmetric hover (fades in, snaps out), rejected on KAN-22 for the same reason.
- A `Fragment` rather than a wrapper `div`, because this is a flex context and an extra element would change the layout. Written out in full, since `<>` cannot take a key — the same constraint as `SettingsCategoryContainer` in KAN-28.

Same root-cause family as **KAN-28**: React reusing a DOM node across things that are not the same thing. There it was `.map()` without `key`; here it's conditional panels sharing one position.

## Tests

Three new, asserting **node identity rather than colour**. The colour is only the symptom — it needs a dark theme to be visible at all, and sampling a transition mid-flight in jsdom would be a timing test.

- the Auto Sync button is not the swatch's node
- nothing inside the panel survives a category change
- **control:** the Sync panel still renders after the switch, so a fix that remounted into an empty tree wouldn't pass

Both identity tests go red against an unkeyed `Fragment`; the control passes either way, which is what makes it a control.

**One correction worth recording:** the subtree test first asserted that *no* node in the container survived. That was wrong — the component's own outer div sits outside the keyed Fragment and is meant to persist — and it failed against the correct fix with that single div as the sole survivor. Rescoped to the panel contents; it still fails against the bug.

## Not related to KAN-22

Measured on the PR #142 build before fixing. That change only suppresses transitions while `data-theme-switching` is set, which is a *theme* change, not a panel change. This defect is independent and pre-existing, and this PR branches from `main`, not from #142.

296/296 tests pass (293 + 3), `tsc` clean, lint unchanged at 0 errors / 28 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)