### PR TITLE
Guard the placeholder base64 decode so the worker cannot throw (KAN-45)

### DIFF
--- a/src/tests/utils/functions/decodeDataUrl.test.ts
+++ b/src/tests/utils/functions/decodeDataUrl.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test, vi } from 'vitest';
+
+// KAN-45. local.test.ts already asserts that a malformed placeholder decodes to
+// null rather than throwing -- but it passes against js-base64 3.7.5 only
+// because that version decodes garbage instead of rejecting it. The production
+// code has no guard, so the guarantee belongs to the dependency, not to us.
+// js-base64 3.9.3 throws InvalidCharacterError, which is what dependabot #138
+// surfaced.
+//
+// Forcing the throw is the whole point of this file: it pins the behaviour to
+// the code rather than to whichever version happens to be installed, so the
+// test keeps its meaning across the bump and after it.
+vi.mock('js-base64', () => ({
+  Base64: {
+    // Present only to keep the module's shape; no test here encodes anything,
+    // and a stub that pretended to would invite someone to trust its output.
+    encode: () => {
+      throw new Error('Base64.encode is not stubbed for these tests');
+    },
+    decode: () => {
+      // The shape js-base64 >= 3.9 throws for input that is not valid base64.
+      throw new DOMException(
+        'The string to be decoded is not correctly encoded.',
+        'InvalidCharacterError'
+      );
+    },
+  },
+}));
+
+vi.mock('../../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+const { decodeDataUrl, placeholderTarget, resolveTabUrl } = await import(
+  '../../../utils/functions/local'
+);
+
+const PLACEHOLDER = 'data:text/html;base64,';
+
+describe('decodeDataUrl when the base64 decoder rejects the input (KAN-45)', () => {
+  // The one that matters: background.ts calls placeholderTarget from
+  // chrome.tabs.onActivated, so this runs in the service worker on every tab
+  // the user activates. A throw there aborts the handler and the placeholder
+  // silently never resolves to its real page -- KAN-36's defect, by a
+  // different route.
+  test('placeholderTarget declines instead of throwing', () => {
+    expect(placeholderTarget(`${PLACEHOLDER}!!!not!!base64!!!`)).toBeNull();
+  });
+
+  test('decodeDataUrl hands back the url it was given', () => {
+    const url = `${PLACEHOLDER}!!!not!!base64!!!`;
+    expect(decodeDataUrl(url)).toBe(url);
+  });
+
+  // decodeDataUrl is also on the save path, via resolveTabUrl -- a capture that
+  // hit an undecodable placeholder would otherwise throw mid-save.
+  test('resolveTabUrl hands back the url it was given', () => {
+    const url = `${PLACEHOLDER}!!!not!!base64!!!`;
+    expect(resolveTabUrl(url)).toBe(url);
+  });
+
+  // Nothing that is not a placeholder should reach the decoder at all, so a
+  // throwing decoder must not change how ordinary URLs are handled.
+  test('leaves a non-placeholder url alone', () => {
+    expect(decodeDataUrl('https://example.com/')).toBe('https://example.com/');
+    expect(placeholderTarget('https://example.com/')).toBeNull();
+  });
+});

--- a/src/utils/functions/local.ts
+++ b/src/utils/functions/local.ts
@@ -276,7 +276,25 @@ export function generatePlaceholderURL(
 export function decodeDataUrl(url: string): string {
   if (url.startsWith(PLACEHOLDER_URL_PREFIX)) {
     const base64Data = url.replace(PLACEHOLDER_URL_PREFIX, '');
-    const decodedHtml = Base64.decode(base64Data);
+
+    // Guarded because the caller cannot afford a throw: placeholderTarget runs
+    // this inside chrome.tabs.onActivated in the service worker, on every tab
+    // the user activates, and an exception there aborts the handler so the
+    // placeholder never resolves to its real page (KAN-45).
+    //
+    // The guard has to live here rather than in the test's expectations: this
+    // used not to throw only because js-base64 3.7.5 decoded malformed input to
+    // garbage. 3.9.3 raises InvalidCharacterError instead, so the no-throw
+    // guarantee was the dependency's, not ours.
+    let decodedHtml: string;
+    try {
+      decodedHtml = Base64.decode(base64Data);
+    } catch {
+      // Undecodable, so there is no page hiding in it. Handing the url back
+      // unchanged is what the rest of this path already does with input it
+      // cannot make sense of.
+      return url;
+    }
 
     // extract the actual URL from the HTML content
     //


### PR DESCRIPTION
Closes KAN-45. Unblocks dependabot #138 (js-base64 3.7.5 → 3.9.3).

## What was wrong

`decodeDataUrl` called `Base64.decode` with no guard (`local.ts:279`). `local.test.ts` already asserted the intended behaviour — its test is literally named *"should return null rather than throw on malformed base64"* — but **the production code never implemented that guarantee. js-base64 3.7.5 did**, by decoding malformed input to garbage rather than rejecting it:

```
"!!!not!!base64!!!" -> "��[jǺ"   (3.7.5, no throw)
```

3.9.3 rejects it instead, so the guarantee vanishes the moment the dependency moves. **The bump is not the bug — it's what exposed one.**

## Why it matters beyond the bump

`placeholderTarget` is called from `chrome.tabs.onActivated` in `background.ts:21`, so **the service worker runs this on every tab the user activates**. An uncaught throw there aborts the handler and the placeholder silently never resolves to its real page — KAN-36's defect returning by a different route.

## The fix

Undecodable input returns the URL unchanged, matching what the rest of that path already does with input it can't make sense of: a foreign `data:` document, a decode yielding nothing, and a non-http(s) target all decline rather than throw.

**The `catch` is deliberately bare.** The failure isn't one error type — 3.9.3 throws `SyntaxError` under Node and `DOMException`/`InvalidCharacterError` under jsdom, which is why CI on #138 reported a different error than a local run does. Catching a specific type would fix one environment and not the other.

## Tests

Four new, in their own file so `js-base64` can be mocked to throw. **That is the point of them**: they pin the no-throw guarantee to *this code* rather than to whichever version happens to be installed, so they keep their meaning both before and after the bump. The existing test in `local.test.ts` can't do that — it passes today for the wrong reason.

Coverage: the worker path (`placeholderTarget`), `decodeDataUrl` directly, the save path via `resolveTabUrl`, and a control that a non-placeholder URL is untouched.

Removing the guard turns three of the four red; the control passes either way.

## Verified against the real dependency

Installed js-base64 3.9.3 locally and ran the full suite: **304/304 pass**. Then restored 3.7.5 — `package.json` and the lockfile are **unchanged in this PR**. The bump itself belongs to #138, which should go green once this is on `main`.

304/304 tests pass (300 + 4), `tsc` clean, lint unchanged at 0 errors / 28 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)