### PR TITLE
Report the real sync verdict after a JSON import (KAN-43)

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -88,5 +88,6 @@
   "RequestUserReviewHeader": "Gefällt Ihnen Tab Keeper?",
   "RequestUserReviewText": "Würden Sie uns eine positive Bewertung hinterlassen?",
   "Maybe Later": "Vielleicht später",
-  "Never Remind Again": "Nicht mehr erinnern"
+  "Never Remind Again": "Nicht mehr erinnern",
+  "Restored on this device, but syncing failed.": "Auf diesem Gerät wiederhergestellt, aber die Synchronisierung ist fehlgeschlagen."
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -89,5 +89,6 @@
   "RequestUserReviewText": "Please consider helping me out with a good review!",
   "Maybe Later": "Maybe Later",
   "Never Remind Again": "Never Remind Again",
-  "Sync unavailable: your saved account token could not be read.": "Sync unavailable: your saved account token could not be read."
+  "Sync unavailable: your saved account token could not be read.": "Sync unavailable: your saved account token could not be read.",
+  "Restored on this device, but syncing failed.": "Restored on this device, but syncing failed."
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -88,5 +88,6 @@
   "RequestUserReviewHeader": "¿Te gusta Tab Keeper?",
   "RequestUserReviewText": "¿Nos dejarías una buena reseña?",
   "Maybe Later": "Más tarde",
-  "Never Remind Again": "No recordar más"
+  "Never Remind Again": "No recordar más",
+  "Restored on this device, but syncing failed.": "Restaurado en este dispositivo, pero falló la sincronización."
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -88,5 +88,6 @@
   "RequestUserReviewHeader": "Vous appréciez Tab Keeper?",
   "RequestUserReviewText": "Pourriez-vous nous laisser un bon avis?",
   "Maybe Later": "Peut-être plus tard",
-  "Never Remind Again": "Ne plus rappeler"
+  "Never Remind Again": "Ne plus rappeler",
+  "Restored on this device, but syncing failed.": "Restauré sur cet appareil, mais la synchronisation a échoué."
 }

--- a/public/locales/hi/translation.json
+++ b/public/locales/hi/translation.json
@@ -88,5 +88,6 @@
   "RequestUserReviewHeader": "टैब कीपर को पसंद कर रहे हैं?",
   "RequestUserReviewText": "क्या आप हमें एक सकारात्मक समीक्षा देंगे?",
   "Maybe Later": "बाद में",
-  "Never Remind Again": "फिर से याद न करें"
+  "Never Remind Again": "फिर से याद न करें",
+  "Restored on this device, but syncing failed.": "इस डिवाइस पर पुनर्स्थापित किया गया, लेकिन सिंक विफल रहा।"
 }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -88,5 +88,6 @@
   "RequestUserReviewHeader": "Ti sta piacendo Tab Keeper?",
   "RequestUserReviewText": "Ti dispiacerebbe lasciarci una recensione positiva?",
   "Maybe Later": "Più tardi",
-  "Never Remind Again": "Non ricordare più"
+  "Never Remind Again": "Non ricordare più",
+  "Restored on this device, but syncing failed.": "Ripristinato su questo dispositivo, ma la sincronizzazione non è riuscita."
 }

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -88,5 +88,6 @@
   "RequestUserReviewHeader": "タブキーパーをお楽しみいただけていますか？",
   "RequestUserReviewText": "ポジティブなレビューをいただけませんか？",
   "Maybe Later": "後で",
-  "Never Remind Again": "再度お知らせしない"
+  "Never Remind Again": "再度お知らせしない",
+  "Restored on this device, but syncing failed.": "このデバイスに復元しましたが、同期に失敗しました。"
 }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -88,5 +88,6 @@
   "RequestUserReviewHeader": "Está gostando do Tab Keeper?",
   "RequestUserReviewText": "Você se importaria de nos deixar uma avaliação positiva?",
   "Maybe Later": "Mais tarde",
-  "Never Remind Again": "Não lembrar mais"
+  "Never Remind Again": "Não lembrar mais",
+  "Restored on this device, but syncing failed.": "Restaurado neste dispositivo, mas a sincronização falhou."
 }

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -88,5 +88,6 @@
   "RequestUserReviewHeader": "Вам нравится Tab Keeper?",
   "RequestUserReviewText": "Не могли бы вы оставить нам положительный отзыв?",
   "Maybe Later": "Позже",
-  "Never Remind Again": "Больше не напоминать"
+  "Never Remind Again": "Больше не напоминать",
+  "Restored on this device, but syncing failed.": "Восстановлено на этом устройстве, но синхронизация не удалась."
 }

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -88,5 +88,6 @@
   "RequestUserReviewHeader": "喜欢Tab Keeper吗？",
   "RequestUserReviewText": "您介意给我们一个好评吗？",
   "Maybe Later": "稍后再说",
-  "Never Remind Again": "不再提醒"
+  "Never Remind Again": "不再提醒",
+  "Restored on this device, but syncing failed.": "已在此设备上恢复，但同步失败。"
 }

--- a/src/components/settings/rightpane/SettingsDetailsContainer.tsx
+++ b/src/components/settings/rightpane/SettingsDetailsContainer.tsx
@@ -35,6 +35,7 @@ import {
   DEV_EMAIL,
   FEEDBACK_MAIL_SUBJECT,
   SHARE_TWITTER_TEXT,
+  TOAST_MESSAGES,
 } from '../../../utils/constants/common';
 import { SettingsCategoryContainer } from '../leftpane/SettingsCategoryContainer';
 import {
@@ -127,7 +128,10 @@ const SettingsDetailsContainer: React.FC = () => {
       const file = (event.target as HTMLInputElement).files![0];
       const reader = new FileReader();
 
-      reader.onload = (fileEvent) => {
+      // async so the cloud write below can be awaited. Its rejection used to
+      // land after this callback had already returned, which put it outside
+      // the try and left the success toast already fired (KAN-43).
+      reader.onload = async (fileEvent) => {
         try {
           const content = fileEvent.target!.result as string;
           // Parses, validates the structure, and refuses anything that would
@@ -146,11 +150,20 @@ const SettingsDetailsContainer: React.FC = () => {
           // appears to work and then silently drops that session.
           dispatch(restoreContainer(tabDataFromJSON));
           dispatch(setIsDirty());
-          dispatch(saveToFirestoreIfDirty());
+
+          // The restore is already done and persisted at this point, so what
+          // is being reported below is the state of the *cloud write*, not of
+          // the import. requestStatus rather than .unwrap(): unwrap would
+          // throw into the catch and produce "Error restoring tabs", which is
+          // the one thing that is definitely untrue here.
+          const saveResult = await dispatch(saveToFirestoreIfDirty());
+          const syncFailed = saveResult.meta.requestStatus === 'rejected';
 
           dispatch(
             showToast({
-              toastText: `Restored tabs successfully!`,
+              toastText: syncFailed
+                ? TOAST_MESSAGES.IMPORT_SYNC_FAILED
+                : TOAST_MESSAGES.IMPORT_SUCCESS,
               duration: 3000,
             })
           );

--- a/src/tests/components/importGuard.test.tsx
+++ b/src/tests/components/importGuard.test.tsx
@@ -9,6 +9,8 @@ import {
   selectCategory,
 } from '../../redux/slices/settingsCategoryStateSlice';
 import { TabMasterContainer } from '../../redux/slices/tabContainerDataStateSlice';
+import { saveToFirestore } from '../../utils/functions/external';
+import { TOAST_MESSAGES } from '../../utils/constants/common';
 
 // KAN-27, the wiring half. local.test.ts proves readImportedContainer refuses an
 // oversized backup; these prove the import handler actually calls it, and that a
@@ -153,5 +155,57 @@ describe('import size guard (KAN-27)', () => {
       expect(store.getState().tabContainerDataState.tabGroups).toHaveLength(1);
     });
     expect(store.getState().globalState.toastText).toMatch(/successfully/i);
+  });
+});
+
+// KAN-43. The import handler dispatched saveToFirestoreIfDirty and immediately
+// claimed success, so a failed cloud write produced a centre-screen "Restored
+// tabs successfully!" at the same moment as the sync_problem glyph in the menu
+// bar. The two assertions below are the two halves of that contradiction: the
+// store really is in the error state, and the toast has to agree with it.
+describe('import sync failure (KAN-43)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // saveToFirestore is a bare vi.fn() from componentSetup rather than a spy,
+    // so restoreAllMocks does not necessarily clear an implementation set on
+    // it. Reset explicitly: a leaked rejection would turn the KAN-27 control
+    // test above red for the wrong reason.
+    vi.mocked(saveToFirestore).mockReset();
+  });
+
+  test('reports a sync failure rather than success when the cloud write rejects', async () => {
+    vi.mocked(saveToFirestore).mockRejectedValue(
+      new Error('permission-denied')
+    );
+
+    const inputs = captureFileInput();
+    const { store } = await renderDataManagement();
+
+    await userEvent.click(
+      await screen.findByText('Restore App Data from File')
+    );
+    dropFile(inputs[0], buildSmallBackup());
+
+    // The local half genuinely succeeded -- this is not data loss, and the
+    // message must not say the restore failed.
+    await waitFor(() => {
+      expect(store.getState().tabContainerDataState.tabGroups).toHaveLength(1);
+    });
+
+    // Proves the write actually failed, so the toast assertion below is not
+    // passing against a successful sync.
+    await waitFor(() => {
+      expect(store.getState().globalState.syncStatus).toBe('error');
+    });
+
+    await waitFor(() => {
+      expect(store.getState().globalState.toastText).toBe(
+        TOAST_MESSAGES.IMPORT_SYNC_FAILED
+      );
+    });
+
+    // isDirty stays set, so the next sync retries the write. That is why this
+    // is a warning about syncing and not an error about restoring.
+    expect(store.getState().globalState.isDirty).toBe(true);
   });
 });

--- a/src/utils/constants/common.ts
+++ b/src/utils/constants/common.ts
@@ -91,6 +91,12 @@ export const TOAST_MESSAGES = {
   // replaces it with a notification, and stays silent when the merge is a
   // no-op, which is the common case.
   SYNC_MERGED: 'Synced changes from another device.',
+  IMPORT_SUCCESS: 'Restored tabs successfully!',
+  // Deliberately not "Error restoring tabs": by the time the cloud write is
+  // attempted the restore has already succeeded on this device, so telling the
+  // user it failed would be as wrong as the success toast this replaces
+  // (KAN-43). isDirty stays set, so the next sync retries the write.
+  IMPORT_SYNC_FAILED: 'Restored on this device, but syncing failed.',
 };
 
 export const TOOLTIP_MESSAGES = {


### PR DESCRIPTION
Closes KAN-43.

## The bug

`handleImportJSON` dispatched `saveToFirestoreIfDirty()` and showed the success toast on the next line. The dispatch returns a promise that was never awaited, so a rejected cloud write resolved *after* `reader.onload` had already returned — outside the `try`, with "Restored tabs successfully!" already on screen. The user saw a centre-screen success message and a `sync_problem` glyph in the menu bar simultaneously.

Only this call site had the problem. The other `saveToFirestoreIfDirty()` caller (`utils/functions/external.ts:58`) sits in the permission/missing-document retry path and makes no claim to the user.

## The fix

`SettingsDetailsContainer.tsx` — make `reader.onload` async, await the thunk, and branch on `meta.requestStatus`.

Deliberately **not** `.unwrap()`: that throws into the existing `catch`, which would produce "Error restoring tabs: …". That message is the one thing that is definitely untrue here — `restoreContainer` has already written localStorage by this point, so the restore genuinely succeeded and only the cloud write failed. Hence a distinct message, localized across all 10 locales:

> Restored on this device, but syncing failed.

`isDirty` stays set either way, so a transient failure still self-heals on the next sync. This changes what the user is *told*, not what is persisted.

## Evidence

**Test written first, and watched fail** (`importGuard.test.tsx`, reusing the KAN-27 `captureFileInput` seam):

```
Expected: "Restored on this device, but syncing failed."
Received: "Restored tabs successfully!"
```

The `syncStatus === 'error'` assertion passed *before* the toast assertion failed — the reported contradiction, reproduced exactly.

**Mutation tested:**

| Mutation | Result |
|---|---|
| Revert to the unawaited `dispatch(...)` | KAN-43 test red |
| Invert the branch (`!== 'rejected'`) | KAN-43 test red **and** the KAN-27 success control red |

**Suite:** 311/311 (was 310), `tsc` 0 errors, eslint 0 errors / 28 warnings (unchanged baseline). `keyCoverage.test.ts` confirms the 10 locale files stayed in parity.

**Verified in the real built extension in Chrome, both directions:**

- *Offline* (a genuine `setDoc` rejection — the `firestore/lite` build has no offline write queue, so it really does reject): toast read "Restored on this device, but syncing failed.", and the menu-bar glyph sat steady on `sync_problem` for 12s.
- *Online*: "Restored tabs successfully!" — and the write was confirmed by clearing `localStorage` and reloading, which pulled the imported session back **from Firestore** with a `cloud_done` glyph.

Both outcomes from the same setup, so the probe can distinguish them.

## Found while verifying — filed as KAN-48

`restoreContainer` (`tabContainerDataStateSlice.ts:738`) does `action.payload.deletedTabGroups?.map(...)`, which writes an **explicit** `deletedTabGroups: undefined` key when the imported backup lacks the field. `JSON.stringify` drops such a key but Firestore's `setDoc` rejects it outright:

```
Unsupported field value: undefined (found in field deletedTabGroups ...)
```

So the first sync after importing a pre-tombstone backup always fails. It self-heals (the next merge re-populates the field, and I verified the data does reach the cloud), which is why it's P3 and not folded into this PR — but it is the most likely real-world trigger for the new toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)