### PR TITLE
Default deletedTabGroups when restoring a container (KAN-48)

### DIFF
--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -735,12 +735,22 @@ export const tabContainerDataStateSlice = createSlice({
             lastModified: Math.max(Date.now(), buriedAt + 1),
           };
         }),
-        deletedTabGroups: action.payload.deletedTabGroups?.map((grave) => {
-          const aliveAt = liveAt.get(grave.tabGroupId);
-          if (aliveAt === undefined) return grave;
-          // Same reasoning, other way round.
-          return { ...grave, deletedAt: Math.max(Date.now(), aliveAt + 1) };
-        }),
+        // `?? []` before the map, not `?.map`. The optional call yields
+        // undefined for a payload with no tombstones - a backup exported before
+        // they existed - but the key is still written, and an explicit
+        // `deletedTabGroups: undefined` is not the same as an absent key.
+        // JSON.stringify erases that difference; Firestore does not. setDoc
+        // walks own enumerable properties and rejects undefined values, so the
+        // next cloud write failed with "Unsupported field value: undefined"
+        // (KAN-48).
+        deletedTabGroups: (action.payload.deletedTabGroups ?? []).map(
+          (grave) => {
+            const aliveAt = liveAt.get(grave.tabGroupId);
+            if (aliveAt === undefined) return grave;
+            // Same reasoning, other way round.
+            return { ...grave, deletedAt: Math.max(Date.now(), aliveAt + 1) };
+          }
+        ),
       };
 
       // update localstorage

--- a/src/tests/redux/tabContainerReducers.test.ts
+++ b/src/tests/redux/tabContainerReducers.test.ts
@@ -31,6 +31,7 @@ import reducer, {
   deleteTabContainerInternal,
   deleteWindowInternal,
   deleteTabInternal,
+  restoreContainer,
 } from '../../redux/slices/tabContainerDataStateSlice';
 import type {
   tabContainerData,
@@ -266,5 +267,55 @@ describe('every content mutation stamps its session', () => {
 
     expect(s.tabGroups).toEqual([]);
     expect(s.deletedTabGroups!.map((t) => t.tabGroupId)).toEqual(['a']);
+  });
+});
+
+// KAN-48. Firestore's setDoc walks own enumerable properties and rejects any
+// whose value is `undefined` -- an explicit `key: undefined` is not the same as
+// an absent key, even though JSON.stringify erases the difference. So a reducer
+// that writes one silently poisons the next cloud write.
+describe('restoreContainer produces a Firestore-writable container', () => {
+  beforeEach(() => localStorage.clear());
+
+  // A backup exported before tombstones existed: no deletedTabGroups field at
+  // all. This is exactly what "Restore App Data from File" is for.
+  const legacyBackup = (): TabMasterContainer => ({
+    lastModified: 2,
+    selectedTabGroupId: null,
+    tabGroups: [group('a')],
+  });
+
+  it('defaults a missing deletedTabGroups to an empty array', () => {
+    const state = reducer(base(), restoreContainer(legacyBackup()));
+
+    expect(state.deletedTabGroups).toEqual([]);
+  });
+
+  // Broader than the case above, and stated the way Firestore states it: the
+  // constraint is "no field is undefined", not "deletedTabGroups is an array".
+  // Any future optional field spread through this reducer fails here too,
+  // rather than being found again in a console warning.
+  it('leaves no explicitly-undefined field for setDoc to reject', () => {
+    const state = reducer(base(), restoreContainer(legacyBackup()));
+
+    const undefinedKeys = Object.keys(state).filter(
+      (key) => state[key as keyof TabMasterContainer] === undefined
+    );
+    expect(undefinedKeys).toEqual([]);
+  });
+
+  // The control: a backup that does carry tombstones must still keep them,
+  // otherwise "default it to []" could be implemented by discarding them.
+  it('keeps tombstones that the backup does carry', () => {
+    const withGraves: TabMasterContainer = {
+      ...legacyBackup(),
+      deletedTabGroups: [{ tabGroupId: 'gone', deletedAt: 5 }],
+    };
+
+    const state = reducer(base(), restoreContainer(withGraves));
+
+    expect(state.deletedTabGroups).toEqual([
+      { tabGroupId: 'gone', deletedAt: 5 },
+    ]);
   });
 });


### PR DESCRIPTION
Closes KAN-48. Found while verifying KAN-43 (#146) in the real extension.

## The bug

`restoreContainer` (`tabContainerDataStateSlice.ts:738`) built its result with:

```ts
deletedTabGroups: action.payload.deletedTabGroups?.map(...)
```

For a backup carrying no tombstones — one exported before they existed, which is exactly what "Restore App Data from File" is for — the optional call yields `undefined`, **but the key is still written**. An explicit `deletedTabGroups: undefined` is not the same as an absent key: `JSON.stringify` erases the difference, Firestore does not. `setDoc` walks own enumerable properties and rejects undefined values, so the first cloud write after such an import always failed:

```
Error updating Firestore: Function setDoc() called with invalid data.
Unsupported field value: undefined (found in field deletedTabGroups ...)
```

`initialState` has no such key and `mergeTabContainers` always emits one, so ordinary state is unaffected — the poison only enters through an imported file.

## The fix

Move the default ahead of the map: `(action.payload.deletedTabGroups ?? []).map(...)`. `[]` is the shape the rest of the sync path already expects.

## Evidence

**Three tests written first** (`tabContainerReducers.test.ts`), two watched fail:

```
expected undefined to deeply equal []
expected [ 'deletedTabGroups' ] to deeply equal []
```

The second states the constraint the way Firestore states it — *no field is undefined* — so any future optional field spread through this reducer fails here rather than in a console warning.

**Mutation tested:**

| Mutation | Result |
|---|---|
| Restore `?.map` | Both new tests red |
| Implement the default as a hardcoded `[]` | The tombstone-preserving control red |

**Suite:** 314/314 (was 311), tsc 0 errors, eslint 0 errors / 28 warnings (unchanged).

**Verified in the real built extension.** The byte-for-byte backup shape that produced KAN-43's "Restored on this device, but syncing failed." now reports "Restored tabs successfully!" with an empty console, and clearing `localStorage` and reloading brings the session back **from Firestore** with a `cloud_done` indicator — so the write landed on the first attempt, not via the self-healing second sync.

## Relationship to KAN-43

KAN-43 made this visible (it was previously masked by an unconditional success toast). This removes the most likely real-world trigger for that new warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)