### PR TITLE
Release 1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,23 @@ Tab Keeper is an intuitive Chrome extension crafted to redefine the way users sa
 
 ## Changelog
 
-### v.1.4.0 (Latest)
+### v.1.4.1 (Latest)
+
+#### Fixes
+
+- Search results now show a window's own title when only its tabs match, instead of borrowing the title of one of those tabs
+- Collapsing or renaming a window no longer affects the wrong row after a window or tab is added to a session
+- Switching themes now applies the new colors immediately instead of fading through the old ones, and the scrollbar changes with them
+- The Auto Sync button no longer flashes as you move between settings sections
+- A backup too large to sync is now refused when you restore it, with an explanation, instead of being loaded and leaving sync stuck
+- Restoring a backup now tells you when it could not be saved to the cloud, instead of always reporting success
+- Restoring a backup saved by an older version no longer fails to sync on its first attempt
+
+#### Improvements
+
+- Dependent packages updated to latest versions
+
+### v.1.4.0
 
 #### Features
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Justine George",
   "description": "Efficiently save and synchronize tabs across devices without the need for personal logins.",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "name": "Tab Keeper - Chrome Tab Manager & Sync Tool",
   "description": "Efficiently save and synchronize tabs across devices without the need for personal logins.",
   "action": {


### PR DESCRIPTION
Seven user-facing fixes merged since `v1.4.0`, no features — so a PATCH bump.

## Version

Both files bumped `1.4.0` → `1.4.1`, edited surgically (one line each, no reformatting):

- `package.json` — the README badge reads it
- `public/manifest.json` — the release workflow reads it at `build_and_release_artifact.yaml:33-36` to name the artifact

## Changelog

Added to `README.md`, and verbatim identical to `Changelog.md` in the wiki repo (pushed separately — the wiki is its own repo). Diffed to confirm byte equality.

| Ticket | Changelog line |
|---|---|
| KAN-23 | Search results show a window's own title when only its tabs match |
| KAN-28 | Collapse/rename state no longer attaches to the wrong row after adding a window or tab |
| KAN-22 | Theme switch applies immediately; scrollbar follows |
| KAN-44 | Auto Sync button no longer flashes between settings sections |
| KAN-27 | An over-large backup is refused on restore, with an explanation |
| KAN-43 | Restore reports when the cloud write failed, instead of always claiming success |
| KAN-48 | Restoring an older backup no longer fails to sync on its first attempt |

## Deliberately omitted from the changelog

**KAN-45**, though its `pending-release` label clears with this release. Its guard prevents a throw that only `js-base64` 3.9.3 produces; 1.4.0 shipped 3.7.5, which decoded malformed input to garbage rather than rejecting it. So relative to 1.4.0 there is no user-visible change — it stops a regression the dependency bump would otherwise have introduced. Same reasoning as KAN-31/KAN-34 in 1.4.0.

Also not in the changelog, as they never reach users: KAN-2 (test infrastructure), KAN-16/39 (unreachable crash), KAN-47 (Redux Toolkit 2), and the dependabot bumps — the last of which are covered by the standing "Dependent packages updated to latest versions" line.

## Verification

- `npm run build` emits `dist/manifest.json` with `"version": "1.4.1"`
- 314/314 tests, `tsc` 0 errors
- Each of the eight `pending-release` tickets confirmed present on `main` after `v1.4.0` via `git log v1.4.0..main`

Tagging is deliberately not part of this PR — `v1.4.1` gets pushed after merge, which is what triggers the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)