### PR TITLE
Order sessions by the instant they were created (KAN-25)

### DIFF
--- a/src/components/home/leftpane/TabGroupEntry.tsx
+++ b/src/components/home/leftpane/TabGroupEntry.tsx
@@ -41,7 +41,7 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
   const handleMouseEnter = () => setIsHovered(true);
   const handleMouseLeave = () => setIsHovered(false);
 
-  const { title, createdTime, windowCount, tabCount, isSelected } =
+  const { title, createdTime, createdAt, windowCount, tabCount, isSelected } =
     tabGroupData;
 
   function handleKeyPress(e: React.KeyboardEvent<HTMLDivElement>) {
@@ -120,7 +120,9 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
             margin-top: 5px;
           `}
         >
-          {getPrettyDate(createdTime)}
+          {/* createdAt is the instant; createdTime is a local wall clock with
+              no offset, kept only for sessions saved before createdAt. */}
+          {getPrettyDate(createdAt ?? createdTime)}
         </div>
       </div>
       {!isSearchPanel && (

--- a/src/components/home/rightpane/HeroContainerRight.tsx
+++ b/src/components/home/rightpane/HeroContainerRight.tsx
@@ -96,7 +96,7 @@ export default function HeroContainerRight() {
     setEditableTitle(e.target.value);
   };
 
-  const { tabGroupId, title, createdTime, windowCount, tabCount } =
+  const { tabGroupId, title, createdTime, createdAt, windowCount, tabCount } =
     selectedTabGroup;
 
   const handleAddCurrWindowClick = async () => {
@@ -248,7 +248,9 @@ export default function HeroContainerRight() {
           style={`padding-top: 2px; padding-left: 8px;`}
         />
         <NormalLabel
-          value={getPrettyDate(createdTime)}
+          // createdAt is the instant; createdTime is a local wall clock with no
+          // offset, kept only for sessions saved before createdAt existed.
+          value={getPrettyDate(createdAt ?? createdTime)}
           size="0.7rem"
           color={COLORS.LABEL_L2_COLOR}
           style="padding-top: 2px; padding-left: 8px;"

--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -42,8 +42,15 @@ export interface windowGroupData {
 
 export interface tabContainerData {
   tabGroupId: string;
-  title: string;
+  // Local wall clock at save time, with no offset recorded, so it cannot be
+  // compared across timezones. Kept for display of rows written before
+  // createdAt existed; createdAt is the field to order and reason on.
   createdTime: string;
+  // The instant the session was saved. Optional because every session stored
+  // before this change lacks it; readers fall back to reading createdTime as
+  // UTC. See createdInstant in mergeTabData.ts.
+  createdAt?: number;
+  title: string;
   windowCount: number;
   tabCount: number;
   isAutoSave: boolean;
@@ -396,6 +403,16 @@ function touch(group: tabContainerData): void {
   group.lastModified = Date.now();
 }
 
+// createdTime and createdAt are the same moment in two formats - a local wall
+// clock for display, and the instant the merge orders on. They are written
+// together, through this, so a reader can never catch them describing
+// different moments.
+function stampCreated(group: tabContainerData): void {
+  const now = new Date();
+  group.createdTime = getStringDate(now);
+  group.createdAt = now.getTime();
+}
+
 // A removed session has to leave a trace, or the device that still holds it
 // re-adds it on the next merge and the user can never delete it anywhere.
 // Re-deleting an id refreshes its timestamp rather than appending a duplicate.
@@ -460,7 +477,7 @@ export const tabContainerDataStateSlice = createSlice({
       if (tabGroupIndex !== -1) {
         state.tabGroups[tabGroupIndex].windowCount += 1;
         state.tabGroups[tabGroupIndex].tabCount += window.tabCount;
-        state.tabGroups[tabGroupIndex].createdTime = getStringDate(new Date());
+        stampCreated(state.tabGroups[tabGroupIndex]);
         state.tabGroups[tabGroupIndex].windows.unshift(window);
         touch(state.tabGroups[tabGroupIndex]);
       }
@@ -487,9 +504,7 @@ export const tabContainerDataStateSlice = createSlice({
         if (windowIndex !== -1) {
           // increment tab count of tabGroup and windowGroup
           state.tabGroups[tabGroupIndex].tabCount += 1;
-          state.tabGroups[tabGroupIndex].createdTime = getStringDate(
-            new Date()
-          );
+          stampCreated(state.tabGroups[tabGroupIndex]);
           state.tabGroups[tabGroupIndex].windows[windowIndex].tabCount += 1;
           // add to windowGroup
           state.tabGroups[tabGroupIndex].windows[windowIndex].tabs.unshift(
@@ -581,9 +596,7 @@ export const tabContainerDataStateSlice = createSlice({
         if (windowIndex !== -1) {
           // decrement tabGroup's window count by 1
           state.tabGroups[tabGroupIndex].windowCount -= 1;
-          state.tabGroups[tabGroupIndex].createdTime = getStringDate(
-            new Date()
-          );
+          stampCreated(state.tabGroups[tabGroupIndex]);
           // decrement tabGroup's tab count by tab count of the window that's been deleted
           state.tabGroups[tabGroupIndex].tabCount -=
             state.tabGroups[tabGroupIndex].windows[windowIndex].tabCount;
@@ -631,9 +644,7 @@ export const tabContainerDataStateSlice = createSlice({
             // decrement window's and tabGroup's tab count by 1
             state.tabGroups[tabGroupIndex].windows[windowIndex].tabCount -= 1;
             state.tabGroups[tabGroupIndex].tabCount -= 1;
-            state.tabGroups[tabGroupIndex].createdTime = getStringDate(
-              new Date()
-            );
+            stampCreated(state.tabGroups[tabGroupIndex]);
 
             state.tabGroups[tabGroupIndex].windows[windowIndex].tabs.splice(
               tabIndex,

--- a/src/tests/components/HeroContainerRight.test.tsx
+++ b/src/tests/components/HeroContainerRight.test.tsx
@@ -3,6 +3,7 @@ import { screen } from '@testing-library/react';
 
 import HeroContainerRight from '../../components/home/rightpane/HeroContainerRight';
 import { renderWithProviders } from '../setup/renderWithProviders';
+import { getPrettyDate } from '../../utils/functions/local';
 import {
   openSearchPanel,
   setSearchInputText,
@@ -45,6 +46,31 @@ const buildSession = () => ({
 });
 
 describe('HeroContainerRight', () => {
+  // KAN-25. createdTime is a local wall clock with no offset, so it cannot be
+  // trusted once a session crosses timezones. createdAt is the instant, and the
+  // date on screen has to come from it whenever it is there. The two are given
+  // deliberately different values so a component still reading createdTime
+  // cannot accidentally pass.
+  test('renders the date from createdAt, not the stored wall clock', async () => {
+    const session = {
+      ...buildSession(),
+      createdTime: '2026-08-31 09:00:00',
+      createdAt: Date.UTC(2027, 2, 4, 12, 0, 0),
+    };
+
+    await renderWithProviders(<HeroContainerRight />, {
+      seedStore: (store) => {
+        store.dispatch(saveToTabContainerInternal(session));
+        store.dispatch(selectTabContainer('group-1'));
+      },
+    });
+
+    expect(
+      await screen.findByText(getPrettyDate(session.createdAt))
+    ).toBeTruthy();
+    expect(screen.queryByText(getPrettyDate('2026-08-31 09:00:00'))).toBeNull();
+  });
+
   test('renders the selected session title', async () => {
     await renderWithProviders(<HeroContainerRight />, {
       seedStore: (store) => {

--- a/src/tests/config/firestoreRoundTrip.test.ts
+++ b/src/tests/config/firestoreRoundTrip.test.ts
@@ -41,7 +41,11 @@ describe('the Firestore read preserves the whole container', () => {
   const stored = {
     lastModified: 1000,
     selectedTabGroupId: 'a',
-    tabGroups: [{ tabGroupId: 'a', lastModified: 1000 }],
+    // createdAt rides inside tabGroups, which the read passes through wholesale,
+    // so this passes today. It is here to fail the day someone rebuilds sessions
+    // field by field the way the container itself is rebuilt - the same mistake
+    // that dropped deletedTabGroups, one level down.
+    tabGroups: [{ tabGroupId: 'a', lastModified: 1000, createdAt: 1000 }],
     deletedTabGroups: [{ tabGroupId: 'gone', deletedAt: 900 }],
   };
 

--- a/src/tests/redux/tabContainerReducers.test.ts
+++ b/src/tests/redux/tabContainerReducers.test.ts
@@ -319,3 +319,97 @@ describe('restoreContainer produces a Firestore-writable container', () => {
     ]);
   });
 });
+
+// KAN-25. Four reducers restamp createdTime to "now". Each has to restamp
+// createdAt too, or the instant drifts away from the wall clock beside it and
+// the merge orders the session by a moment that has already passed.
+describe('createdAt restamping', () => {
+  beforeEach(() => localStorage.clear());
+
+  const seeded = (): TabMasterContainer => {
+    const g = group('a');
+    g.createdAt = 1_000;
+    g.windows.push({
+      windowId: 'w2',
+      windowHeight: 100,
+      windowWidth: 100,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 1,
+      title: 't',
+      tabs: [{ tabId: 'extra', favicon: '', title: 't', url: 'https://b.co' }],
+    });
+    g.windowCount = 2;
+    g.tabCount = 2;
+    return reducer(base(), saveToTabContainerInternal(g));
+  };
+
+  const newWindow = {
+    windowId: 'w3',
+    windowHeight: 100,
+    windowWidth: 100,
+    windowOffsetTop: 0,
+    windowOffsetLeft: 0,
+    tabCount: 1,
+    title: 't',
+    tabs: [{ tabId: 'n', favicon: '', title: 't', url: 'https://c.co' }],
+  };
+
+  const cases: [string, () => TabMasterContainer][] = [
+    [
+      'adding a window',
+      () =>
+        reducer(
+          seeded(),
+          addCurrWindowToTabGroupInternal({
+            tabGroupId: 'a',
+            window: newWindow,
+          })
+        ),
+    ],
+    [
+      'adding a tab',
+      () =>
+        reducer(
+          seeded(),
+          addCurrTabToWindowInternal({
+            tabGroupId: 'a',
+            windowId: 'w-a',
+            tabData: {
+              tabId: 'n',
+              favicon: '',
+              title: 't',
+              url: 'https://c.co',
+            },
+          })
+        ),
+    ],
+    [
+      'deleting a window',
+      () =>
+        reducer(
+          seeded(),
+          deleteWindowInternal({ tabGroupId: 'a', windowId: 'w2' })
+        ),
+    ],
+    [
+      'deleting a tab',
+      () =>
+        reducer(
+          seeded(),
+          deleteTabInternal({ tabGroupId: 'a', windowId: 'w-a', tabId: 't-a' })
+        ),
+    ],
+  ];
+
+  it.each(cases)('%s restamps createdAt', (_label, act) => {
+    const before = Date.now();
+    const after = act();
+    const stamped = byId(after, 'a').createdAt;
+
+    expect(stamped).not.toBe(1_000);
+    expect(typeof stamped).toBe('number');
+    expect(stamped!).toBeGreaterThanOrEqual(before);
+    expect(stamped!).toBeLessThanOrEqual(Date.now());
+  });
+});

--- a/src/tests/utils/functions/capture.test.ts
+++ b/src/tests/utils/functions/capture.test.ts
@@ -161,6 +161,24 @@ describe('captureOpenWindows against the chrome fake', () => {
     expect(captured!.windows[0].tabs.map((tab) => tab.url)).toEqual([A, B]);
   });
 
+  // KAN-25. A newly captured session is the one case where both timestamps are
+  // written from scratch, so it is where they must agree.
+  test('stamps the capture instant alongside the display string', async () => {
+    handle = setupChromeFake({
+      windows: [
+        { id: 1, tabs: [{ id: 1, url: A, title: 'A' }] as chrome.tabs.Tab[] },
+      ],
+    });
+
+    const before = Date.now();
+    const captured = await captureOpenWindows('probe');
+
+    expect(captured).not.toBeNull();
+    expect(typeof captured!.createdAt).toBe('number');
+    expect(captured!.createdAt!).toBeGreaterThanOrEqual(before);
+    expect(captured!.createdAt!).toBeLessThanOrEqual(Date.now());
+  });
+
   test('captures a tab added through tabs.create', async () => {
     handle = setupChromeFake({ windows: [{ id: 1 }] });
 

--- a/src/tests/utils/functions/local.test.ts
+++ b/src/tests/utils/functions/local.test.ts
@@ -481,6 +481,51 @@ describe('isValidTabMasterContainer', () => {
     expect(isValidTabMasterContainer(validData)).toBe(true);
   });
 
+  // KAN-25. createdAt is the key the merge sorts sessions on, so a non-number
+  // reaching the store would make every comparison against it NaN and leave the
+  // list order dependent on input order. Absent must stay valid: every session
+  // saved before createdAt existed lacks it.
+  describe('createdAt', () => {
+    const withCreatedAt = (group: Record<string, unknown>) => ({
+      lastModified: 1,
+      selectedTabGroupId: null,
+      tabGroups: [
+        {
+          tabGroupId: 'g',
+          title: 't',
+          createdTime: '2023-10-17 22:01:23',
+          windowCount: 0,
+          tabCount: 0,
+          isAutoSave: false,
+          isSelected: false,
+          windows: [],
+          ...group,
+        },
+      ],
+    });
+
+    test('accepts a session with no createdAt', () => {
+      expect(isValidTabMasterContainer(withCreatedAt({}))).toBe(true);
+    });
+
+    test('accepts a numeric createdAt', () => {
+      expect(isValidTabMasterContainer(withCreatedAt({ createdAt: 1 }))).toBe(
+        true
+      );
+    });
+
+    test.each([
+      ['a string', '1788171081798'],
+      ['null', null],
+      ['an object', {}],
+      ['a boolean', true],
+    ])('rejects createdAt that is %s', (_label, createdAt) => {
+      expect(isValidTabMasterContainer(withCreatedAt({ createdAt }))).toBe(
+        false
+      );
+    });
+  });
+
   // Tombstones arrived with the automatic merge. The merge iterates this list
   // and writes the result back to Firestore, so a malformed value must be
   // rejected here rather than walked - a string would be iterated character by

--- a/src/tests/utils/functions/mergeTabData.test.ts
+++ b/src/tests/utils/functions/mergeTabData.test.ts
@@ -482,3 +482,77 @@ describe('mergeTabContainers - the flags describe what is written', () => {
     expect(r.changedFromCloud).toBe(true);
   });
 });
+
+// KAN-25. createdTime is a local wall clock with no offset recorded, so two
+// devices in different zones write strings that cannot be compared to each
+// other. createdAt is the instant, and it is what the order must follow.
+describe('createdAt ordering', () => {
+  const at = (id: string, createdAt: number, createdTime: string) => ({
+    ...group(id, 1),
+    createdAt,
+    createdTime,
+  });
+
+  it('orders by the instant, not by the local wall clock string', () => {
+    // 'tokyo' was saved an hour later in real time, but its local clock read
+    // 06:00 while 'la' read 20:00 the same day. Comparing the strings puts
+    // 'la' on top; comparing the instants puts 'tokyo' there, which is right.
+    const { merged } = mergeTabContainers(
+      container(30, [
+        at('la', Date.UTC(2026, 8, 1, 4, 0, 0), '2026-09-01 20:00:00'),
+        at('tokyo', Date.UTC(2026, 8, 1, 5, 0, 0), '2026-09-01 06:00:00'),
+      ]),
+      container(20, []),
+      NOW
+    );
+    expect(ids(merged)).toEqual(['tokyo', 'la']);
+  });
+
+  it('reads a legacy row with no createdAt as UTC', () => {
+    // The offset was never recorded, so it cannot be recovered. Reading the
+    // string as UTC is wrong by at most the writer's offset but is identically
+    // wrong on every device, which is what keeps two devices agreeing. Reading
+    // it as local time instead would make this order depend on $TZ.
+    const { merged } = mergeTabContainers(
+      container(30, [
+        { ...group('legacy', 1), createdTime: '2026-09-01 12:00:00' },
+        at('newer', Date.UTC(2026, 8, 1, 13, 0, 0), '2026-09-01 06:00:00'),
+        at('older', Date.UTC(2026, 8, 1, 11, 0, 0), '2026-09-01 23:00:00'),
+      ]),
+      container(20, []),
+      NOW
+    );
+    expect(ids(merged)).toEqual(['newer', 'legacy', 'older']);
+  });
+
+  it('leaves the order of legacy-only rows unchanged', () => {
+    // Regression guard: the overwhelming majority of stored sessions have no
+    // createdAt, and their relative order must not shift under the new key.
+    const legacy = (id: string, createdTime: string) => ({
+      ...group(id, 1),
+      createdTime,
+    });
+    const { merged } = mergeTabContainers(
+      container(30, [
+        legacy('old', '2026-08-01 00:00:00'),
+        legacy('new', '2026-08-30 00:00:00'),
+        legacy('mid', '2026-08-20 00:00:00'),
+      ]),
+      container(20, []),
+      NOW
+    );
+    expect(ids(merged)).toEqual(['new', 'mid', 'old']);
+  });
+
+  it('sorts an unparseable createdTime last instead of poisoning the order', () => {
+    const { merged } = mergeTabContainers(
+      container(30, [
+        { ...group('corrupt', 1), createdTime: 'not a date' },
+        { ...group('fine', 1), createdTime: '2026-08-01 00:00:00' },
+      ]),
+      container(20, []),
+      NOW
+    );
+    expect(ids(merged)).toEqual(['fine', 'corrupt']);
+  });
+});

--- a/src/utils/functions/capture.ts
+++ b/src/utils/functions/capture.ts
@@ -98,10 +98,15 @@ export async function captureOpenWindows(
 
   if (windowsGroupData.length === 0) return null;
 
+  // One `now` for both: read the clock twice and a capture that straddles a
+  // second boundary writes a display string and an instant that disagree.
+  const now = new Date();
+
   return {
     tabGroupId: uuidv4(),
     title,
-    createdTime: getStringDate(new Date()),
+    createdTime: getStringDate(now),
+    createdAt: now.getTime(),
     windowCount: windowsGroupData.length,
     tabCount,
     isAutoSave: false,

--- a/src/utils/functions/local.ts
+++ b/src/utils/functions/local.ts
@@ -542,6 +542,10 @@ const isValidTabContainerData = (data: unknown): data is tabContainerData => {
     typeof data.tabGroupId === 'string' &&
     typeof data.title === 'string' &&
     typeof data.createdTime === 'string' &&
+    // Absent is valid - every session saved before createdAt existed lacks it.
+    // Present but not a number is not: the merge sorts on this, and NaN makes
+    // every comparison against it false, leaving the order up to input order.
+    (data.createdAt === undefined || typeof data.createdAt === 'number') &&
     typeof data.windowCount === 'number' &&
     typeof data.tabCount === 'number' &&
     typeof data.isAutoSave === 'boolean' &&

--- a/src/utils/functions/mergeTabData.ts
+++ b/src/utils/functions/mergeTabData.ts
@@ -42,7 +42,32 @@ function sessionTimestamp(
 const compareAsc = (a: string, b: string): number =>
   a < b ? -1 : a > b ? 1 : 0;
 
-const compareDesc = (a: string, b: string): number => compareAsc(b, a);
+const LEGACY_CREATED_TIME = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/;
+
+// The instant a session was created, for ordering.
+//
+// createdAt is that instant outright. Sessions saved before it existed have
+// only createdTime, a local wall clock written with no offset, so the moment it
+// refers to is genuinely unrecoverable. Those are read as UTC: wrong by however
+// far the writer was from UTC, but wrong the *same way* on every device, which
+// is what keeps two devices agreeing on the order. Reading them as local time
+// instead would make the merge result depend on the reader's timezone.
+//
+// Two legacy rows still order exactly as they did when this compared the raw
+// strings, because reading a zero-padded `YYYY-MM-DD HH:MM:SS` as UTC is
+// monotonic in the string.
+export function createdInstant(group: tabContainerData): number {
+  if (typeof group.createdAt === 'number') return group.createdAt;
+
+  const parts = LEGACY_CREATED_TIME.exec(group.createdTime);
+  // Anything else is corrupt: sort it last rather than returning NaN, which
+  // would make every comparison involving it false and leave the sort's output
+  // dependent on the input order.
+  if (!parts) return 0;
+
+  const [, year, month, day, hour, minute, second] = parts.map(Number);
+  return Date.UTC(year, month - 1, day, hour, minute, second);
+}
 
 type Event =
   | { kind: 'present'; at: number; group: tabContainerData }
@@ -161,18 +186,19 @@ export function mergeTabContainers(
       survivors.push({ ...event.group, lastModified: event.at });
     }
   }
-  // Ordered by createdTime, not lastModified, because createdTime is the date
-  // the UI displays. Sorting by edit time while showing save time sent a
-  // renamed session to the top of the list, above sessions whose visible dates
-  // were newer - the list read Aug 1, Aug 30, Aug 29.
+  // Ordered by creation, not lastModified, because creation is what the UI
+  // displays. Sorting by edit time while showing save time sent a renamed
+  // session to the top of the list, above sessions whose visible dates were
+  // newer - the list read Aug 1, Aug 30, Aug 29.
   //
-  // Plain comparisons rather than localeCompare: the two devices have to agree
-  // on the order, and localeCompare varies with the device's locale.
-  // tabGroupId breaks exact ties so the result is total and stable.
-  // getStringDate zero-pads, so `YYYY-MM-DD HH:MM:SS` sorts correctly as text.
+  // The key is the instant (createdInstant), not the createdTime string. Two
+  // devices in different timezones write different wall clocks for the same
+  // moment, so comparing the strings ordered them by where the user was rather
+  // than by when they saved. tabGroupId breaks exact ties so the result is
+  // total and stable.
   survivors.sort(
     (a, b) =>
-      compareDesc(a.createdTime, b.createdTime) ||
+      createdInstant(b) - createdInstant(a) ||
       compareAsc(a.tabGroupId, b.tabGroupId)
   );
 


### PR DESCRIPTION
## What this changes

`createdTime` is a local wall clock written with no offset recorded, so it cannot be compared across timezones. `mergeTabData` sorted the session list on that string directly (`compareDesc`, a raw lexicographic compare), which meant the order followed *where* the user was rather than *when* they saved.

This adds **`createdAt`**, an epoch-ms instant, alongside it:

- **Sort** — `mergeTabData` now orders on `createdInstant()`: `createdAt` when present, otherwise the legacy string read as UTC.
- **Display** — `TabGroupEntry` and `HeroContainerRight` render `createdAt ?? createdTime`, so a session saved in one timezone reads correctly in another.
- **Write** — `createdTime` and `createdAt` are written together, through `stampCreated()` in the slice and a single `now` in `captureOpenWindows`, so a reader cannot catch them describing different moments.
- **Validate** — the import validator rejects a non-numeric `createdAt`. It is the sort key, and `NaN` makes every comparison against it false, leaving the order dependent on input order.

`createdTime` itself is unchanged, so nothing that reads it changes and no stored row needs migrating.

## Why not the one-liner the ticket proposed

KAN-25 proposed changing `getStringDate` to `toISOString()`. That puts two formats into a lexicographic sort: the separator at index 10 goes from `' '` (0x20) to `'T'` (0x54), so under the descending sort **any ISO row outranks a same-day legacy row regardless of which is actually newer**. Extensions update per device, so both formats really do coexist while a merge runs across them.

Demonstrated with the real comparators before writing any code — truth is `A-late (23:30) > B-mid (14:00) > A-early (09:00)`:

```
CONTROL - all rows in current format
   order: A-late > B-mid > A-early     CORRECT

EXPERIMENT - mixed formats after toISOString()
   order: B-mid > A-late > A-early     WRONG -- list is misordered
```

The control is the point: same harness, same comparators, correct on today's format. That is the regression class KAN-32 already fixed once (`mergeTabData.ts:164-167`, the list reading "Aug 1, Aug 30, Aug 29").

The ticket also claimed `createdTime` was "display-only (never used in logic/sorting/comparison)" and listed `ConflictModal.tsx` in its change surface. The first is false — `mergeTabData.ts:175`. The second no longer exists; it was deleted in `7d1b38f` (KAN-32, #124).

## Why legacy rows are read as UTC, not local

The writer's offset was never recorded and is unrecoverable. Reading legacy strings as UTC is wrong by that offset, but **identically wrong on every device** — which is what keeps two devices agreeing on the order. Reading them as local time would make the merge result depend on the reader's `$TZ`, breaking the invariant recorded at `mergeTabData.ts:169-171`. Two legacy rows still order exactly as before, because reading a zero-padded `YYYY-MM-DD HH:MM:SS` as UTC is monotonic in the string.

## Semantics

The date label changes meaning from "the wall clock where I saved it" to "that instant, in my current timezone". **For a single-timezone user these are identical**; they differ only for a user who saves in one zone and reads in another, which is the case being fixed. Confirmed as the intended behaviour before implementing.

## Tests — 314 → 330

Every test below was written first and watched fail. One of them (`orders by the instant...`) passed on the first attempt because I had built the scenario backwards so the string order already agreed with the instant order; it was rewritten until it failed for the right reason.

| Test | Failed before as |
|---|---|
| `orders by the instant, not by the local wall clock string` | `['la','tokyo']` vs `['tokyo','la']` |
| `reads a legacy row with no createdAt as UTC` | `['older','legacy','newer']` vs `['newer','legacy','older']` |
| `sorts an unparseable createdTime last instead of poisoning the order` | `['corrupt','fine']` vs `['fine','corrupt']` |
| `leaves the order of legacy-only rows unchanged` | regression guard — passes both sides by design |
| 4x `... restamps createdAt` (add window/tab, delete window/tab) | `expected 1000 not to be 1000` |
| `stamps the capture instant alongside the display string` | `expected 'undefined' to be 'number'` |
| `renders the date from createdAt, not the stored wall clock` | `Unable to find ... Mar 4, 2027 at 4:00:00 AM` |
| 4x `rejects createdAt that is a string/null/an object/a boolean` | `expected true to be false` |

`firestoreRoundTrip` gains `createdAt` in its fixture. That one passes today — `tabGroups` is passed through wholesale — and is there to fail the day someone rebuilds sessions field-by-field the way the container itself is, the same mistake that dropped `deletedTabGroups` one level up.

```
Test Files  34 passed (34)
     Tests  330 passed (330)
tsc: 0 errors
eslint: 0 errors, 28 warnings (unchanged from main)
```

## Verified in the real extension

Built the shipping artifact (remote-URL strip applied), loaded it, and drove the real popup page.

Saving a session through the UI stamped `createdAt: 1788308983189` (`2026-09-02T00:29:43.189Z` = 17:29:43 PDT), agreeing with its `createdTime` of `2026-09-01 17:29:43` to within a second.

Then the control — the two fields were deliberately driven apart on one session (`createdTime: '2026-01-02 03:04:05'`, `createdAt: Date.UTC(2031,6,9,20,0,0)`) to see which one the built artifact reads:

```
datesOnScreen:          ["Jul 9, 2031 at 1:00:00 PM", "Sept 1, 2026 at 1:55:00 PM"]
followsInstant_2031:    true
followsWallClock_Jan2026: false
```

The screen followed `createdAt` (20:00 UTC rendered as 13:00 PDT), not the wall-clock string beside it. The second row is a genuinely legacy session with no `createdAt`, still rendering from its string — so both the instant path and the fallback were confirmed in the same load. Order correct, console clean apart from the pre-existing cross-world preload warning.

First attempt at that control failed to prove anything: the Firestore sync overwrote the tampered `localStorage` on reload, so the screen showed the original values. Re-run offline, where the write survives.

Test data was restored and the network re-enabled afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)