### PR TITLE
Apply the icon's label spacing in Button (KAN-26)

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -53,7 +53,20 @@ const Button: React.FC<ButtonProps> = ({
     ${style && style}
   `;
 
-  iconStyle;
+  // Space the icon away from whatever sits next to it, but only when there is
+  // something next to it -- on an icon-only button the padding would just be a
+  // bare asymmetry.
+  //
+  // iconStyle goes last so a caller's own padding wins. The single caller that
+  // passes it (HeroContainerRight's "Add window") sends the shorthand
+  // `padding: 4px 4px 2px 4px`, which is meant to override this outright.
+  // Reversing the order would silently restyle that button.
+  const iconSpacing = [
+    imageSrc || text ? 'padding-right: 8px;' : '',
+    iconStyle ?? '',
+  ]
+    .filter(Boolean)
+    .join(' ');
 
   // No wrapper element: the button must be the flex child itself, otherwise a
   // width: 100% passed through `style` resolves against a shrink-wrapped div
@@ -72,7 +85,7 @@ const Button: React.FC<ButtonProps> = ({
           disable={true}
           focusable={true}
           size={iconSize}
-          style={(imageSrc || text) && 'padding-right: 8px;' && iconStyle}
+          style={iconSpacing}
         />
       )}
       {imageSrc && (

--- a/src/tests/components/buttonIconSpacing.test.tsx
+++ b/src/tests/components/buttonIconSpacing.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'vitest';
+
+import Button from '../../components/common/Button';
+import { renderWithProviders } from '../setup/renderWithProviders';
+
+// KAN-26. Button.tsx built the icon's style with a JS `&&` chain:
+//
+//   style={(imageSrc || text) && 'padding-right: 8px;' && iconStyle}
+//
+// `&&` yields its last truthy operand, so the padding literal was discarded in
+// every case -- when iconStyle was set it lost to iconStyle, and when it was
+// not the chain resolved to undefined. The gap the padding exists to create
+// was therefore never applied on any button.
+//
+// Measured in the real extension on 2026-09-01, on Settings > Data Management:
+// glyph-to-label gap was 4px (the Icon container's own `padding: 4px`), and
+// injecting the intended `padding-right: 8px` moved it to 8px. So the visible
+// defect is a uniform 4px deficit.
+//
+// These assert on computed padding rather than on the style string, because
+// the string is an implementation detail -- what matters is what reaches the
+// icon after Emotion has composed `containerStyle` with the injected style.
+const iconContainerOf = (container: HTMLElement): HTMLElement => {
+  const glyph = container.querySelector('.material-symbols-outlined');
+  if (!glyph) throw new Error('no icon glyph rendered');
+  // Icon.tsx renders containerStyle > wrapper > span.glyph
+  return glyph.parentElement!.parentElement as HTMLElement;
+};
+
+describe('Button icon spacing', () => {
+  test('separates the icon from its label', async () => {
+    const { container } = await renderWithProviders(
+      <Button text="Backup App Data to File" iconType="publish" />
+    );
+
+    expect(getComputedStyle(iconContainerOf(container)).paddingRight).toBe(
+      '8px'
+    );
+  });
+
+  test('separates the icon from an adjacent image', async () => {
+    const { container } = await renderWithProviders(
+      <Button imageSrc="https://example.com/i.png" iconType="publish" />
+    );
+
+    expect(getComputedStyle(iconContainerOf(container)).paddingRight).toBe(
+      '8px'
+    );
+  });
+
+  // The only caller in the codebase that passes iconStyle is
+  // HeroContainerRight.tsx:307, the "Add window" button, and it passes the
+  // shorthand `padding: 4px 4px 2px 4px`. That shorthand has to keep winning,
+  // or fixing this ticket silently restyles a button nobody asked to change.
+  // This is what pins the ordering: iconStyle must come last.
+  test("lets a caller's own padding override the separation", async () => {
+    const { container } = await renderWithProviders(
+      <Button
+        text="Add window"
+        iconType="add"
+        iconStyle="padding: 4px 4px 2px 4px;"
+      />
+    );
+
+    expect(getComputedStyle(iconContainerOf(container)).paddingRight).toBe(
+      '4px'
+    );
+  });
+
+  // Nothing to separate the icon from, so the padding would be a bare
+  // asymmetry. This is the one branch the old `&&` chain got right.
+  test('adds no separation to an icon with no label or image', async () => {
+    const { container } = await renderWithProviders(
+      <Button iconType="publish" />
+    );
+
+    // Icon's own containerStyle padding, untouched.
+    expect(getComputedStyle(iconContainerOf(container)).paddingRight).toBe(
+      '4px'
+    );
+  });
+});


### PR DESCRIPTION
## The defect

`Button.tsx` built the icon's style with a JS `&&` chain:

```tsx
style={(imageSrc || text) && 'padding-right: 8px;' && iconStyle}
```

`&&` yields its **last** truthy operand, so the padding literal was discarded in every case:

| `iconStyle` | result | padding applied? |
|---|---|---|
| defined | `iconStyle` | no |
| undefined | `undefined` | no |
| `(imageSrc \|\| text)` falsy | falsy | no — correct by intent |

There was no input for which the padding was applied. The ticket described this as happening only "when `iconStyle` is defined"; it was **unconditional**.

Also removes the dead `iconStyle;` expression statement on line 56.

## Reach

Every button that sets `iconType` alongside `text` or `imageSrc`: the Settings backup/restore pair, "Rate this app", "Share your thoughts", "Share on Twitter (X)", and the Account screens (Reset Password, Create an Account, Sign In).

Those callers pass `justify-content: center`, overriding `Button`'s own `space-around`, so no free space is distributed between the icon and the label — the only separation left was the `Icon` container's own `padding: 4px`.

## Measured, not inferred

The triage on this ticket reasoned the gap was 4px short but explicitly flagged that as un-measured. It has now been measured in the real built extension, on Settings → Data Management.

**Before**, with the intended padding injected live as a positive control (and restored afterwards):

| Button | visible gap | with intended padding | delta |
|---|---|---|---|
| Backup App Data to File | 4px | 8px | +4 |
| Restore App Data from File | 4px | 8px | +4 |

**After this change**, same measurement on a rebuilt and reloaded extension:

```json
[{"label":"Backup App Data to File",   "visibleGapPx":8, "containerPaddingRight":"8px"},
 {"label":"Restore App Data from File","visibleGapPx":8, "containerPaddingRight":"8px"}]
```

The gap is measured glyph-ink to label-ink. My first attempt measured the Icon *container's* edge instead and reported a delta of 0 for both states — that was the probe being wrong, not the code: the container is flush with the label by construction, so growing its padding moves both edges together and the difference cancels.

## The ordering is now deliberate

Exactly one caller passes `iconStyle` — `HeroContainerRight.tsx:307`, the "Add window" button — and it passes the shorthand `padding: 4px 4px 2px 4px`, which is meant to override this outright. So `iconStyle` must stay **last**.

The old `&&` chain got that right by accident, since it simply returned `iconStyle`. It is now ordered on purpose and commented, and pinned by a test. Verified in the browser after the change: that button still computes `padding: 4px 4px 2px 4px` with a 4px gap.

## Tests — 330 → 334

New `src/tests/components/buttonIconSpacing.test.tsx`, written first. Assertions are on computed padding rather than the style string, because the string is an implementation detail — what matters is what reaches the icon after Emotion composes it.

| Test | Before |
|---|---|
| `separates the icon from its label` | **FAIL** — `expected '4px' to be '8px'` |
| `separates the icon from an adjacent image` | **FAIL** — `expected '4px' to be '8px'` |
| `lets a caller's own padding override the separation` | passes both sides — pins the ordering |
| `adds no separation to an icon with no label or image` | passes both sides — the branch the old chain got right |

The two failures reproduce the same 4px→8px numbers measured in the real extension.

```
Test Files  35 passed (35)
     Tests  334 passed (334)
tsc: 0 errors
eslint: 0 errors, 28 warnings (unchanged from main)
```

Console clean in the browser apart from the pre-existing cross-world preload warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)