### PR TITLE
Capture only normal windows into a session (KAN-50)

### DIFF
--- a/src/tests/setup/chrome.fake.ts
+++ b/src/tests/setup/chrome.fake.ts
@@ -70,6 +70,10 @@ export function setupChromeFake(seed: ChromeSeed = {}): ChromeFakeHandle {
     const created = {
       id: nextId++,
       focused: false,
+      // Chrome never returns a window without a type, and getAll filters on
+      // it, so a window that defaulted to undefined would be invisible to
+      // every query. Explicit `type` in the seed still wins.
+      type: 'normal',
       ...rest,
     } as chrome.windows.Window;
     windows.push(created);
@@ -202,14 +206,31 @@ export function setupChromeFake(seed: ChromeSeed = {}): ChromeFakeHandle {
     },
 
     windows: {
+      // `windowTypes` is part of the query contract, not decoration: capture
+      // passes ['normal'] to keep popup windows out of a saved session
+      // (KAN-50), and background.ts passes it to pick what focus mode closes.
+      // A fake that ignored it would hand those callers popups anyway and
+      // report the bug fixed while it was not. Chrome's documented default
+      // when the caller omits it is ['normal', 'popup'].
       getAll: (
         info: chrome.windows.QueryOptions,
         cb?: (result: chrome.windows.Window[]) => void
-      ) =>
-        settle(
-          windows.map((win) => (info?.populate ? populate(win) : { ...win })),
+      ) => {
+        // `${WindowType}` and not WindowType: the enum's string form is what
+        // the API surface actually uses, and what a caller can pass literally.
+        const wanted: `${chrome.windows.WindowType}`[] = info?.windowTypes ?? [
+          'normal',
+          'popup',
+        ];
+        return settle(
+          windows
+            .filter(
+              (win) => win.type !== undefined && wanted.includes(win.type)
+            )
+            .map((win) => (info?.populate ? populate(win) : { ...win })),
           cb
-        ),
+        );
+      },
       getCurrent: (
         info: chrome.windows.QueryOptions,
         cb?: (result: chrome.windows.Window) => void
@@ -230,6 +251,7 @@ export function setupChromeFake(seed: ChromeSeed = {}): ChromeFakeHandle {
         const created = {
           id: nextId++,
           focused: data.focused ?? false,
+          type: data.type ?? 'normal',
         } as unknown as chrome.windows.Window;
         windows.push(created);
         for (const url of typeof data.url === 'string'

--- a/src/tests/setup/chromeFake.test.ts
+++ b/src/tests/setup/chromeFake.test.ts
@@ -132,6 +132,69 @@ describe('chrome.windows fake', () => {
     expect(windows.map((w) => w.id)).toEqual([8]);
     expect(handle.removedWindowIds).toEqual([7]);
   });
+
+  // KAN-50. capture and background.ts both narrow getAll with windowTypes. A
+  // fake that ignored the filter would hand them popups regardless and let a
+  // popup-exclusion test pass without the production code doing anything.
+  test('getAll honours windowTypes', async () => {
+    handle = setupChromeFake({
+      windows: [{ id: 7 }, { id: 8, type: 'popup' }],
+    });
+
+    const normals = await new Promise<chrome.windows.Window[]>((resolve) =>
+      chrome.windows.getAll({ windowTypes: ['normal'] }, resolve)
+    );
+    const popups = await new Promise<chrome.windows.Window[]>((resolve) =>
+      chrome.windows.getAll({ windowTypes: ['popup'] }, resolve)
+    );
+
+    expect(normals.map((w) => w.id)).toEqual([7]);
+    expect(popups.map((w) => w.id)).toEqual([8]);
+  });
+
+  // Chrome's documented default when the caller omits windowTypes. This is the
+  // behaviour the KAN-50 bug rode in on, so it is pinned rather than assumed.
+  test('getAll defaults to normal and popup when windowTypes is omitted', async () => {
+    handle = setupChromeFake({
+      windows: [{ id: 7 }, { id: 8, type: 'popup' }],
+    });
+
+    const windows = await new Promise<chrome.windows.Window[]>((resolve) =>
+      chrome.windows.getAll({}, resolve)
+    );
+
+    expect(windows.map((w) => w.id)).toEqual([7, 8]);
+  });
+
+  // A seeded window with no explicit type has to default to 'normal', or every
+  // existing test's windows would be filtered out of every typed query.
+  test('a seeded window defaults to type normal', async () => {
+    handle = setupChromeFake({ windows: [{ id: 7 }] });
+
+    const windows = await new Promise<chrome.windows.Window[]>((resolve) =>
+      chrome.windows.getAll({ windowTypes: ['normal'] }, resolve)
+    );
+
+    expect(windows.map((w) => w.type)).toEqual(['normal']);
+  });
+
+  test('create defaults to type normal and honours an explicit popup', async () => {
+    handle = setupChromeFake();
+
+    const normal = await new Promise<chrome.windows.Window | undefined>(
+      (resolve) => chrome.windows.create({ url: 'https://a.example/' }, resolve)
+    );
+    const popup = await new Promise<chrome.windows.Window | undefined>(
+      (resolve) =>
+        chrome.windows.create(
+          { url: 'https://b.example/', type: 'popup' },
+          resolve
+        )
+    );
+
+    expect(normal!.type).toBe('normal');
+    expect(popup!.type).toBe('popup');
+  });
 });
 
 describe('chrome.runtime fake', () => {

--- a/src/tests/utils/functions/capture.test.ts
+++ b/src/tests/utils/functions/capture.test.ts
@@ -201,4 +201,72 @@ describe('captureOpenWindows against the chrome fake', () => {
     expect(captured).not.toBeNull();
     expect(captured!.windows[0].tabs.map((tab) => tab.url)).toEqual([A, B]);
   });
+
+  // KAN-50. capture asked chrome for every window type, while focus mode's
+  // close (background.ts) and count (the slice) both filter to 'normal'. So
+  // focus mode saved popup windows it then left open, and the confirmation
+  // undercounted what it was about to close.
+  //
+  // Excluding them loses nothing: the saved record has no `type` field at all
+  // -- windowId, geometry, tabCount, title, tabs -- so a captured popup was
+  // already reopening as an ordinary window. Confirmed in the real extension
+  // before this changed: a saved popup restored with type 'normal'.
+  test('excludes popup windows', async () => {
+    handle = setupChromeFake({
+      windows: [
+        { id: 1, tabs: [{ id: 1, url: A, title: 'A' }] as chrome.tabs.Tab[] },
+        {
+          id: 2,
+          type: 'popup',
+          tabs: [{ id: 2, url: B, title: 'B' }] as chrome.tabs.Tab[],
+        },
+      ],
+    });
+
+    const captured = await captureOpenWindows('probe');
+
+    expect(captured).not.toBeNull();
+    expect(captured!.windows).toHaveLength(1);
+    expect(captured!.windows[0].tabs.map((tab) => tab.url)).toEqual([A]);
+  });
+
+  // Filtering getAll is not sufficient on its own: capture unshifts
+  // getCurrent() to put the user's focused window first, and that unshift
+  // ran regardless of type. Seeding the popup first makes it the fake's
+  // current window, which is the case a getAll-only filter would miss.
+  test('excludes a popup even when it is the current window', async () => {
+    handle = setupChromeFake({
+      windows: [
+        {
+          id: 1,
+          type: 'popup',
+          tabs: [{ id: 1, url: B, title: 'B' }] as chrome.tabs.Tab[],
+        },
+        { id: 2, tabs: [{ id: 2, url: A, title: 'A' }] as chrome.tabs.Tab[] },
+      ],
+    });
+
+    const captured = await captureOpenWindows('probe');
+
+    expect(captured).not.toBeNull();
+    expect(captured!.windows).toHaveLength(1);
+    expect(captured!.windows[0].tabs.map((tab) => tab.url)).toEqual([A]);
+  });
+
+  // The worst path: a popup is the only thing open. Returning null is the
+  // caller's cue that there is no session to save, so focus mode does not
+  // promise a save it will not make.
+  test('returns null when only popup windows are open', async () => {
+    handle = setupChromeFake({
+      windows: [
+        {
+          id: 1,
+          type: 'popup',
+          tabs: [{ id: 1, url: B, title: 'B' }] as chrome.tabs.Tab[],
+        },
+      ],
+    });
+
+    expect(await captureOpenWindows('probe')).toBeNull();
+  });
 });

--- a/src/utils/functions/capture.ts
+++ b/src/utils/functions/capture.ts
@@ -54,8 +54,19 @@ export function isAlreadySaved(
 export async function captureOpenWindows(
   title: string
 ): Promise<tabContainerData | null> {
+  // Normal windows only. Omitting windowTypes gets Chrome's default of
+  // ['normal', 'popup'], which is what focus mode's close (background.ts) and
+  // its count (requestFocusTabContainer) never used -- so a popup was saved
+  // into the session, left open, and missing from the "will be closed" count.
+  //
+  // Nothing is lost by dropping them: a windowGroupData records windowId,
+  // geometry, tabCount, title and tabs, and no window type, so a captured
+  // popup already came back from a restore as an ordinary window.
   const allWindows = await new Promise<chrome.windows.Window[]>((resolve) =>
-    chrome.windows.getAll({ populate: true }, (result) => resolve(result))
+    chrome.windows.getAll(
+      { populate: true, windowTypes: ['normal'] },
+      (result) => resolve(result)
+    )
   );
 
   const currentWindow = await new Promise<chrome.windows.Window>((resolve) =>
@@ -63,10 +74,16 @@ export async function captureOpenWindows(
   );
 
   // Current window first, so a restore reopens the user's focus where it was.
+  // getCurrent is deliberately left unfiltered - filtering the query would
+  // leave no way to tell "the current window is a popup" from "there is no
+  // current window" - so the type is checked here instead. Without this the
+  // unshift would put a popup back after getAll had excluded it.
   const windowList = allWindows.filter(
-    (window) => window.id !== currentWindow.id
+    (window) => window.id !== currentWindow?.id
   );
-  windowList.unshift(currentWindow);
+  if (currentWindow?.type === 'normal') {
+    windowList.unshift(currentWindow);
+  }
 
   let tabCount = 0;
 


### PR DESCRIPTION
`captureOpenWindows` called `chrome.windows.getAll` with **no `windowTypes`**, which gets Chrome's default of `['normal', 'popup']`. Both places that *act* on those windows filter to normal:

```ts
chrome.windows.getAll({ populate: true })                  // capture.ts   — normal + popup
chrome.windows.getAll({ windowTypes: ['normal'] })         // background.ts — the close
chrome.windows.getAll({ windowTypes: ['normal'] })         // slice         — the count
```

So focus mode saved popup windows into the session, then never closed them, and the confirmation undercounted what it was about to close.

## Measured in the real extension, before and after

One normal window plus one real popup (`chrome.windows.create({ type: 'popup' })`) open:

| | Before | After |
| --- | --- | --- |
| Dialog | "Your open window is already saved" (1) | "Your open window is already saved" (1) |
| Session saved | **2 Windows - 3 Tabs**, incl. the popup | **1 Window - 2 Tabs**, popup excluded |
| Popup after switching | still on screen, and duplicated in the save | not saved |

Both sessions are visible side by side in the list, so the pre-fix save acts as its own control.

## Why excluding popups loses nothing

This was checked before any code changed, because "stop saving popups" only counts as a fix if popups were not being saved usefully.

A `windowGroupData` stores `windowId, windowHeight, windowWidth, windowOffsetTop, windowOffsetLeft, tabCount, title, tabs` — **no window type**. Saving a popup and restoring it in the real extension returned a window with `type: "normal"`, `popupsNow: 0`. The kind of window is destroyed at capture time, so a saved popup was already reopening as an ordinary tab-strip window. This declines to save something that was never restorable, rather than removing a working feature.

(Geometry *is* stored, so a restored popup came back roughly the right size — just as a normal window. That is the one thing given up, and it is not what the user asked for when they popped a window out.)

## Filtering getAll alone is not sufficient

`capture` unshifts `getCurrent()` to put the focused window first, and that ran regardless of type — so a popup that *was* the current window went straight back in after `getAll` had excluded it. `getCurrent` is deliberately left unfiltered, because narrowing the query makes "the current window is a popup" indistinguishable from "there is no current window"; the type is checked at the unshift instead.

Proved load-bearing, not defensive: applying only the `getAll` filter leaves 2 of the 3 new tests failing.

## The fake was lying

`chrome.fake.ts`'s `getAll` **ignored `windowTypes` completely**. It would have returned popups to `capture` no matter what production did — so a popup-exclusion test could never have gone green for the right reason, and a naive one would have reported the bug fixed while nothing was. It now models the query contract: Chrome's `['normal', 'popup']` default, a `'normal'` default for seeded and created windows, and its own tests pinning all of it.

This is the second time this fake has silently misreported (see the `capture.ts:74` comment about it returning `null` for everything it created).

## Verification

Test-first. All three behaviour tests were RED before the fix, for the right reason (`expected length 1, got 2` / `expected non-null to be null`).

The control that matters: with the **fake fix in place** but `capture.ts` reverted, all 3 still fail — so the production change is doing the work, not the harness.

```
npm run lint    0 errors, 28 warnings         exit 0
npx tsc --noEmit                              clean
npm run test    35 files, 341 tests passed    (was 334, +7)
npm run build   built in 85ms
npm audit       found 0 vulnerabilities
```

Two failures the gate caught along the way, both worth noting: `tsc` rejected `chrome.windows.windowTypeEnum` (the API uses the enum's string form, `` `${WindowType}` ``), and the build was broken while the tests were green — vitest does not typecheck.

Closes KAN-50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)