### PR TITLE
Clear three P4 defects: thunk type, focus copy, body background (KAN-24, KAN-42, KAN-49)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,7 +4,10 @@
 
 body {
   margin: 0;
-  background-color: grey;
+  /* useDocumentTheme publishes --app-background on <html> (KAN-49). The literal
+     stays as the fallback, matching the scrollbar properties below: it is what
+     paints for the one frame before the hook's first layout effect runs. */
+  background-color: var(--app-background, grey);
 }
 
 /* Suppresses every transition while the theme is being swapped (KAN-22).

--- a/src/hooks/useDocumentTheme.ts
+++ b/src/hooks/useDocumentTheme.ts
@@ -43,6 +43,13 @@ export function useDocumentTheme(): void {
       COLORS.SCROLLBAR_THUMB_HOVER
     );
 
+    // 3. body's background (KAN-49), same reason as the scrollbar: body is not
+    //    reachable from an emotion class either. It had a hardcoded `grey`
+    //    that never tracked the theme, and <html> has no background of its
+    //    own, so that grey painted whatever viewport area the 790x550 app box
+    //    did not cover.
+    root.style.setProperty('--app-background', COLORS.PRIMARY_COLOR);
+
     // Two frames, not one: the first only guarantees the new styles are
     // computed, the second that they have been painted. Releasing after one
     // still let the tail of the change animate on slower frames.

--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -236,8 +236,25 @@ export const requestFocusTabContainer = createAsyncThunk(
     // Worked out here as well as at the moment of switching, because the
     // dialog must not promise a save that will not happen.
     const captured = await captureOpenWindows(params.saveTitle);
-    const willSave =
-      captured !== null && !isAlreadySaved(captured, state.tabGroups);
+
+    // Nothing to capture is a third case, not a kind of "already saved"
+    // (KAN-42). Folding it into `willSave === false` made the dialog say "Your
+    // open window is already saved. It will be closed." when nothing was ever
+    // saved -- a false claim about the user's data from the one dialog whose
+    // whole job is telling them what happens to their tabs.
+    //
+    // Handled before `willSave` exists rather than by widening it to a
+    // tri-state: the boolean is then only ever computed when there is
+    // something to save, so it cannot mean two things again. Skipping the
+    // prompt is the same call the early return above makes -- there is nothing
+    // to warn about losing, since every window being closed is empty, and
+    // focusTabContainer already no-ops its own save on a null capture.
+    if (captured === null) {
+      thunkAPI.dispatch(focusTabContainer(params));
+      return;
+    }
+
+    const willSave = !isAlreadySaved(captured, state.tabGroups);
 
     thunkAPI.dispatch(
       openFocusModal({
@@ -322,7 +339,12 @@ export const saveToTabContainer = createAsyncThunk(
 
 // add current window to the specified tabgroup and display a toast message
 export const addCurrWindowToTabGroup = createAsyncThunk(
-  'global/saveToTabContainer',
+  // Named for what it does. It shared 'global/saveToTabContainer' with the
+  // thunk above until KAN-24: harmless, because createAsyncThunk is a factory
+  // with no registry and nothing consumed the string, but it showed two
+  // different operations under one name in DevTools and would have made the
+  // first `addCase(saveToTabContainer.fulfilled, ...)` match this one too.
+  'global/addCurrWindowToTabGroup',
   async (params: addCurrWindowToTabGroupParams, thunkAPI) => {
     thunkAPI.dispatch(addCurrWindowToTabGroupInternal(params));
 

--- a/src/tests/components/documentTheme.test.tsx
+++ b/src/tests/components/documentTheme.test.tsx
@@ -62,6 +62,31 @@ describe('useDocumentTheme (KAN-22)', () => {
     );
   });
 
+  // KAN-49. App.css hardcoded `background-color: grey` on body, unthemed since
+  // the first LeftPane commit. <html> has no background, so that grey paints
+  // any viewport area the 790x550 app box does not cover. Published through the
+  // same hook as the scrollbar colours, for the same reason: body is not
+  // reachable from an emotion class.
+  test('publishes the app background as a custom property', async () => {
+    await renderWithProviders(<Probe />);
+
+    expect(
+      document.documentElement.style.getPropertyValue('--app-background')
+    ).toBe(LIGHT_THEME.PRIMARY_COLOR);
+  });
+
+  test('republishes the app background when the theme changes', async () => {
+    const { store } = await renderWithProviders(<Probe />);
+
+    act(() => {
+      store.dispatch(setTheme(Theme.DARKENHEIMER));
+    });
+
+    expect(
+      document.documentElement.style.getPropertyValue('--app-background')
+    ).toBe(DARKENHEIMER_THEME.PRIMARY_COLOR);
+  });
+
   // The flag must be set in the SAME commit that changes the colours, not a
   // frame later -- one frame late and the transition has already started, which
   // is the whole defect.

--- a/src/tests/redux/focusConfirm.test.ts
+++ b/src/tests/redux/focusConfirm.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Inlined rather than imported: a vi.hoisted block runs before the module
+// graph is evaluated, and common.ts reads window.screen at module load.
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(async () => undefined),
+  saveToFirestore: vi.fn(async () => undefined),
+  displayToast: vi.fn(),
+}));
+
+import {
+  requestFocusTabContainer,
+  saveToTabContainer,
+  addCurrWindowToTabGroup,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import { setupChromeFake } from '../setup/chrome.fake';
+import { makeTestStore } from '../setup/makeStore';
+
+const PARAMS = {
+  tabGroupId: 'group-1',
+  goToURLText: 'Go to URL',
+  saveTitle: 'Auto-saved before switching',
+};
+
+describe('requestFocusTabContainer (KAN-42)', () => {
+  let handle: ReturnType<typeof setupChromeFake> | undefined;
+
+  beforeEach(() => {
+    handle?.restore();
+    handle = undefined;
+  });
+
+  // The defect: `willSave` collapsed two different situations into one `false`.
+  //
+  //   const willSave = captured !== null && !isAlreadySaved(captured, groups);
+  //
+  // so `false` meant EITHER "already saved" OR "there was nothing to capture",
+  // and both selected the FocusConfirmBodySaved* copy -- "Your open window is
+  // already saved. It will be closed." In the second case nothing was saved and
+  // nothing ever had been, so the dialog stated something untrue about the
+  // user's data. The comment at the willSave site says the dialog must not
+  // promise a save that will not happen; implying one already happened is the
+  // same defect pointed the other way.
+  it('does not open the confirmation when there is nothing to capture', async () => {
+    // A normal window carrying no tabs: getAll (which does not populate) counts
+    // it, so the "nothing is open" early return does not fire, while
+    // captureOpenWindows drops every tab-less window and returns null.
+    handle = setupChromeFake({ windows: [{ id: 1 }] });
+
+    const { store, seen } = makeTestStore();
+    await store.dispatch(requestFocusTabContainer(PARAMS));
+
+    expect(seen).not.toContain('globalState/openFocusModal');
+  });
+
+  // The control for the test above: the same call DOES open the dialog when
+  // there is genuinely something to save, so the assertion is not passing
+  // because the modal never opens under this harness.
+  it('opens the confirmation when there is something to capture', async () => {
+    handle = setupChromeFake({
+      windows: [
+        {
+          id: 1,
+          tabs: [
+            { id: 1, url: 'https://a.example/', title: 'A' },
+          ] as chrome.tabs.Tab[],
+        },
+      ],
+    });
+
+    const { store, seen } = makeTestStore();
+    await store.dispatch(requestFocusTabContainer(PARAMS));
+
+    expect(seen).toContain('globalState/openFocusModal');
+  });
+});
+
+// KAN-24. Two thunks were registered with the same action type string. RTK has
+// no registry and deduplicates nothing, so both ran correctly and no user was
+// ever affected -- but DevTools showed two different operations under one name,
+// and the first `builder.addCase(saveToTabContainer.fulfilled, ...)` anyone
+// wrote would silently have matched "add current window" too.
+describe('async thunk action types (KAN-24)', () => {
+  it('gives each thunk its own action type', () => {
+    expect(addCurrWindowToTabGroup.typePrefix).not.toBe(
+      saveToTabContainer.typePrefix
+    );
+  });
+
+  // Pinned rather than merely asserted distinct, so a future rename that
+  // reintroduces a collision by renaming the wrong one still fails here.
+  it('names them after what they do', () => {
+    expect(saveToTabContainer.typePrefix).toBe('global/saveToTabContainer');
+    expect(addCurrWindowToTabGroup.typePrefix).toBe(
+      'global/addCurrWindowToTabGroup'
+    );
+  });
+});


### PR DESCRIPTION
Three unrelated P4s in one PR because none justifies its own. Each is independently reverted and re-tested below; no two share a file except the slice.

## KAN-24 — colliding thunk action type

`addCurrWindowToTabGroup` was registered as `'global/saveToTabContainer'`, the same string `saveToTabContainer` uses.

**No user was ever affected.** `createAsyncThunk` is a factory with no registry — it deduplicates nothing, and nothing in the codebase consumes the string. Undo/redo keys off the slice-internal reducer names in `actionTypes.ts` (`addCurrWindowToTabGroupInternal` vs `saveToTabContainerInternal`), which were always distinct. The real costs were DevTools showing two operations under one name, and the first `builder.addCase(saveToTabContainer.fulfilled, ...)` anyone wrote silently matching "add current window" too.

Renamed to `'global/addCurrWindowToTabGroup'`, with a test pinning **both** strings — not merely asserting they differ, so a future rename that reintroduces a collision by renaming the wrong one still fails.

## KAN-42 — dialog claimed a save that never happened

```ts
const willSave = captured !== null && !isAlreadySaved(captured, tabGroups);
```

`false` meant *either* "already saved" *or* "there was nothing to capture", and both selected the `FocusConfirmBodySaved*` copy — **"Your open window is already saved. It will be closed."** In the second case nothing was saved and nothing ever had been. The comment at that site says the dialog must not promise a save that will not happen; implying one already happened is the same defect pointed the other way.

Handled **before** `willSave` exists rather than by widening it to a tri-state, so the boolean is only computed when there is something to save and cannot mean two things again. A null capture takes the same path the existing "nothing is open" early return takes — there is nothing to warn about losing, since every window being closed is empty, and `focusTabContainer` already no-ops its own save on a null capture.

That avoids inventing a third message and translating it into ten locales for a case that needs a normal window carrying **zero tabs** to reach. Worth being explicit: I could not construct that state in a real browser, since closing the last tab closes the window. The fix is right regardless, but its reachability is an argument, not a proof — this code has been misjudged twice before.

## KAN-49 — unthemed body background

`App.css` set `background-color: grey` on body, hardcoded since the first LeftPane commit. `<html>` has no background of its own, so that grey painted whatever viewport area the 790x550 app box did not cover — 50px at 100% zoom, 116px at 90%.

Published as `--app-background` through `useDocumentTheme`, alongside the scrollbar properties and for the same reason: body cannot be reached from an emotion class. The literal stays as the CSS fallback, matching the convention already there.

## Verification

Test-first. All 5 new tests RED before the fixes, for the right reasons (`expected '' to be '#F5F7FA'`, `expected 'global/saveToTabContainer' to be 'global/addCurrWindowToTabGroup'`, `expected [...] to not include 'globalState/openFocusModal'`).

**Per-fix revert controls** — each production file reverted alone, keeping everything else:

| Reverted | Fails | Still passes |
| --- | --- | --- |
| `tabContainerDataStateSlice.ts` | 3 (KAN-24 ×2, KAN-42 ×1) | the KAN-42 control |
| `useDocumentTheme.ts` | 2 (KAN-49) | the 4 KAN-22 scrollbar tests |

The KAN-42 negative assertion ships with its own positive control — the same call **does** open the dialog when there is something to capture — so it cannot pass merely because the modal never opens under this harness.

**In the built extension:**
- body's computed background follows the theme: `rgb(42,42,42)` dark → `rgb(245,247,250)` light, via a real theme switch in Settings.
- Removing `--app-background` live repaints body `rgb(128, 128, 128)` — exactly the old grey — and restoring brings the theme colour back. That control proves the property is what does the work.
- `elementFromPoint` at the bottom of an 800×600 viewport returns `HTML`, i.e. the uncovered band the ticket describes exists and is now themed.
- Focus dialog still opens with correct copy on the normal path; "add current window" still adds (1→2 windows) and still undoes (2→1), which is the one plausible regression route KAN-24 identified.

```
npm run lint    0 errors, 28 warnings         exit 0
npx tsc --noEmit                              clean
npm run test    36 files, 347 tests passed    (was 341, +6)
npm run build   built in 99ms
npm audit       found 0 vulnerabilities
```

Closes KAN-24, KAN-42, KAN-49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)