### PR TITLE
Enable the React Compiler lint rules and clear their 3 findings (KAN-51)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,21 +43,22 @@ export default tseslint.config(
   // react-hooks is on 7 because it is the ONLY release whose peer range accepts
   // ESLint 10; every version from 5.0.0 to 7.0.0 caps at ^9. That forces in its
   // React Compiler machinery (@babel/core, hermes-parser, zod) as a transitive
-  // cost we cannot avoid while on ESLint 10.
+  // cost we cannot avoid while on ESLint 10 (KAN-46).
   //
-  // We do not enable the compiler rules yet. `configs.flat['recommended-latest']`
-  // turns ~14 extra rules on at 'error'; measured against this codebase it
-  // reports 3 real `react-hooks/set-state-in-effect` errors. Fixing those changes
-  // render behaviour in 3 components, which is a code change, not a config port -
-  // tracked separately so a lint-config failure stays distinguishable from it.
-  // Only the two rules this project has always gated on are enabled here.
+  // Since the dependency is paid for either way, the full rule set is on:
+  // `recommended-latest` is 17 rules, the two this project has always gated on
+  // plus 15 React Compiler ones. Enabling them cost 3 fixes, all
+  // `react-hooks/set-state-in-effect` and all the same shape -- state seeded
+  // from a prop by an effect, in HeroContainerRight and WindowEntryContainer.
+  // Two were rename drafts being overwritten mid-edit by a sync merge; one was
+  // a reset a `key` already performed. See KAN-51 and renameDrafts.test.tsx.
+  //
+  // Spread into a `files`-scoped block rather than listed bare: the upstream
+  // object carries no `files`, and every other block here is scoped to ts/tsx.
   {
     files: ['**/*.{ts,tsx}'],
     plugins: { 'react-hooks': reactHooks },
-    rules: {
-      'react-hooks/rules-of-hooks': 'error',
-      'react-hooks/exhaustive-deps': 'warn',
-    },
+    rules: reactHooks.configs.flat['recommended-latest'].rules,
   },
 
   // Must stay last: turns off every core rule that conflicts with prettier.

--- a/src/components/home/rightpane/HeroContainerRight.tsx
+++ b/src/components/home/rightpane/HeroContainerRight.tsx
@@ -66,22 +66,32 @@ export default function HeroContainerRight() {
     searchInputText
   )[0];
 
-  useEffect(() => {
-    if (selectedTabGroup) setEditableTitle(selectedTabGroup.title);
-  }, [selectedTabGroup]);
-
   // Belt and braces: RightPane does not mount this component when the list is
   // empty, so this should be unreachable -- but it is what makes the component
   // safe on its own terms rather than safe because of its only caller (KAN-16).
-  // It sits below every hook deliberately. Moving it above the useEffect that
-  // seeds the editable title would change the hook count between the
+  // It sits below every hook deliberately: an early return above the useEffect
+  // that reads the current tab name would change the hook count between the
   // nothing-selected and selected renders, and React throws "Rendered more
   // hooks than during the previous render" on that transition.
   if (!selectedTabGroup) return null;
 
+  // `editableTitle` is a DRAFT: nothing reads it unless `isEditing` is true, so
+  // it is seeded at the moment editing starts rather than kept in step with the
+  // prop by an effect.
+  //
+  // The effect this replaces depended on the whole selectedTabGroup object, so
+  // any change to the selected session re-seeded the draft -- including changes
+  // the user did not make. customMiddleware dispatches syncStateWithFirestore()
+  // with no user action, and the merge lands replaceState(merged), so a sync
+  // tick arriving mid-rename threw away what had been typed. KAN-51.
+  const startEditing = () => {
+    setEditableTitle(selectedTabGroup.title);
+    setIsEditing(true);
+  };
+
   const handleTabGroupTitleClick = () => {
     if (!isSearchPanel) {
-      setIsEditing(true);
+      startEditing();
     }
   };
 
@@ -232,7 +242,7 @@ export default function HeroContainerRight() {
                 backgroundColor={COLORS.SECONDARY_COLOR}
                 onClick={(e) => {
                   e.stopPropagation();
-                  setIsEditing(true);
+                  startEditing();
                 }}
                 focusable={isContainerHovered}
               />

--- a/src/components/home/rightpane/TabGroupDetailsContainer.tsx
+++ b/src/components/home/rightpane/TabGroupDetailsContainer.tsx
@@ -112,6 +112,16 @@ export default function TabGroupDetailsContainer() {
               // collapse and rename state, and an index key is identical to
               // the positional default React already uses, so it would leave
               // that state bleeding onto the wrong window after a deletion.
+              //
+              // This key is also what resets collapse state when the user
+              // switches sessions. Window ids are uuidv4 minted in exactly two
+              // places (capture.ts and HeroContainerRight) and nothing clones a
+              // session, so no id is shared between two tab groups -- selecting
+              // a different one swaps the whole key set and React remounts every
+              // row, which re-runs useState(true). WindowEntryContainer used to
+              // do that reset with an effect on tabGroupId; it was deleted as
+              // redundant with this key (KAN-51). Weaken this key and that reset
+              // goes with it -- renameDrafts.test.tsx covers it.
               <div key={windowId}>
                 <WindowEntryContainer
                   title={title}

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler, useEffect, useState } from 'react';
+import React, { MouseEventHandler, useState } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -55,18 +55,9 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     null
   );
 
-  useEffect(() => {
-    setNewTitle(title);
-  }, [title]);
-
   const isSearchPanel = useSelector(
     (state: RootState) => state.globalState.isSearchPanel
   );
-
-  // reset the 'windowOpenState' to true whenever a different tabGroup is selected.
-  useEffect(() => {
-    setWindowOpenState(true);
-  }, [tabGroupId]);
 
   const containerStyle = css`
     display: flex;
@@ -161,6 +152,17 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setNewTitle(e.target.value);
+  };
+
+  // `newTitle` is a DRAFT: nothing reads it unless `isEditing` is true, so it is
+  // seeded at the moment editing starts rather than kept in step with the prop
+  // by an effect. The effect this replaces re-seeded on every change to `title`,
+  // so a rename arriving from another device -- a Firestore merge lands
+  // replaceState(merged) with no user action -- overwrote what was being typed
+  // here. KAN-51.
+  const startEditing = () => {
+    setNewTitle(title);
+    setIsEditing(true);
   };
 
   const handleBlur = () => {
@@ -293,7 +295,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
               backgroundColor={COLORS.HOVER_COLOR}
               onClick={(e) => {
                 e.stopPropagation();
-                setIsEditing(true);
+                startEditing();
               }}
               focusable={isParentHovered}
             />

--- a/src/tests/components/HeroContainerRight.test.tsx
+++ b/src/tests/components/HeroContainerRight.test.tsx
@@ -108,9 +108,14 @@ describe('HeroContainerRight', () => {
   });
 
   // The guard has to sit below every hook. Returning null above the useEffect
-  // that seeds the editable title would change the hook count between these
+  // that reads the current tab name would change the hook count between these
   // two renders, and React throws "Rendered more hooks than during the previous
   // render" on the second one.
+  //
+  // KAN-51 deleted the OTHER effect that used to sit above the guard -- the one
+  // seeding the editable title -- so that effect is no longer what this test is
+  // protecting. The remaining chrome.tabs.query effect is, and one hook above
+  // the guard is all it takes for the transition to matter.
   test('mounts the session when the store goes from nothing selected to selected', async () => {
     const { store } = await renderWithProviders(<HeroContainerRight />);
 

--- a/src/tests/components/renameDrafts.test.tsx
+++ b/src/tests/components/renameDrafts.test.tsx
@@ -1,0 +1,305 @@
+import { describe, expect, test } from 'vitest';
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import HeroContainerRight from '../../components/home/rightpane/HeroContainerRight';
+import TabGroupDetailsContainer from '../../components/home/rightpane/TabGroupDetailsContainer';
+import {
+  renderWithProviders,
+  RenderWithProvidersResult,
+} from '../setup/renderWithProviders';
+import {
+  replaceState,
+  saveToTabContainerInternal,
+  selectTabContainer,
+  updateWindowGroupTitle,
+  TabMasterContainer,
+} from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-51. Three `react-hooks/set-state-in-effect` sites, all of them the same
+// shape: a piece of state seeded from a prop by an effect.
+//
+// Two of them (HeroContainerRight's `editableTitle`, WindowEntryContainer's
+// `newTitle`) are RENAME DRAFTS -- read only while `isEditing` is true. An
+// effect that keeps re-seeding them from the prop for the component's whole
+// lifetime does not just cost a render pass; it overwrites what the user is
+// typing whenever the prop moves underneath them. That is reachable without
+// any user action: customMiddleware.ts dispatches syncStateWithFirestore(),
+// and the merge lands replaceState(merged) (globalStateSlice.ts:121).
+//
+// The third (WindowEntryContainer's `windowOpenState`) is a reset-on-identity
+// -change, which is the job a `key` already does -- see the last test.
+
+const buildWindow = (n: number, title: string, tabTitles: string[]) => ({
+  windowId: `win-${n}`,
+  windowHeight: 1080,
+  windowWidth: 1920,
+  windowOffsetTop: 0,
+  windowOffsetLeft: 0,
+  tabCount: tabTitles.length,
+  title,
+  tabs: tabTitles.map((tabTitle, i) => ({
+    tabId: `w${n}-t${i}`,
+    favicon: '',
+    title: tabTitle,
+    url: `https://example.com/w${n}/t${i}`,
+  })),
+});
+
+// A factory rather than a shared constant: saveToTabContainerInternal's reducer
+// mutates what it is handed and Immer freezes it, so a session reused across
+// tests arrives at the second dispatch already frozen and throws.
+const buildGroup = (
+  n: number,
+  title: string,
+  windows: ReturnType<typeof buildWindow>[]
+) => ({
+  tabGroupId: `group-${n}`,
+  title,
+  createdTime: `2026-09-01 09:0${n}:00`,
+  createdAt: Date.UTC(2026, 8, 1, 9, n, 0),
+  windowCount: windows.length,
+  tabCount: windows.reduce((sum, w) => sum + w.tabs.length, 0),
+  isAutoSave: false,
+  isSelected: false,
+  windows,
+});
+
+// What a Firestore merge does to the store: replaceState with a whole new
+// container. structuredClone because the live state is Immer-frozen, and
+// replaceState returns its payload verbatim -- so the copy has to be mutable
+// and has to carry selectedTabGroupId, or the selection is lost for an
+// unrelated reason and the test would pass by accident.
+function landSyncMerge(
+  store: RenderWithProvidersResult['store'],
+  mutate: (container: TabMasterContainer) => void
+) {
+  const merged: TabMasterContainer = structuredClone(
+    store.getState().tabContainerDataState
+  );
+  mutate(merged);
+  act(() => {
+    store.dispatch(replaceState(merged));
+  });
+}
+
+describe('rename drafts survive the prop moving underneath them (KAN-51)', () => {
+  describe('session title (HeroContainerRight)', () => {
+    // The behaviour the effect currently provides, and the one a naive
+    // "just delete the effect" silently breaks. Must stay green throughout.
+    test('the rename field opens seeded with the current session title', async () => {
+      await renderWithProviders(<HeroContainerRight />, {
+        seedStore: (s) => {
+          s.dispatch(
+            saveToTabContainerInternal(
+              buildGroup(1, 'Research', [buildWindow(1, 'Morning', ['Kagi'])])
+            )
+          );
+          s.dispatch(selectTabContainer('group-1'));
+        },
+      });
+
+      await userEvent.click(await screen.findByText('Research'));
+
+      expect(screen.getByRole<HTMLInputElement>('textbox').value).toBe(
+        'Research'
+      );
+    });
+
+    // The second half of the same contract: seeding has to follow the
+    // SELECTION, not just the first mount. Deleting the effect without moving
+    // the seed into the click handler leaves this showing the stale title.
+    test('the rename field seeds from the session selected now, not the one selected at mount', async () => {
+      const { store } = await renderWithProviders(<HeroContainerRight />, {
+        seedStore: (s) => {
+          s.dispatch(
+            saveToTabContainerInternal(
+              buildGroup(1, 'Research', [buildWindow(1, 'Morning', ['Kagi'])])
+            )
+          );
+          s.dispatch(
+            saveToTabContainerInternal(
+              buildGroup(2, 'Holiday', [buildWindow(2, 'Evening', ['Maps'])])
+            )
+          );
+          s.dispatch(selectTabContainer('group-1'));
+        },
+      });
+
+      expect(await screen.findByText('Research')).toBeTruthy();
+
+      act(() => {
+        store.dispatch(selectTabContainer('group-2'));
+      });
+
+      await userEvent.click(await screen.findByText('Holiday'));
+
+      expect(screen.getByRole<HTMLInputElement>('textbox').value).toBe(
+        'Holiday'
+      );
+    });
+
+    // RED. The effect depends on the whole `selectedTabGroup` OBJECT, so any
+    // change to the selected session -- including one the user did not make --
+    // re-seeds the draft and throws away what they typed.
+    test('an in-flight rename survives a sync merge landing', async () => {
+      const { store } = await renderWithProviders(<HeroContainerRight />, {
+        seedStore: (s) => {
+          s.dispatch(
+            saveToTabContainerInternal(
+              buildGroup(1, 'Research', [buildWindow(1, 'Morning', ['Kagi'])])
+            )
+          );
+          s.dispatch(selectTabContainer('group-1'));
+        },
+      });
+
+      await userEvent.click(await screen.findByText('Research'));
+      const input = screen.getByRole<HTMLInputElement>('textbox');
+
+      await userEvent.clear(input);
+      await userEvent.type(input, 'Thesis notes');
+      expect(input.value).toBe('Thesis notes');
+
+      // A merge lands while the user is still typing. It touches a DIFFERENT
+      // session field -- the tab count -- so nothing about the title itself
+      // changed; only the object identity did.
+      landSyncMerge(store, (container) => {
+        container.tabGroups[0].tabCount = 99;
+      });
+
+      expect(screen.getByRole<HTMLInputElement>('textbox').value).toBe(
+        'Thesis notes'
+      );
+    });
+  });
+
+  describe('window title (WindowEntryContainer)', () => {
+    test('the rename field opens seeded with the current window title', async () => {
+      await renderWithProviders(<TabGroupDetailsContainer />, {
+        seedStore: (s) => {
+          s.dispatch(
+            saveToTabContainerInternal(
+              buildGroup(1, 'Research', [
+                buildWindow(1, 'Morning reading', ['Kagi']),
+              ])
+            )
+          );
+          s.dispatch(selectTabContainer('group-1'));
+        },
+      });
+
+      await userEvent.click(
+        await screen.findByLabelText('rename window group')
+      );
+
+      expect(screen.getByRole<HTMLInputElement>('textbox').value).toBe(
+        'Morning reading'
+      );
+    });
+
+    // RED. Same defect one layer down. Here the effect depends on `title`
+    // alone, so it takes a change to THAT window's title to trigger it --
+    // which is what a merge carrying a rename made on another device does.
+    // updateWindowGroupTitle is the minimal action that produces the identical
+    // prop change; the reachable source is the sync merge.
+    test('an in-flight rename survives that window being renamed elsewhere', async () => {
+      const { store } = await renderWithProviders(
+        <TabGroupDetailsContainer />,
+        {
+          seedStore: (s) => {
+            s.dispatch(
+              saveToTabContainerInternal(
+                buildGroup(1, 'Research', [
+                  buildWindow(1, 'Morning reading', ['Kagi']),
+                ])
+              )
+            );
+            s.dispatch(selectTabContainer('group-1'));
+          },
+        }
+      );
+
+      await userEvent.click(
+        await screen.findByLabelText('rename window group')
+      );
+      const input = screen.getByRole<HTMLInputElement>('textbox');
+
+      await userEvent.clear(input);
+      await userEvent.type(input, 'Deep work');
+      expect(input.value).toBe('Deep work');
+
+      act(() => {
+        store.dispatch(
+          updateWindowGroupTitle({
+            tabGroupId: 'group-1',
+            windowId: 'win-1',
+            editableTitle: 'Renamed on my laptop',
+          })
+        );
+      });
+
+      expect(screen.getByRole<HTMLInputElement>('textbox').value).toBe(
+        'Deep work'
+      );
+    });
+  });
+
+  describe('window collapse state (WindowEntryContainer)', () => {
+    // NOT red -- this passes with the effect in place, and the point of the
+    // ticket is that it also passes without it, because TabGroupDetailsContainer
+    // keys each window by windowId (KAN-28) and window ids are uuidv4 minted in
+    // exactly two places (capture.ts, HeroContainerRight) with nothing cloning a
+    // session. Switching sessions therefore swaps the entire key set and React
+    // remounts, which re-runs useState(true).
+    //
+    // A test that cannot fail proves nothing, so this one has a control: change
+    // the key in TabGroupDetailsContainer to a constant (or to the array index,
+    // which is the same thing for a single-window group -- use two windows) and
+    // this MUST go red once the effect is gone. If it stays green it is not
+    // testing the reset.
+    test('a window collapsed in one session is not collapsed in another', async () => {
+      const { store } = await renderWithProviders(
+        <TabGroupDetailsContainer />,
+        {
+          seedStore: (s) => {
+            s.dispatch(
+              saveToTabContainerInternal(
+                buildGroup(1, 'Research', [
+                  buildWindow(1, 'Morning reading', ['Alpha Page']),
+                  buildWindow(2, 'Afternoon reading', ['Bravo Page']),
+                ])
+              )
+            );
+            s.dispatch(
+              saveToTabContainerInternal(
+                buildGroup(3, 'Holiday', [
+                  buildWindow(3, 'Flights', ['Charlie Page']),
+                  buildWindow(4, 'Hotels', ['Delta Page']),
+                ])
+              )
+            );
+            s.dispatch(selectTabContainer('group-1'));
+          },
+        }
+      );
+
+      const accordions = await screen.findAllByLabelText('collapse');
+      expect(accordions).toHaveLength(2);
+
+      // Collapse the SECOND window. Slot 1 in group-1 is collapsed; if the
+      // instance is recycled rather than remounted, slot 1 of group-3 inherits
+      // it and "Delta Page" disappears.
+      await userEvent.click(accordions[1]);
+      expect(screen.queryByText('Bravo Page')).toBeNull();
+
+      act(() => {
+        store.dispatch(selectTabContainer('group-3'));
+      });
+
+      expect(await screen.findByText('Charlie Page')).toBeTruthy();
+      expect(screen.getByText('Delta Page')).toBeTruthy();
+      expect(screen.queryAllByLabelText('collapse')).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
Closes KAN-51.

## Why now

KAN-46 had to move `eslint-plugin-react-hooks` to 7.1.1 — the only release whose peer range accepts ESLint 10 — which pulled in the React Compiler machinery (`@babel/core`, `hermes-parser`, `zod`) transitively **whether or not the rules were enabled**. The dependency cost was already paid; this collects the value.

`recommended-latest` is 17 rules: the 2 this project has always gated on, plus 15 compiler ones. Measured against this codebase it reports **exactly 3 errors**, all `react-hooks/set-state-in-effect`, all the same shape — state seeded from a prop by an effect.

## Two of the three were a real defect

`HeroContainerRight`'s `editableTitle` and `WindowEntryContainer`'s `newTitle` are rename **drafts**: nothing reads them unless `isEditing` is true. An effect kept re-seeding them from the prop for the component's whole lifetime, so any change to the underlying session overwrote what the user was typing.

That is reachable with **no user action**. `customMiddleware.ts:71` dispatches `syncStateWithFirestore()`, and the merge lands `replaceState(merged)` (`globalStateSlice.ts:121`). Undo lands `restoreContainer()`, which rebuilds `tabGroups` via `.map()` — so it changes the selected session's object identity even when no text changed. Clicking away can't reach this because it blurs and commits; an async merge or a Cmd+Z can.

Both drafts are now seeded in the handler that starts the edit, which is where a draft's life should begin.

## The third was redundant

`WindowEntryContainer` reset `windowOpenState` on `tabGroupId` change. `TabGroupDetailsContainer` already keys each window by `windowId` (KAN-28); window ids are `uuidv4()` minted in exactly two places (`capture.ts:105`, `HeroContainerRight.tsx:119`) and nothing clones a session, so selecting another session swaps the entire key set, React remounts, and `useState(true)` re-runs. Deleted — and the key's new responsibility is written down where the key lives, so weakening it isn't a silent regression.

## Evidence

**Automated** — `renameDrafts.test.tsx`, 6 new tests.

The two draft-clobbering tests were watched RED before any component changed:

```
AssertionError: expected 'Research' to be 'Thesis notes'
AssertionError: expected 'Renamed on my laptop' to be 'Deep work'
```

The other four characterise seeding and the collapse reset — they are precisely what a naive "just delete the effect" breaks.

**The collapse test is proven non-vacuous**, since a redundancy claim needs a control:

| `key` | `windowOpenState` effect | collapse test |
|---|---|---|
| `windowId` | present (original) | GREEN |
| `windowId` | deleted (this PR) | GREEN |
| array index | deleted | **RED** |
| array index | present | GREEN |

So the key, not the effect, is what performs that reset.

**Real extension A/B** on the built artifact, identical script, only the build differing:

| build | session-rename draft after Cmd+Z |
|---|---|
| effects present (`index-BRyTObQm.js`) | **wiped to `"Delta"`** |
| effects deleted (`index-uPEHhWkB.js`) | **survived** |

Also verified live on the fixed build: window-group rename seeds correctly and its draft survives; collapse state resets in **both** directions across a session switch (collapse a window in session A, switch to B — all 7 windows expanded; switch back — expanded again). Window ids confirmed disjoint across the two stored sessions, which is the premise the deletion rests on. Console clean apart from the pre-existing lazy-chunk preload warnings.

One scope note: the live A/B discriminates for the *session* rename. For the *window* rename the effect depends on `title` alone, so the live Cmd+Z probe confirms the fix doesn't regress but does not by itself separate the two builds — the discriminating case (a rename arriving from another device) is the automated test, which was watched RED.

**Gates:** 353 tests pass (37 files, +6), `tsc` 0 errors, lint **0 errors / 28 warnings** — byte-identical to the ESLint 10 baseline — build succeeds, `npm audit` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)