### PR TITLE
Let native text undo win over the app shortcut (KAN-52)

### DIFF
--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -17,6 +17,30 @@ import { closeToast } from '../redux/slices/globalStateSlice';
 import { RateAndReviewModal } from './modals/RateAndReviewModal';
 import { FocusConfirmModal } from './modals/FocusConfirmModal';
 
+// KAN-52. The undo/redo shortcuts are registered on `window`, so they also see
+// keystrokes aimed at a text field. When they do, the browser's own undo stack
+// is the right handler and this one must stand down -- both by not dispatching
+// the app's session-level undo, and by not calling preventDefault(), which is
+// what actually suppresses the native undo.
+//
+// Deliberately a blanket tagName test rather than a list of text-ish input
+// types: every <input> in this app is a text field -- there are no checkboxes
+// or radios anywhere in src/ -- so there is nothing for the broader check to
+// get wrong today, and no type list to drift out of sync with the platform.
+// Revisit if a non-text input is ever added, since this would then also
+// silence the app shortcut while that control has focus.
+//
+// `target` is an EventTarget (no tagName, and nullable), so it has to be
+// narrowed before it can be inspected.
+function isNativelyUndoableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return (
+    target.tagName === 'INPUT' ||
+    target.tagName === 'TEXTAREA' ||
+    target.isContentEditable
+  );
+}
+
 export default function MainContainer() {
   const COLORS = useThemeColors();
   const dispatch: AppDispatch = useDispatch();
@@ -40,6 +64,10 @@ export default function MainContainer() {
   // Keyboard shortcut listener for undo/redo
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
+      // Guard the whole handler, not just undo: redo is native inside a text
+      // field too (cmd+shift+z on macOS, ctrl+y on Windows).
+      if (isNativelyUndoableTarget(event.target)) return;
+
       if (!isSettingsPage) {
         // check for ctrl+z
         if (event.ctrlKey && event.key === 'z') {

--- a/src/tests/components/undoShortcutScope.test.tsx
+++ b/src/tests/components/undoShortcutScope.test.tsx
@@ -1,0 +1,251 @@
+import { describe, expect, test } from 'vitest';
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import MainContainer from '../../components/MainContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  saveToTabContainerInternal,
+  selectTabContainer,
+} from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-52. MainContainer registers a `window` keydown listener for ctrl/cmd
+// +Z/+Y that only checks `isSettingsPage`. It never looks at `event.target`,
+// so it also fires while a text input has focus: it dispatches the app's
+// session-level undo AND calls preventDefault(), which suppresses the
+// browser's native text undo. The user gets nothing back and no feedback.
+//
+// The probe is the ACTION RECORDER, not the store contents. `undo` no-ops
+// when `past` is empty, and (see KAN-51) `restoreContainer` rebuilds
+// tabGroups via .map() so undo changes object identity rather than values --
+// a state-value check cannot see this trigger fire in either direction.
+// Whether the action was dispatched at all is the thing under test.
+
+const UNDO = 'undoRedo/undo';
+const REDO = 'undoRedo/redo';
+
+type Chord = {
+  key: string;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+};
+
+// Dispatched on the element itself rather than typed into a focused field:
+// keydown bubbles to the window listener carrying `target`, which is exactly
+// the path the real event takes. Returning the event lets a caller assert on
+// defaultPrevented -- the half of the defect that breaks native undo.
+function press(target: EventTarget, chord: Chord) {
+  const event = new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    ...chord,
+  });
+  act(() => {
+    target.dispatchEvent(event);
+  });
+  return event;
+}
+
+const buildGroup = (title: string) => ({
+  tabGroupId: 'group-1',
+  title,
+  createdTime: '2026-09-01 09:01:00',
+  createdAt: Date.UTC(2026, 8, 1, 9, 1, 0),
+  windowCount: 1,
+  tabCount: 1,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: 'win-1',
+      windowHeight: 1080,
+      windowWidth: 1920,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 1,
+      title: 'Morning',
+      tabs: [
+        {
+          tabId: 'w1-t0',
+          favicon: '',
+          title: 'Kagi',
+          url: 'https://example.com/w1/t0',
+        },
+      ],
+    },
+  ],
+});
+
+describe('undo/redo shortcuts yield to native text editing (KAN-52)', () => {
+  // CONTROL. Must stay green throughout: the guard has to scope the listener
+  // down, not switch it off. Without this a "return early always" fix passes
+  // every other test in this file.
+  describe('outside a text field the app shortcut still works', () => {
+    test('cmd+z on the document runs the app undo and claims the event', async () => {
+      const { seen } = await renderWithProviders(<MainContainer />);
+
+      const before = seen.length;
+      const event = press(document.body, { key: 'z', metaKey: true });
+
+      expect(seen.slice(before)).toContain(UNDO);
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    test('cmd+shift+z on the document runs the app redo and claims the event', async () => {
+      const { seen } = await renderWithProviders(<MainContainer />);
+
+      const before = seen.length;
+      const event = press(document.body, {
+        key: 'z',
+        metaKey: true,
+        shiftKey: true,
+      });
+
+      expect(seen.slice(before)).toContain(REDO);
+      expect(event.defaultPrevented).toBe(true);
+    });
+  });
+
+  // RED. The "save all open windows as a session" box is on screen the moment
+  // the popup opens, pre-filled with the current tab's title -- the single most
+  // reachable text field in the app, needing no sign-in and no saved sessions.
+  describe('inside the save-session name box', () => {
+    test('cmd+z neither runs the app undo nor blocks the native one', async () => {
+      const { container, seen } = await renderWithProviders(<MainContainer />);
+
+      const input = container.querySelector('input#name');
+      expect(input).toBeTruthy();
+
+      const before = seen.length;
+      const event = press(input!, { key: 'z', metaKey: true });
+
+      expect(seen.slice(before)).not.toContain(UNDO);
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    test('ctrl+z neither runs the app undo nor blocks the native one', async () => {
+      const { container, seen } = await renderWithProviders(<MainContainer />);
+
+      const input = container.querySelector('input#name');
+      const before = seen.length;
+      const event = press(input!, { key: 'z', ctrlKey: true });
+
+      expect(seen.slice(before)).not.toContain(UNDO);
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    // Redo is native inside a text field too -- cmd+shift+z on macOS, ctrl+y
+    // on Windows. The ticket flagged this as worth checking rather than
+    // assuming; the answer is that it has the same defect.
+    test('cmd+shift+z neither runs the app redo nor blocks the native one', async () => {
+      const { container, seen } = await renderWithProviders(<MainContainer />);
+
+      const input = container.querySelector('input#name');
+      const before = seen.length;
+      const event = press(input!, { key: 'z', metaKey: true, shiftKey: true });
+
+      expect(seen.slice(before)).not.toContain(REDO);
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    test('ctrl+y neither runs the app redo nor blocks the native one', async () => {
+      const { container, seen } = await renderWithProviders(<MainContainer />);
+
+      const input = container.querySelector('input#name');
+      const before = seen.length;
+      const event = press(input!, { key: 'y', ctrlKey: true });
+
+      expect(seen.slice(before)).not.toContain(REDO);
+      expect(event.defaultPrevented).toBe(false);
+    });
+  });
+
+  // The guard's contract is "any element the browser undoes natively", not
+  // "the inputs this app happens to render today". Nothing in src/ is a
+  // <textarea> or contentEditable, so without these two the clauses covering
+  // them are dead weight that no test touches -- dropping them from the
+  // predicate leaves the whole suite green. The elements are mounted directly
+  // rather than found in the tree for that reason: the listener is on
+  // `window`, so anything in the document reaches it by the real path.
+  describe('other natively-undoable elements', () => {
+    function mount(el: HTMLElement) {
+      document.body.appendChild(el);
+      return el;
+    }
+
+    test('cmd+z inside a textarea neither runs the app undo nor blocks the native one', async () => {
+      const { seen } = await renderWithProviders(<MainContainer />);
+      const area = mount(document.createElement('textarea'));
+
+      const before = seen.length;
+      const event = press(area, { key: 'z', metaKey: true });
+
+      expect(seen.slice(before)).not.toContain(UNDO);
+      expect(event.defaultPrevented).toBe(false);
+      area.remove();
+    });
+
+    // jsdom does not implement isContentEditable -- it reads back `undefined`
+    // even with the attribute set, and assigning `.contentEditable` throws.
+    // Defining it is emulating the one browser API the guard depends on, not
+    // stubbing the code under test: the predicate still runs for real and
+    // still has to decide. Confirmed against a real contentEditable element
+    // in the built extension separately, since jsdom cannot show that.
+    test('cmd+z inside a contentEditable element neither runs the app undo nor blocks the native one', async () => {
+      const { seen } = await renderWithProviders(<MainContainer />);
+      const editable = mount(document.createElement('div'));
+      Object.defineProperty(editable, 'isContentEditable', { value: true });
+
+      const before = seen.length;
+      const event = press(editable, { key: 'z', metaKey: true });
+
+      expect(seen.slice(before)).not.toContain(UNDO);
+      expect(event.defaultPrevented).toBe(false);
+      editable.remove();
+    });
+
+    // The other half of the contract: a focusable NON-editable element must
+    // still get the app shortcut. WindowEntryContainer renders exactly this --
+    // a div with tabIndex={0} and its own onKeyDown -- so this is the shape
+    // that would break if the guard keyed off "is focusable" instead.
+    test('cmd+z on a focusable non-editable div still runs the app undo', async () => {
+      const { seen } = await renderWithProviders(<MainContainer />);
+      const div = mount(document.createElement('div'));
+      div.tabIndex = 0;
+
+      const before = seen.length;
+      const event = press(div, { key: 'z', metaKey: true });
+
+      expect(seen.slice(before)).toContain(UNDO);
+      expect(event.defaultPrevented).toBe(true);
+      div.remove();
+    });
+  });
+
+  // RED. The ticket's headline scenario: mistyping a session rename and
+  // reaching for cmd+z. Driven through the real UI (click the title to enter
+  // edit mode) rather than by querying a hidden field, so the test also fails
+  // if the rename affordance stops being reachable.
+  describe('inside the session rename field', () => {
+    test('cmd+z neither runs the app undo nor blocks the native one', async () => {
+      const { seen } = await renderWithProviders(<MainContainer />, {
+        seedStore: (s) => {
+          s.dispatch(saveToTabContainerInternal(buildGroup('Research')));
+          s.dispatch(selectTabContainer('group-1'));
+        },
+      });
+
+      // By aria-label, not by title text: the session title also renders in
+      // the left pane entry, so findByText('Research') matches two elements.
+      await userEvent.click(await screen.findByLabelText('rename session'));
+      const input = screen.getByDisplayValue('Research');
+
+      const before = seen.length;
+      const event = press(input, { key: 'z', metaKey: true });
+
+      expect(seen.slice(before)).not.toContain(UNDO);
+      expect(event.defaultPrevented).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes KAN-52.

## The defect

`MainContainer` registers the undo/redo shortcuts on `window` and only checked `isSettingsPage`. It never looked at `event.target`, so the handler also fired for keystrokes aimed at a text field — dispatching the app's session-level undo and calling `preventDefault()`, which is what actually suppresses the browser's native text undo.

A user who mistyped while renaming a session and reached for Cmd+Z got nothing back and no feedback. Reachable in all four text fields on the main page (`UserInputContainer`'s search and save-name boxes, `HeroContainerRight`'s session rename, `WindowEntryContainer`'s window rename), with no sign-in and no saved sessions — the save-name box is on screen and pre-filled the moment the popup opens.

## The fix

An `isNativelyUndoableTarget(event.target)` guard at the top of the handler.

**Why the top, not inside the undo branch.** The four shortcut branches are independent `if`s, and redo is native inside a text field too (Cmd+Shift+Z on macOS, Ctrl+Y on Windows). A guard in the undo branch alone would leave the other three live.

**Why a blanket tagName test** rather than a list of text-ish input types: every `<input>` in this app is a text field — there are no checkboxes or radios anywhere in `src/` — so there is nothing for the broader check to get wrong today, and no type list to drift out of sync with the platform. Noted in the code as the thing to revisit if a non-text input is ever added.

## Evidence

**Live A/B against the built extension.** Control build (guard stashed) vs fixed build, identical script both times, different bundle hashes confirmed. Did the app call `preventDefault`?

| probe | control | fixed |
|---|---|---|
| input cmd+z | `true` | `false` |
| input ctrl+z | `true` | `false` |
| input cmd+shift+z | `true` | `false` |
| input ctrl+y | `true` | `false` |
| contentEditable cmd+z | `true` | `false` |
| **body cmd+z** (control) | `true` | `true` |
| **body cmd+shift+z** (control) | `true` | `true` |
| **focusable non-editable div** (control) | `true` | `true` |

The last three are the controls that keep this honest: the guard has to scope the listener down, not switch it off.

**The native undo stack is real and reachable.** With focus in the save-session box, `execCommand('undo')` took `"about:blankTYPOXYZ"` back to `"about:blankTYPO"`. A plain uncontrolled input in the same page behaved identically (`"HELLO"` → `""`), confirming the probe itself works rather than the app being special.

**What is *not* verified.** A CDP-synthesized `Meta+z` does not trigger Chrome's native undo command at all — the plain uncontrolled input ignored it too — so automation cannot drive the final keyboard-to-undo step end to end. What is proven is that the app no longer intercepts the keystroke; the browser is free to handle it.

## Tests

10 new tests in `src/tests/components/undoShortcutScope.test.tsx`. Written RED first: 5 failed / 2 passed against unfixed code.

The probe is the **action recorder**, not store contents — `undo` no-ops on an empty stack, and `restoreContainer` changes object identity rather than values (see KAN-51), so a state-value check cannot see this trigger fire in either direction.

Mutations run against the suite, all killed:

| mutation | result |
|---|---|
| M1 predicate always `true` (fix too broad) | 2 failed — the controls caught it |
| M2 guard moved below the undo branch | 4 failed |
| M3 drop `TEXTAREA` + `contentEditable` | 2 failed |
| M4 key off focusability, not editability | 2 failed |
| M5 drop `contentEditable` only | 1 failed |

M3 and M5 initially **survived** — the `TEXTAREA`/`contentEditable` clauses had no coverage because nothing in the app is either. Added tests that mount those elements directly, since the listener is on `window` and anything in the document reaches it by the real path.

jsdom does not implement `isContentEditable` (it reads back `undefined`, and assigning `.contentEditable` throws), so that clause is exercised with the property defined in the unit test and confirmed against a real `contentEditable` element in the browser, where Chrome reports `isContentEditable: true`.

## Gate

363 tests / 38 files (was 353 / 37), `tsc` 0 errors, lint 0 errors + 28 warnings (unchanged baseline), `npm audit` 0 vulnerabilities. Popup console clean apart from the pre-existing preload warning for the lazy-loaded `windows` chunk.

## Filed separately

- **KAN-54** — Shift+Z redo runs undo first and cancels itself out, so keyboard redo is dead on macOS. Found while writing this test; unrelated cause, not fixed here.
- **KAN-53** closed as a duplicate of KAN-52 (filed twice, 38 seconds apart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)