### PR TITLE
Make the undo/redo chords case-insensitive and mutually exclusive (KAN-54)

### DIFF
--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -68,40 +68,32 @@ export default function MainContainer() {
       // field too (cmd+shift+z on macOS, ctrl+y on Windows).
       if (isNativelyUndoableTarget(event.target)) return;
 
-      if (!isSettingsPage) {
-        // check for ctrl+z
-        if (event.ctrlKey && event.key === 'z') {
-          dispatch(undo());
-          dispatch(closeToast());
-          event.preventDefault();
-        }
+      if (isSettingsPage) return;
 
-        // check for command+z
-        if (event.metaKey && event.key === 'z') {
-          dispatch(undo());
-          dispatch(closeToast());
-          event.preventDefault();
-        }
+      // Every chord needs a platform modifier. ctrl and meta are treated
+      // interchangeably so one handler serves Windows/Linux and macOS.
+      if (!event.ctrlKey && !event.metaKey) return;
 
-        // check for ctrl+y or ctrl+shift+z
-        if (
-          (event.ctrlKey && event.key === 'y') ||
-          (event.ctrlKey && event.shiftKey && event.key === 'z')
-        ) {
-          dispatch(redo());
-          dispatch(closeToast());
-          event.preventDefault();
-        }
+      // KAN-54. `event.key` carries the SHIFTED character, so a real
+      // Shift+Z arrives as 'Z' -- and as 'z' when CapsLock inverts Shift for
+      // letters. Comparing against a lowercase literal missed the first case
+      // entirely, which is why macOS redo did nothing. Normalise instead.
+      const key = event.key.toLowerCase();
 
-        // check for command+y or command+shift+z
-        if (
-          (event.metaKey && event.key === 'y') ||
-          (event.metaKey && event.shiftKey && event.key === 'z')
-        ) {
-          dispatch(redo());
-          dispatch(closeToast());
-          event.preventDefault();
-        }
+      // Redo is tested first and returns. That ordering is what keeps the
+      // chords mutually exclusive: shift+z has to stop here, or it goes on to
+      // satisfy the plain-undo branch as well and the two cancel out.
+      if (key === 'y' || (key === 'z' && event.shiftKey)) {
+        dispatch(redo());
+        dispatch(closeToast());
+        event.preventDefault();
+        return;
+      }
+
+      if (key === 'z') {
+        dispatch(undo());
+        dispatch(closeToast());
+        event.preventDefault();
       }
     }
     window.addEventListener('keydown', handleKeyDown);

--- a/src/tests/components/undoRedoChords.test.tsx
+++ b/src/tests/components/undoRedoChords.test.tsx
@@ -1,0 +1,146 @@
+import { describe, expect, test } from 'vitest';
+import { act } from '@testing-library/react';
+
+import MainContainer from '../../components/MainContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+
+// KAN-54. Two defects in the same handler, and which one bites depends on the
+// key value the keyboard actually sends.
+//
+// 1. CASE. Every branch compared `event.key` against a lowercase literal, but
+//    `key` carries the SHIFTED character -- a real Cmd+Shift+Z arrives as 'Z'
+//    and matched nothing at all, so macOS keyboard redo did nothing.
+// 2. EXCLUSIVITY. The four branches were independent `if`s and the undo ones
+//    never excluded Shift, so a chord arriving as lowercase 'z' WITH shift
+//    (CapsLock inverts Shift for letters) satisfied both the undo and the redo
+//    branch and dispatched undo THEN redo -- exact inverses, netting nothing.
+//
+// The assertion is the EXACT action sequence, not `toContain`. "Contains redo"
+// passes against the cancelling double-dispatch, and a state check cannot tell
+// "redo worked" from "undo and redo cancelled" -- they end in the same place.
+
+const UNDO = 'undoRedo/undo';
+const REDO = 'undoRedo/redo';
+
+type Chord = {
+  key: string;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+};
+
+// Fired on document.body rather than typed: the listener is on `window`, and
+// a body target keeps it clear of the KAN-52 text-field guard.
+async function chord(c: Chord) {
+  const { seen } = await renderWithProviders(<MainContainer />);
+  const before = seen.length;
+  const event = new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    ...c,
+  });
+  act(() => {
+    document.body.dispatchEvent(event);
+  });
+  return {
+    actions: seen.slice(before).filter((a) => a.startsWith('undoRedo/')),
+    prevented: event.defaultPrevented,
+  };
+}
+
+describe('undo/redo keyboard chords dispatch exactly one action (KAN-54)', () => {
+  describe('undo', () => {
+    test('cmd+z', async () => {
+      const r = await chord({ key: 'z', metaKey: true });
+      expect(r.actions).toEqual([UNDO]);
+      expect(r.prevented).toBe(true);
+    });
+
+    test('ctrl+z', async () => {
+      const r = await chord({ key: 'z', ctrlKey: true });
+      expect(r.actions).toEqual([UNDO]);
+      expect(r.prevented).toBe(true);
+    });
+  });
+
+  describe('redo as a real keyboard sends it', () => {
+    // RED (case). A physical Shift+Z produces key 'Z'. The old handler
+    // compared against 'z' and matched nothing, so this dispatched no action
+    // and did not even preventDefault -- macOS redo was simply inert.
+    test('cmd+shift+Z', async () => {
+      const r = await chord({ key: 'Z', metaKey: true, shiftKey: true });
+      expect(r.actions).toEqual([REDO]);
+      expect(r.prevented).toBe(true);
+    });
+
+    test('ctrl+shift+Z', async () => {
+      const r = await chord({ key: 'Z', ctrlKey: true, shiftKey: true });
+      expect(r.actions).toEqual([REDO]);
+      expect(r.prevented).toBe(true);
+    });
+
+    test('ctrl+y', async () => {
+      const r = await chord({ key: 'y', ctrlKey: true });
+      expect(r.actions).toEqual([REDO]);
+      expect(r.prevented).toBe(true);
+    });
+
+    test('cmd+y', async () => {
+      const r = await chord({ key: 'y', metaKey: true });
+      expect(r.actions).toEqual([REDO]);
+      expect(r.prevented).toBe(true);
+    });
+  });
+
+  describe('redo when CapsLock inverts Shift and the key arrives lowercase', () => {
+    // RED (exclusivity). Here the old handler matched BOTH the undo branch
+    // (metaKey && key === 'z', no Shift exclusion) and the redo branch, so it
+    // dispatched [UNDO, REDO] -- which cancel exactly, and stamp lastModified
+    // twice on the way.
+    test('cmd+shift+z', async () => {
+      const r = await chord({ key: 'z', metaKey: true, shiftKey: true });
+      expect(r.actions).toEqual([REDO]);
+      expect(r.prevented).toBe(true);
+    });
+
+    test('ctrl+shift+z', async () => {
+      const r = await chord({ key: 'z', ctrlKey: true, shiftKey: true });
+      expect(r.actions).toEqual([REDO]);
+      expect(r.prevented).toBe(true);
+    });
+
+    test('cmd+Y', async () => {
+      const r = await chord({ key: 'Y', metaKey: true });
+      expect(r.actions).toEqual([REDO]);
+      expect(r.prevented).toBe(true);
+    });
+  });
+
+  // CONTROLS. The handler has to stay narrow: a fix that dispatches undo for
+  // anything, or claims every keystroke, passes every test above.
+  describe('chords the app must ignore', () => {
+    test('z with no modifier is ordinary typing', async () => {
+      const r = await chord({ key: 'z' });
+      expect(r.actions).toEqual([]);
+      expect(r.prevented).toBe(false);
+    });
+
+    test('shift+Z with no modifier is ordinary typing', async () => {
+      const r = await chord({ key: 'Z', shiftKey: true });
+      expect(r.actions).toEqual([]);
+      expect(r.prevented).toBe(false);
+    });
+
+    test('cmd+a is select-all and belongs to the browser', async () => {
+      const r = await chord({ key: 'a', metaKey: true });
+      expect(r.actions).toEqual([]);
+      expect(r.prevented).toBe(false);
+    });
+
+    test('cmd+shift+a is not a redo chord', async () => {
+      const r = await chord({ key: 'A', metaKey: true, shiftKey: true });
+      expect(r.actions).toEqual([]);
+      expect(r.prevented).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes KAN-54. Follows #155 (KAN-52) in the same handler.

## Two defects, and which one bites depends on the key value

**1. Case.** Every branch compared `event.key` against a lowercase literal, but `key` carries the *shifted* character. A real Cmd+Shift+Z arrives as `'Z'` and matched nothing at all — no action, no `preventDefault`. **macOS keyboard redo did nothing whatsoever.** Ctrl+Y was the only working redo chord, and it isn't a macOS convention.

**2. Exclusivity.** The four branches were independent `if`s and the undo branches never excluded Shift, so a chord arriving as lowercase `'z'` *with* Shift satisfied both the undo and the redo branch — dispatching `undo` then `redo`, exact inverses, netting no change while stamping `lastModified` (the merge tiebreaker) twice. Reachable with **CapsLock on**, which inverts Shift for letters.

Fixing either alone is insufficient: exclusivity alone leaves `'Z'` unmatched; case alone turns the common macOS path into the cancelling double-dispatch.

## The fix

The four overlapping branches collapse into one modifier check, a `toLowerCase()` normalisation, and a redo test that `return`s before the undo test can also match. Net −34/+26 lines.

## How I caught the second defect (and corrected my own ticket)

My original KAN-54 evidence used synthetic events with `key: 'z'` + `shiftKey`, and `press_key "Meta+Shift+z"`. **Both are unfaithful.** I found this by typing `Shift+z` into a plain text input through the same `press_key` path — it inserted a lowercase `"z"`, where a real keyboard inserts `"Z"`. So `press_key` doesn't apply Shift to printable characters, and my original "double-dispatch is why macOS redo is dead" claim described a chord a normal keyboard never sends. The ticket is corrected in a comment; the headline (macOS redo is dead) survived, the mechanism didn't.

## Evidence

**Live, against the built extension.** Toolbar button enabled-state reflects the stack depths (`isUndoableSelector` = `past.length > 0`, `isRedoableSelector` = `future.length > 0`):

| step | undo btn | redo btn |
|---|---|---|
| select a session | enabled | disabled |
| **Cmd+Z** | disabled | enabled |
| **Cmd+Shift+Z** (`key: 'Z'`) | **enabled** | **disabled** |

That third row is the fix working end to end — the real macOS chord consumed `future` and pushed back onto `past`. Pre-fix it was inert (`defaultPrevented: false`).

Dispatch-level check on the built extension, all six chords plus controls:

```
real_cmdShiftZ_uppercase   true      (was false pre-fix)
real_ctrlShiftZ_uppercase  true      (was false pre-fix)
capslock_cmdShiftZ_lower   true
cmd_y / cmd_z_undo         true
bare_z / bare_shift_Z      false     <- controls
cmd_a                      false     <- control
```

## Tests

13 new in `src/tests/components/undoRedoChords.test.tsx`, asserting the **exact action sequence** per chord — not `toContain`. "Contains redo" passes against the cancelling double-dispatch, and a state check cannot tell "redo worked" from "undo and redo cancelled" because they land in the same place.

RED first: **5 failed / 8 passed** — uppercase chords recording `[]`, lowercase-with-shift recording `['undoRedo/undo','undoRedo/redo']`.

| mutation | result |
|---|---|
| N1 drop `.toLowerCase()` | 3 failed |
| N2 drop the early `return` in redo | 4 failed |
| N3 drop `shiftKey` from the redo test | 4 failed |
| N4 drop the modifier guard | 2 failed |

KAN-52's text-field guard tests stay green throughout (23 passing across both files).

## Gate

376 tests / 39 files (was 363 / 38), `tsc` 0, lint 0 errors + 28 warnings (unchanged), build clean.

## Filed separately

**KAN-55** — undo consumes a history step but does not revert a session *rename*. Found verifying this end to end. Not a keyboard defect: the toolbar undo button reproduces it identically and never touches this handler. The same machinery works correctly for selection, so it's specific to what gets captured around a rename. Mechanism deliberately left un-guessed — it needs store instrumentation, not DOM probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)