### PR TITLE
Keep an undone content edit from being resurrected by the next sync (KAN-55)

### DIFF
--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -425,6 +425,55 @@ function touch(group: tabContainerData): void {
   group.lastModified = Date.now();
 }
 
+// Do two copies of a session carry the same content?
+//
+// Used by restoreContainer to tell the sessions a restore is reverting from
+// the ones it is merely carrying along unchanged (KAN-55).
+//
+// Written out rather than JSON.stringify-compared because key order is not
+// guaranteed to match: an imported container has been through JSON.parse,
+// while the live one was built by these reducers. Two equal sessions with
+// different key order would compare unequal, and every import would then
+// assert every session it contains.
+//
+// `lastModified` is deliberately excluded. It is the thing the caller is
+// deciding whether to rewrite, so including it would make every session that
+// had ever been touched look changed.
+function sameSessionContent(a: tabContainerData, b: tabContainerData): boolean {
+  return (
+    a.title === b.title &&
+    a.createdTime === b.createdTime &&
+    a.createdAt === b.createdAt &&
+    a.isAutoSave === b.isAutoSave &&
+    a.windowCount === b.windowCount &&
+    a.tabCount === b.tabCount &&
+    a.windows.length === b.windows.length &&
+    a.windows.every((window, i) => sameWindowContent(window, b.windows[i]))
+  );
+}
+
+// isSelected is not compared: it is per-device view state, not content, and
+// the merge already ignores it for the same reason.
+function sameWindowContent(a: windowGroupData, b: windowGroupData): boolean {
+  return (
+    a.windowId === b.windowId &&
+    a.title === b.title &&
+    a.windowHeight === b.windowHeight &&
+    a.windowWidth === b.windowWidth &&
+    a.windowOffsetTop === b.windowOffsetTop &&
+    a.windowOffsetLeft === b.windowOffsetLeft &&
+    a.tabCount === b.tabCount &&
+    a.tabs.length === b.tabs.length &&
+    a.tabs.every(
+      (tab, i) =>
+        tab.tabId === b.tabs[i].tabId &&
+        tab.title === b.tabs[i].title &&
+        tab.url === b.tabs[i].url &&
+        tab.favicon === b.tabs[i].favicon
+    )
+  );
+}
+
 // createdTime and createdAt are the same moment in two formats - a local wall
 // clock for display, and the instant the merge orders on. They are written
 // together, through this, so a reader can never catch them describing
@@ -751,21 +800,59 @@ export const tabContainerDataStateSlice = createSlice({
           tabGroup.lastModified ?? state.lastModified,
         ])
       );
+      // KAN-55. The live copy of each session, to tell the sessions this
+      // restore actually changes from the ones it is merely carrying along.
+      const liveGroup = new Map(
+        state.tabGroups.map((tabGroup) => [tabGroup.tabGroupId, tabGroup])
+      );
 
       const restored: TabMasterContainer = {
         ...action.payload,
         tabGroups: action.payload.tabGroups.map((tabGroup) => {
-          const buriedAt = withdrawnAt.get(tabGroup.tabGroupId);
-          if (buriedAt === undefined) return tabGroup;
+          const current = liveGroup.get(tabGroup.tabGroupId);
+
+          // KAN-55. The second thing a restore may have to outrank, alongside
+          // a tombstone: a live session whose content this restore is
+          // reverting. The merge resolves each session by its own
+          // `lastModified` with cloud winning ties, so handing a reverted
+          // session back with its snapshot timestamp let the cloud copy --
+          // which still holds the edit -- win the next merge. The undo applied
+          // locally and sync silently put the edit back.
+          //
+          // Compared by content, not by timestamp. `touch()` does advance a
+          // session's timestamp on every content change, but two edits inside
+          // the same millisecond are indistinguishable by it, which is not
+          // hypothetical: saving and renaming in quick succession produces
+          // exactly that, and the timestamp version of this check passed or
+          // failed depending on where a millisecond boundary happened to fall.
+          //
+          // Only sessions that actually differ are stamped. Bumping every
+          // restored session would make an undo assert the whole container,
+          // overwriting edits made on another device to sessions the user
+          // never touched here.
+          const supersededAt =
+            current !== undefined && !sameSessionContent(current, tabGroup)
+              ? liveAt.get(tabGroup.tabGroupId)
+              : undefined;
+
+          const mustOutrank = [
+            withdrawnAt.get(tabGroup.tabGroupId),
+            supersededAt,
+          ].filter((at): at is number => at !== undefined);
+
+          // Neither buried nor superseded: this restore is not changing this
+          // session, so leave its timestamp exactly as it was.
+          if (mustOutrank.length === 0) return tabGroup;
+
           return {
             ...tabGroup,
-            // Strictly after the tombstone, not merely Date.now(). Undoing a
-            // delete promptly enough lands in the same millisecond, and the
+            // Strictly after whatever it must beat, not merely Date.now().
+            // Undoing promptly enough lands in the same millisecond, and the
             // merge gives exact ties to cloud - so an equal timestamp loses to
-            // the very tombstone this is withdrawing. The un-delete happened
-            // after the delete by definition; encode that rather than trusting
-            // clock granularity.
-            lastModified: Math.max(Date.now(), buriedAt + 1),
+            // the very tombstone or edit this is superseding. The undo
+            // happened after the thing it undoes by definition; encode that
+            // rather than trusting clock granularity.
+            lastModified: Math.max(Date.now(), Math.max(...mustOutrank) + 1),
           };
         }),
         // `?? []` before the map, not `?.map`. The optional call yields

--- a/src/tests/redux/undoContentSurvivesSync.test.ts
+++ b/src/tests/redux/undoContentSurvivesSync.test.ts
@@ -27,6 +27,7 @@ import {
   syncStateWithFirestore,
 } from '../../redux/slices/globalStateSlice';
 import {
+  restoreContainer,
   saveToTabContainerInternal,
   updateTabGroupTitle,
   updateWindowGroupTitle,
@@ -214,5 +215,64 @@ describe('undoing a content edit survives the next sync (KAN-55)', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// restoreContainer serves the import path too, so the same stamping now
+// applies there. undoTombstone.test.ts already covers importing a backup that
+// predates a DELETE; this is the content equivalent, and it is the reason the
+// change is safe to make on a path the user reaches from Settings.
+//
+// A backup is by definition older than what it is replacing. Without the
+// stamp its sessions carry the file's timestamps, lose the next merge to the
+// cloud copy they were meant to replace, and the restore the user explicitly
+// asked for is silently reverted -- the same defect as the undo, one path
+// over.
+describe('importing a backup that predates a content edit (KAN-55)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mocks.loadFromFirestore.mockReset();
+    mocks.saveToFirestore.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('keeps the imported title through the next sync', async () => {
+    const { store } = makeTestStore();
+    store.dispatch(setSignedIn());
+    store.dispatch(setUserId('u1'));
+
+    store.dispatch(saveToTabContainerInternal(group('s1', 'Alpha')));
+    store.dispatch(
+      updateTabGroupTitle({ tabGroupId: 's1', editableTitle: 'RENAMED' })
+    );
+
+    // The cloud holds the rename.
+    const cloud: TabMasterContainer = JSON.parse(
+      JSON.stringify(store.getState().tabContainerDataState)
+    );
+
+    // The user restores a backup taken before that rename. Its timestamps are
+    // the file's -- deliberately older than the cloud's copy.
+    const backup: TabMasterContainer = {
+      lastModified: Date.UTC(2026, 7, 1, 0, 0, 0),
+      selectedTabGroupId: null,
+      tabGroups: [
+        {
+          ...group('s1', 'Alpha'),
+          lastModified: Date.UTC(2026, 7, 1, 0, 0, 0),
+        },
+      ],
+    };
+    store.dispatch(restoreContainer(backup));
+
+    const imported = store.getState().tabContainerDataState;
+    expect(titleOf('s1', imported.tabGroups)).toBe('Alpha');
+
+    mocks.loadFromFirestore.mockResolvedValue(cloud);
+    localStorage.setItem('tabContainerData', JSON.stringify(imported));
+    await store.dispatch(syncStateWithFirestore() as never);
+
+    expect(
+      titleOf('s1', store.getState().tabContainerDataState.tabGroups)
+    ).toBe('Alpha');
   });
 });

--- a/src/tests/redux/undoContentSurvivesSync.test.ts
+++ b/src/tests/redux/undoContentSurvivesSync.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Inlined rather than imported: a vi.hoisted block runs before the module
+// graph is evaluated, and common.ts reads window.screen at module load.
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+const mocks = vi.hoisted(() => ({
+  loadFromFirestore: vi.fn(async (): Promise<unknown> => undefined),
+  saveToFirestore: vi.fn<(userId: string, data: unknown) => Promise<void>>(
+    async () => undefined
+  ),
+}));
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: mocks.loadFromFirestore,
+  saveToFirestore: mocks.saveToFirestore,
+  displayToast: vi.fn(),
+}));
+
+import {
+  setSignedIn,
+  setUserId,
+  syncStateWithFirestore,
+} from '../../redux/slices/globalStateSlice';
+import {
+  saveToTabContainerInternal,
+  updateTabGroupTitle,
+  updateWindowGroupTitle,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import { undo } from '../../redux/slices/undoRedoSlice';
+import { makeTestStore } from '../setup/makeStore';
+import type {
+  tabContainerData,
+  TabMasterContainer,
+} from '../../redux/slices/tabContainerDataStateSlice';
+
+function group(id: string, title: string): tabContainerData {
+  return {
+    tabGroupId: id,
+    title,
+    createdTime: '2026-08-31 00:00:00',
+    createdAt: Date.UTC(2026, 7, 31, 0, 0, 0),
+    windowCount: 1,
+    tabCount: 1,
+    isAutoSave: false,
+    isSelected: false,
+    windows: [
+      {
+        windowId: `w-${id}`,
+        windowHeight: 100,
+        windowWidth: 100,
+        windowOffsetTop: 0,
+        windowOffsetLeft: 0,
+        tabCount: 1,
+        title: 'window',
+        tabs: [
+          {
+            tabId: `t-${id}`,
+            favicon: '',
+            title: 'Kagi',
+            url: 'https://kagi.com/',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+const titleOf = (id: string, groups: tabContainerData[]) =>
+  groups.find((g) => g.tabGroupId === id)?.title;
+
+// KAN-55, the content half of the defect undoTombstone.test.ts covers for
+// deletes.
+//
+// The merge resolves each session by its own `lastModified`, cloud winning ties
+// (collect() in mergeTabData.ts uses `at >= existing.at` with cloud collected
+// second). restoreContainer stamps a fresh timestamp ONLY on a session it is
+// withdrawing from a tombstone; every other session is handed back with the
+// timestamp it was snapshotted with.
+//
+// So undoing a rename hands the merge a session that is OLDER than the renamed
+// copy already in the cloud. The cloud wins and the rename comes back: the undo
+// applies locally, then sync silently reverses it. Verified against the real
+// extension -- online the title never reverts, offline it does.
+describe('undoing a content edit survives the next sync (KAN-55)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mocks.loadFromFirestore.mockReset();
+    mocks.saveToFirestore.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('keeps a session title the user undid', async () => {
+    const { store } = makeTestStore();
+    store.dispatch(setSignedIn());
+    store.dispatch(setUserId('u1'));
+
+    store.dispatch(saveToTabContainerInternal(group('s1', 'Alpha')));
+
+    store.dispatch(
+      updateTabGroupTitle({ tabGroupId: 's1', editableTitle: 'RENAMED' })
+    );
+    // The cloud received the rename, exactly as auto-sync would have pushed it.
+    const cloudAfterRename = JSON.parse(
+      JSON.stringify(store.getState().tabContainerDataState)
+    );
+    expect(titleOf('s1', cloudAfterRename.tabGroups)).toBe('RENAMED');
+
+    store.dispatch(undo());
+    const afterUndo = store.getState().tabContainerDataState;
+    // The undo itself works -- this is not where the defect is.
+    expect(titleOf('s1', afterUndo.tabGroups)).toBe('Alpha');
+
+    mocks.loadFromFirestore.mockResolvedValue(cloudAfterRename);
+    localStorage.setItem('tabContainerData', JSON.stringify(afterUndo));
+    await store.dispatch(syncStateWithFirestore() as never);
+
+    expect(
+      titleOf('s1', store.getState().tabContainerDataState.tabGroups)
+    ).toBe('Alpha');
+  });
+
+  // Same defect one level down: a window rename lives inside the session, so it
+  // rides on the same per-session timestamp and loses the same way.
+  it('keeps a window title the user undid', async () => {
+    const { store } = makeTestStore();
+    store.dispatch(setSignedIn());
+    store.dispatch(setUserId('u1'));
+
+    store.dispatch(saveToTabContainerInternal(group('s1', 'Alpha')));
+
+    store.dispatch(
+      updateWindowGroupTitle({
+        tabGroupId: 's1',
+        windowId: 'w-s1',
+        editableTitle: 'RENAMED WINDOW',
+      })
+    );
+    const cloudAfterRename = JSON.parse(
+      JSON.stringify(store.getState().tabContainerDataState)
+    );
+
+    store.dispatch(undo());
+    const afterUndo = store.getState().tabContainerDataState;
+    expect(afterUndo.tabGroups[0].windows[0].title).toBe('window');
+
+    mocks.loadFromFirestore.mockResolvedValue(cloudAfterRename);
+    localStorage.setItem('tabContainerData', JSON.stringify(afterUndo));
+    await store.dispatch(syncStateWithFirestore() as never);
+
+    expect(
+      store.getState().tabContainerDataState.tabGroups[0].windows[0].title
+    ).toBe('window');
+  });
+
+  // The control, and the one that decides whether the fix is scoped correctly:
+  // an undo must assert only the sessions it changes. If it stamps every
+  // session it is carrying, it silently outranks edits another device made to
+  // sessions the user never touched here -- turning an undo of a rename into
+  // data loss somewhere else.
+  //
+  // Time is pinned so the ordering is a property of the fix and not of how
+  // fast the test happens to run. An earlier version of this control gave the
+  // laptop's edit a timestamp 60s in the FUTURE, which beat any local stamp --
+  // so it passed even when the fix bumped every session. A mutation that
+  // widened the fix to `current !== undefined` survived it. The margins below
+  // exist to make that mutation fail.
+  it('does not clobber an unrelated session edited elsewhere', async () => {
+    const T0 = Date.UTC(2026, 8, 1, 12, 0, 0);
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(T0);
+
+      const { store } = makeTestStore();
+      store.dispatch(setSignedIn());
+      store.dispatch(setUserId('u1'));
+
+      store.dispatch(saveToTabContainerInternal(group('s1', 'Alpha')));
+      store.dispatch(saveToTabContainerInternal(group('s2', 'Bravo')));
+
+      vi.setSystemTime(T0 + 1_000);
+      store.dispatch(
+        updateTabGroupTitle({ tabGroupId: 's1', editableTitle: 'RENAMED' })
+      );
+
+      // The laptop edited s2 half a second after the save -- newer than this
+      // device's copy of s2, so the merge should keep it, but comfortably in
+      // the past by the time the undo below runs.
+      const cloud: TabMasterContainer = JSON.parse(
+        JSON.stringify(store.getState().tabContainerDataState)
+      );
+      const s2 = cloud.tabGroups.find((g) => g.tabGroupId === 's2')!;
+      s2.title = 'EDITED ON LAPTOP';
+      s2.lastModified = T0 + 500;
+
+      vi.setSystemTime(T0 + 2_000);
+      store.dispatch(undo());
+      const afterUndo = store.getState().tabContainerDataState;
+
+      mocks.loadFromFirestore.mockResolvedValue(cloud);
+      localStorage.setItem('tabContainerData', JSON.stringify(afterUndo));
+      await store.dispatch(syncStateWithFirestore() as never);
+
+      const merged = store.getState().tabContainerDataState.tabGroups;
+      // The undo this device performed survives.
+      expect(titleOf('s1', merged)).toBe('Alpha');
+      // The edit the other device made does too. A fix that stamps every
+      // restored session would stamp s2 at T0+2000, outranking the laptop's
+      // T0+500, and this device's stale "Bravo" would win.
+      expect(titleOf('s2', merged)).toBe('EDITED ON LAPTOP');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
Closes KAN-55.

Undoing a rename applied locally and was then **silently reversed by sync**, so the undo appeared to do nothing.

## Root cause

The merge resolves each session by its own `lastModified`, with cloud taking ties — `collect()` in `mergeTabData.ts` uses `at >= existing.at` and collects cloud second.

`restoreContainer` stamped a fresh timestamp **only** on a session it was withdrawing from a tombstone (`if (buriedAt === undefined) return tabGroup`). Every other session was handed back carrying the timestamp it was snapshotted with. So an undo handed the merge a session **older** than the edited copy already in the cloud — the cloud won, and the edit came back.

This is the same failure `undoTombstone.test.ts` exists for. The middleware comment already spells it out:

> *"Restoring blind lets the next merge re-apply the delete, so undo appears to work and then reverses itself."*

Only the delete half was ever fixed. This is the content half.

## Why content comparison, not timestamps

`touch()` advances a session's timestamp on every content change and nothing else, so "live is strictly newer than the snapshot" *looks* like it identifies exactly the changed sessions. I wrote that version first — **two edits in the same millisecond are indistinguishable by it**, and its tests passed or failed depending on where a millisecond boundary happened to fall. Saving and renaming in quick succession produces exactly that.

The fix compares content instead, and is deliberately **scoped**: only sessions that actually differ are stamped. Stamping every restored session would make an undo assert the whole container, overwriting edits another device made to sessions the user never touched here — turning an undo of a rename into data loss somewhere else.

## Evidence

**Offline was the control that isolated sync as the cause, before any code changed:**

| network | after rename | after Cmd+Z |
|---|---|---|
| online | `KAN55-CLEAN-PROBE` | `KAN55-CLEAN-PROBE` — no revert |
| offline | `OFFLINE-RENAME` | `TabKeeper - Tab Manager Extension` — **reverted** |

**Live A/B against the real extension**, signed in and online, same script, confirmed distinct bundle hashes:

| build | after rename | after Cmd+Z |
|---|---|---|
| control (`o_NkBuhD`) | `KAN55-CLEAN-PROBE` | `KAN55-CLEAN-PROBE` — no revert |
| fixed (`DENYto1E`) | `FIXED-BUILD-RENAME` | `KAN55-CLEAN-PROBE` — **reverted** |

Held after **8s — 16× the 500ms sync debounce** — so the sync genuinely ran and did not reverse it. That wait matters: the whole defect was the undo applying and *then* being undone.

Per-session timestamps afterwards show the scoping is right:

```
KAN55-CLEAN-PROBE (undone)   lastModified 1788324267594   <- stamped
Delta             (untouched) lastModified 1788316359915   <- unchanged
```

## Tests

3 new, driving the real store through a mocked Firestore round trip, in the shape of the existing `undoTombstone.test.ts`. Mutations:

| mutation | result |
|---|---|
| M1 never treat a session as superseded (old behaviour) | 3 failed |
| M2 treat every session as superseded (too broad) | 1 failed |
| M3 content compare ignores windows | 1 failed |
| M4 drop the tombstone half | 4 failed |

**M2 initially survived.** My control gave the other device a timestamp 60s in the *future*, which beat any local stamp — so it passed even against a fix that stamped everything, i.e. it passed for the wrong reason. Time is now pinned with fake timers so the ordering is a property of the fix rather than of how fast the test happens to run.

## A correction to the ticket

I filed KAN-55 saying the toolbar undo button reproduced it identically and therefore the fault was "in the capture layer, not the shortcut layer". The first half is right and the second is wrong — the capture layer is fine. `set` pushes the correct pre-edit snapshot and `undo` restores it correctly; both of my first two reproductions (raw store, and the real `App` with its boot effects) showed undo working, because **both were signed out**. The defect only exists where a cloud copy can win the merge back.

## Gate

379 tests / 40 files (was 376 / 39), tsc 0, lint 0 errors + 28 warnings, `npm audit` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)