### PR TITLE
Stop selection and search scheduling a Firestore sync (KAN-35)

### DIFF
--- a/src/redux/middleware/customMiddleware.ts
+++ b/src/redux/middleware/customMiddleware.ts
@@ -45,6 +45,23 @@ const actionsToCapture = [
 
 const isCapturableAction = (type: string) => actionsToCapture.includes(type);
 
+// Captured into undo/redo, but deliberately never synced: these change what the
+// user is looking at, not what is stored (KAN-35).
+//
+// Selection has to be filtered here rather than by leaving it out of
+// `actionsToCapture`, because that list drives both jobs at once -- dropping it
+// there would stop the sync by also dropping selection out of undo history.
+//
+// Nor is it enough to stop `selectTabContainer` bumping the container's
+// `lastModified`: `isDataStateChangeAction` compares state *references*, and the
+// reducer flips `isSelected` on every group regardless, so Immer hands back a
+// new reference and the branch fires anyway.
+//
+// This covers search too. Typing dispatches `setSearchInputText`, which is not
+// capturable at all; search reaches the network only because
+// TabGroupEntryContainer selects the first filtered result on every keystroke.
+const actionsToIgnoreForSync = [SELECT_TAB_CONTAINER_ACTION];
+
 const isUndoRedoAction = (type: string) =>
   [UNDO_ACTION, REDO_ACTION].includes(type);
 
@@ -117,7 +134,9 @@ export const customMiddleware: Middleware = (store) => {
     } else if (isDataStateChangeAction(action.type, prevState, nextState)) {
       const { tabContainerDataState } = nextState;
       store.dispatch(set({ tabContainerDataState: tabContainerDataState }));
-      store.dispatch(setIsDirty());
+      if (!actionsToIgnoreForSync.includes(action.type)) {
+        store.dispatch(setIsDirty());
+      }
     }
 
     return result;

--- a/src/tests/components/searchDoesNotSync.test.tsx
+++ b/src/tests/components/searchDoesNotSync.test.tsx
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'vitest';
+import { act } from '@testing-library/react';
+
+import TabGroupEntryContainer from '../../components/home/leftpane/TabGroupEntryContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  saveToTabContainerInternal,
+  selectTabContainer,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import {
+  openSearchPanel,
+  setSearchInputText,
+} from '../../redux/slices/globalStateSlice';
+import { IS_DIRTY_ACTION } from '../../utils/constants/actionTypes';
+
+// KAN-35, the search half. Typing never marks the store dirty by itself --
+// `setSearchInputText` is not a capturable action. It reached the network
+// indirectly: TabGroupEntryContainer selects the first filtered result on every
+// keystroke (the effect keyed on [searchInputText]), and selection used to mark
+// the store dirty.
+//
+// This is the user-visible statement of the ticket, and it is deliberately an
+// integration test rather than a store-level one: the store-level test in
+// src/tests/redux/selectionDoesNotSync.test.ts can only prove that a *direct*
+// selectTabContainer is clean, not that search still routes through it.
+//
+// The mutation test for this file: restore the unconditional
+// `store.dispatch(setIsDirty())` in customMiddleware's data-change branch.
+// Both tests below must go red.
+
+const buildGroup = (n: number, title: string) => ({
+  tabGroupId: `group-${n}`,
+  title,
+  createdTime: `2026-09-01 09:0${n}:00`,
+  windowCount: 1,
+  tabCount: 1,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: `win-${n}`,
+      windowHeight: 1080,
+      windowWidth: 1920,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 1,
+      title: `Window ${n}`,
+      tabs: [
+        {
+          tabId: `w${n}-t0`,
+          favicon: '',
+          title: `Page ${n}`,
+          url: `https://example.com/${n}`,
+        },
+      ],
+    },
+  ],
+});
+
+// saveToTabContainerInternal unshifts and selects what it just saved, so
+// "Bravo" is selected on entry. Searching for "Alpha" therefore moves the
+// selection, which is what makes the assertion meaningful -- a search that
+// re-selected the already-selected group would leave the old code clean too.
+const renderSeeded = () =>
+  renderWithProviders(<TabGroupEntryContainer />, {
+    seedStore: (s) => {
+      s.dispatch(saveToTabContainerInternal(buildGroup(1, 'Alpha')));
+      s.dispatch(saveToTabContainerInternal(buildGroup(2, 'Bravo')));
+      s.dispatch(openSearchPanel());
+    },
+  });
+
+describe('searching does not schedule a Firestore sync (KAN-35)', () => {
+  test('typing in the search box does not mark the store dirty', async () => {
+    const { store, seen } = await renderSeeded();
+    seen.length = 0;
+
+    await act(async () => {
+      store.dispatch(setSearchInputText('Alpha'));
+    });
+
+    // The control for this file: the search must actually have moved the
+    // selection. Without this, a search that matched nothing would leave the
+    // effect dormant and the dirty assertion would pass vacuously.
+    expect(store.getState().tabContainerDataState.selectedTabGroupId).toBe(
+      'group-1'
+    );
+    expect(seen).not.toContain(IS_DIRTY_ACTION);
+  });
+
+  test('clicking a session does not mark the store dirty', async () => {
+    const { store, seen } = await renderSeeded();
+    seen.length = 0;
+
+    await act(async () => {
+      store.dispatch(selectTabContainer('group-1'));
+    });
+
+    expect(store.getState().tabContainerDataState.selectedTabGroupId).toBe(
+      'group-1'
+    );
+    expect(seen).not.toContain(IS_DIRTY_ACTION);
+  });
+});

--- a/src/tests/redux/selectionDoesNotSync.test.ts
+++ b/src/tests/redux/selectionDoesNotSync.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// common.ts reads window.screen at module load, and this is a node test.
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+import { makeTestStore } from '../setup/makeStore';
+import {
+  saveToTabContainerInternal,
+  selectTabContainer,
+  updateTabGroupTitle,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import { IS_DIRTY_ACTION, SET_ACTION } from '../../utils/constants/actionTypes';
+import { setSignedIn } from '../../redux/slices/globalStateSlice';
+import { DEBOUNCE_TIME_WINDOW } from '../../utils/constants/common';
+
+const SYNC_PENDING_ACTION = 'global/syncStateWithFirestore/pending';
+
+// KAN-35. Selecting a session is view state: it belongs in localStorage and in
+// undo/redo, but it must not reach the network.
+//
+// Two describes, deliberately at different depths.
+//
+// The first asserts on setIsDirty, the flag the middleware branch sets. It is
+// one step upstream of the network, so it pins the branch itself regardless of
+// auth state -- but on its own it would be a proxy for the ticket's claim
+// rather than the claim.
+//
+// The second signs in and asserts on the sync thunk itself. That is the
+// behaviour the ticket names, and it is the one a signed-out store cannot see:
+// the middleware only reaches the debounced sync when isSignedIn and isAutoSync
+// are both true, so signed out there is no sync either way and a test would
+// pass against completely broken code.
+//
+// Every describe here pairs its negative assertion with a positive control for
+// the same reason: `not.toContain` passes just as happily when the harness is
+// blind as when the fix works.
+//
+// The mutation test for this file: restore the unconditional
+// `store.dispatch(setIsDirty())` in customMiddleware's data-change branch. Both
+// controls must stay green and both selection tests must go red.
+
+const buildWindow = () => ({
+  windowId: 'win-1',
+  windowHeight: 1080,
+  windowWidth: 1920,
+  windowOffsetTop: 0,
+  windowOffsetLeft: 0,
+  tabCount: 1,
+  title: 'Window 1',
+  tabs: [
+    {
+      tabId: 'w1-t0',
+      favicon: '',
+      title: 'Alpha Page',
+      url: 'https://example.com/alpha',
+    },
+  ],
+});
+
+// A factory rather than a shared constant: saveToTabContainerInternal mutates
+// its payload and Immer freezes it, so a reused object throws on the second
+// dispatch.
+const buildGroup = (n: number) => ({
+  tabGroupId: `group-${n}`,
+  title: `Group ${n}`,
+  createdTime: `2026-09-01 09:0${n}:00`,
+  windowCount: 1,
+  tabCount: 1,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [buildWindow()],
+});
+
+// Two groups, so that selecting one is a genuine change of selection rather
+// than a no-op the reducer might be excused for ignoring. saveToTabContainerInternal
+// unshifts and selects what it just saved, so group-2 is selected on entry.
+const seededStore = () => {
+  const { store, seen } = makeTestStore();
+  store.dispatch(saveToTabContainerInternal(buildGroup(1)));
+  store.dispatch(saveToTabContainerInternal(buildGroup(2)));
+  seen.length = 0;
+  return { store, seen };
+};
+
+describe('selection does not schedule a Firestore sync (KAN-35)', () => {
+  // The control. Without this, a middleware that never dispatched setIsDirty
+  // for anything at all would satisfy the two tests below.
+  test('a content edit still marks the store dirty', () => {
+    const { store, seen } = seededStore();
+
+    store.dispatch(
+      updateTabGroupTitle({
+        tabGroupId: 'group-1',
+        editableTitle: 'Renamed',
+      })
+    );
+
+    expect(seen).toContain(IS_DIRTY_ACTION);
+  });
+
+  test('selecting a session does not mark the store dirty', () => {
+    const { store, seen } = seededStore();
+
+    store.dispatch(selectTabContainer('group-1'));
+
+    expect(seen).not.toContain(IS_DIRTY_ACTION);
+  });
+
+  // Guards against the naive fix of dropping SELECT_TAB_CONTAINER_ACTION from
+  // actionsToCapture, which would stop the sync by also dropping selection out
+  // of undo/redo history.
+  test('selecting a session is still captured into undo history', () => {
+    const { store, seen } = seededStore();
+
+    store.dispatch(selectTabContainer('group-1'));
+
+    expect(seen).toContain(SET_ACTION);
+    expect(
+      store.getState().undoRedo.present.tabContainerDataState.selectedTabGroupId
+    ).toBe('group-1');
+  });
+});
+
+// The tests above assert on setIsDirty, which is one step upstream of the
+// network: the middleware only reaches the debounced sync when isSignedIn and
+// isAutoSync are both true, and a default store is signed out. That makes them
+// blind to the thing the ticket actually names.
+//
+// These sign in, so the gate is open and the debounced thunk really would fire.
+// isAutoSync already defaults to true.
+describe('selection does not reach Firestore when signed in (KAN-35)', () => {
+  const signedInStore = () => {
+    const { store, seen } = seededStore();
+    store.dispatch(setSignedIn());
+    seen.length = 0;
+    return { store, seen };
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // The control, and the one that proves the gate is genuinely open: without
+  // it, a store that was somehow still signed out would pass the test below
+  // while proving nothing at all.
+  test('a content edit does schedule the sync thunk', () => {
+    const { store, seen } = signedInStore();
+
+    store.dispatch(
+      updateTabGroupTitle({ tabGroupId: 'group-1', editableTitle: 'Renamed' })
+    );
+    vi.advanceTimersByTime(DEBOUNCE_TIME_WINDOW + 1);
+
+    expect(seen).toContain(SYNC_PENDING_ACTION);
+  });
+
+  test('selecting a session does not schedule the sync thunk', () => {
+    const { store, seen } = signedInStore();
+
+    store.dispatch(selectTabContainer('group-1'));
+    vi.advanceTimersByTime(DEBOUNCE_TIME_WINDOW + 1);
+
+    expect(seen).not.toContain(SYNC_PENDING_ACTION);
+  });
+});


### PR DESCRIPTION
Closes KAN-35.

## What was wrong

Clicking between saved sessions, or typing in the search box, marked the store dirty and scheduled a debounced Firestore round trip. Post-KAN-32 the merge usually computes `changedFromCloud === false` and writes nothing, so the cost is a wasted **read** per interaction rather than a write — but that is still one read per click against a free-tier quota, and on battery.

## Root cause

`customMiddleware`'s data-change branch does two jobs at once:

```ts
} else if (isDataStateChangeAction(action.type, prevState, nextState)) {
  store.dispatch(set({ tabContainerDataState }));  // capture into undo/redo
  store.dispatch(setIsDirty());                    // schedule a network sync
}
```

Selection legitimately needs the first and never the second. The code had no way to express that, so the two shipped together.

## Why not the two obvious alternatives

Both were checked against the code and rejected:

- **Dropping `SELECT_TAB_CONTAINER_ACTION` from `actionsToCapture`** would stop the sync by also dropping selection out of undo history, which it belongs in. The test `selecting a session is still captured into undo history` exists to catch exactly this.
- **Not bumping the container `lastModified`** — the direction the ticket suggested — *does not fix this at all*. `isDataStateChangeAction` compares state **references**, and the reducer flips `isSelected` on every group regardless of the timestamp, so Immer hands back a new reference and the branch fires anyway. That timestamp is a real but independent problem; filed as KAN-58.

## Search needed no separate fix

`setSearchInputText` is not in `actionsToCapture` at all. Typing reached the network only because `TabGroupEntryContainer` selects the first filtered result on every keystroke (`TabGroupEntryContainer.tsx:47-51`), so closing the selection path closes both. There is an integration test asserting that, rather than relying on the reasoning.

## Safety

Verified against all three production dispatch sites of `selectTabContainer` — the search effect, the click handler, and the focus-session thunk (`tabContainerDataStateSlice.ts:310`). All three are pure view state. The focus flow marks itself dirty via `saveToTabContainerInternal` when there is genuinely something to save, and the internal call at `slice:517` is a *case reducer*, not a dispatched action, so saving still syncs.

## Tests

Two depths, deliberately, because a signed-out store cannot see the behaviour the ticket names — the debounced sync is gated on `isSignedIn && isAutoSync`.

| Test | Depth |
|---|---|
| `a content edit still marks the store dirty` | control |
| `selecting a session does not mark the store dirty` | branch |
| `selecting a session is still captured into undo history` | guards the naive fix |
| `a content edit does schedule the sync thunk` | control, **signed in** |
| `selecting a session does not schedule the sync thunk` | **signed in**, asserts on `global/syncStateWithFirestore/pending` |
| `typing in the search box does not mark the store dirty` | integration, rendered component |
| `clicking a session does not mark the store dirty` | integration, rendered component |

Every negative assertion is paired with a positive control, because `not.toContain` passes just as happily when the harness is blind as when the fix works.

## Evidence

**Mutation test** — restored the unconditional `store.dispatch(setIsDirty())`:

```
× selecting a session does not mark the store dirty
× selecting a session does not schedule the sync thunk
× typing in the search box does not mark the store dirty
× clicking a session does not mark the store dirty
Tests  4 failed | 3 passed (7)
```

All four target tests red, all three controls green. Fix restored and confirmed absent from the file afterwards.

**Full gate on the final tree:**

```
Test Files  44 passed (44)
     Tests  400 passed (400)          (was 393 across 42 files)

8 passed (5.2s)                        Playwright, real built extension

app tsc   0 errors
e2e tsc   0 errors
lint      0 errors, 28 warnings        (unchanged baseline)
```

E2E steps 3 (clicking a session) and 5 (search filters the list) exercise the changed paths against the real artifact.

## Filed while here

- **KAN-57** (P3) — the same search effect pushes one undo entry per keystroke *and clears the redo stack*. Measured: 4 keystrokes → +4 undo entries, redo stack 1 → 0. Undo something, then search, and redo is silently dead. Not addressed here; it is a component/undo defect, not a sync one.
- **KAN-58** (P4) — selection still inflates the container `lastModified`, which legacy sessions inherit as their merge timestamp via `sessionTimestamp`. Narrow (pre-per-session-timestamp data only) but a data-loss shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)