### PR TITLE
Stop a selection change destroying the redo stack (KAN-57)

### DIFF
--- a/src/redux/middleware/customMiddleware.ts
+++ b/src/redux/middleware/customMiddleware.ts
@@ -1,6 +1,6 @@
 import { isAction, Middleware } from '@reduxjs/toolkit';
 
-import { set } from '../slices/undoRedoSlice';
+import { set, setPresentWithoutHistory } from '../slices/undoRedoSlice';
 import { debounce } from '../../utils/functions/local';
 import { DEBOUNCE_TIME_WINDOW } from '../../utils/constants/common';
 import { setIsDirty, syncStateWithFirestore } from '../slices/globalStateSlice';
@@ -45,12 +45,17 @@ const actionsToCapture = [
 
 const isCapturableAction = (type: string) => actionsToCapture.includes(type);
 
-// Captured into undo/redo, but deliberately never synced: these change what the
-// user is looking at, not what is stored (KAN-35).
+// Actions that change what the user is looking at rather than what is stored.
+// Selection is the only one today.
+//
+// These are tracked in history so `present` matches the screen, but they are
+// neither synced (KAN-35) nor recorded as undoable steps (KAN-57). Both
+// exclusions come off this one list because they are the same claim -- view
+// state is not data -- applied to the two things the branch below decides.
 //
 // Selection has to be filtered here rather than by leaving it out of
-// `actionsToCapture`, because that list drives both jobs at once -- dropping it
-// there would stop the sync by also dropping selection out of undo history.
+// `actionsToCapture`, because that list is what keeps `present` in step at all;
+// dropping it there would leave history restoring a stale selection.
 //
 // Nor is it enough to stop `selectTabContainer` bumping the container's
 // `lastModified`: `isDataStateChangeAction` compares state *references*, and the
@@ -58,9 +63,9 @@ const isCapturableAction = (type: string) => actionsToCapture.includes(type);
 // new reference and the branch fires anyway.
 //
 // This covers search too. Typing dispatches `setSearchInputText`, which is not
-// capturable at all; search reaches the network only because
+// capturable at all; search reaches both consequences only because
 // TabGroupEntryContainer selects the first filtered result on every keystroke.
-const actionsToIgnoreForSync = [SELECT_TAB_CONTAINER_ACTION];
+const viewStateOnlyActions = [SELECT_TAB_CONTAINER_ACTION];
 
 const isUndoRedoAction = (type: string) =>
   [UNDO_ACTION, REDO_ACTION].includes(type);
@@ -133,8 +138,15 @@ export const customMiddleware: Middleware = (store) => {
       store.dispatch(setIsDirty());
     } else if (isDataStateChangeAction(action.type, prevState, nextState)) {
       const { tabContainerDataState } = nextState;
-      store.dispatch(set({ tabContainerDataState: tabContainerDataState }));
-      if (!actionsToIgnoreForSync.includes(action.type)) {
+      const isViewStateOnly = viewStateOnlyActions.includes(action.type);
+
+      store.dispatch(
+        isViewStateOnly
+          ? setPresentWithoutHistory({ tabContainerDataState })
+          : set({ tabContainerDataState })
+      );
+
+      if (!isViewStateOnly) {
         store.dispatch(setIsDirty());
       }
     }

--- a/src/redux/slices/undoRedoSlice.ts
+++ b/src/redux/slices/undoRedoSlice.ts
@@ -58,10 +58,31 @@ export const undoRedoSlice = createSlice({
     setPresentStartup: (state, action: PayloadAction<UndoableStates>) => {
       state.present = action.payload;
     },
+
+    // Keep `present` in step with the store without recording an undoable step
+    // (KAN-57).
+    //
+    // For changes that are not edits -- selecting a session is the only one
+    // today. `present` still has to move, or the next undo would restore a
+    // stale selection; but `past` must not grow, and above all `future` must
+    // not be cleared. `set` clears it because a genuine new edit invalidates
+    // the redo branch, and selection creates no such branch: renaming, undoing,
+    // then clicking any other session used to make the rename unrecoverable.
+    //
+    // Distinct from setPresentStartup, which happens to have the same body.
+    // That one restores history at boot; sharing it would make a name that
+    // says "startup" carry the selection path too.
+    setPresentWithoutHistory: (
+      state,
+      action: PayloadAction<UndoableStates>
+    ) => {
+      state.present = action.payload;
+    },
   },
 });
 
-export const { set, undo, redo, setPresentStartup } = undoRedoSlice.actions;
+export const { set, undo, redo, setPresentStartup, setPresentWithoutHistory } =
+  undoRedoSlice.actions;
 
 // selectors
 export const isUndoableSelector = (state: RootState) =>

--- a/src/tests/components/searchDoesNotFloodUndo.test.tsx
+++ b/src/tests/components/searchDoesNotFloodUndo.test.tsx
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'vitest';
+import { act } from '@testing-library/react';
+
+import TabGroupEntryContainer from '../../components/home/leftpane/TabGroupEntryContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  saveToTabContainerInternal,
+  updateTabGroupTitle,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import {
+  openSearchPanel,
+  setSearchInputText,
+} from '../../redux/slices/globalStateSlice';
+import { undo } from '../../redux/slices/undoRedoSlice';
+
+// KAN-57, the search route. TabGroupEntryContainer selects the first filtered
+// result on every keystroke (the effect keyed on [searchInputText], which
+// unlike the click handler beside it has no same-id guard), so each character
+// typed used to push an undo entry and clear the redo stack.
+//
+// Measured before the fix, typing four characters: past 2 -> 6, future 1 -> 0.
+//
+// This is the component-level counterpart to
+// src/tests/redux/selectionIsNotUndoable.test.ts, which pins the same
+// behaviour at the store. Kept separate because only this one proves search
+// still routes through selection at all -- a store-level test cannot.
+
+const buildGroup = (n: number, title: string) => ({
+  tabGroupId: `group-${n}`,
+  title,
+  createdTime: `2026-09-01 09:0${n}:00`,
+  windowCount: 1,
+  tabCount: 1,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: `win-${n}`,
+      windowHeight: 1080,
+      windowWidth: 1920,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 1,
+      title: `Window ${n}`,
+      tabs: [
+        {
+          tabId: `w${n}-t0`,
+          favicon: '',
+          title: `Page ${n}`,
+          url: `https://example.com/${n}`,
+        },
+      ],
+    },
+  ],
+});
+
+const renderSeeded = () =>
+  renderWithProviders(<TabGroupEntryContainer />, {
+    seedStore: (s) => {
+      s.dispatch(saveToTabContainerInternal(buildGroup(1, 'Alpha')));
+      s.dispatch(saveToTabContainerInternal(buildGroup(2, 'Bravo')));
+      s.dispatch(openSearchPanel());
+    },
+  });
+
+const type = async (
+  store: Awaited<ReturnType<typeof renderSeeded>>['store'],
+  text: string
+) => {
+  for (let i = 1; i <= text.length; i++) {
+    await act(async () => {
+      store.dispatch(setSearchInputText(text.slice(0, i)));
+    });
+  }
+};
+
+describe('searching does not flood undo history (KAN-57)', () => {
+  test('typing four characters adds no undo entries', async () => {
+    const { store } = await renderSeeded();
+    const before = store.getState().undoRedo.past.length;
+
+    await type(store, 'Alph');
+
+    // The control: the search must actually have moved the selection, or the
+    // effect never fired and this passes for the wrong reason.
+    expect(store.getState().tabContainerDataState.selectedTabGroupId).toBe(
+      'group-1'
+    );
+    expect(store.getState().undoRedo.past.length).toBe(before);
+  });
+
+  test('typing does not destroy a pending redo', async () => {
+    const { store } = await renderSeeded();
+
+    await act(async () => {
+      store.dispatch(
+        updateTabGroupTitle({ tabGroupId: 'group-2', editableTitle: 'RENAMED' })
+      );
+    });
+    await act(async () => {
+      store.dispatch(undo());
+    });
+    expect(store.getState().undoRedo.future.length).toBeGreaterThan(0);
+
+    await type(store, 'Alph');
+
+    expect(store.getState().undoRedo.future.length).toBeGreaterThan(0);
+  });
+});

--- a/src/tests/redux/selectionDoesNotSync.test.ts
+++ b/src/tests/redux/selectionDoesNotSync.test.ts
@@ -24,6 +24,7 @@ import { setSignedIn } from '../../redux/slices/globalStateSlice';
 import { DEBOUNCE_TIME_WINDOW } from '../../utils/constants/common';
 
 const SYNC_PENDING_ACTION = 'global/syncStateWithFirestore/pending';
+const SET_PRESENT_WITHOUT_HISTORY_ACTION = 'undoRedo/setPresentWithoutHistory';
 
 // KAN-35. Selecting a session is view state: it belongs in localStorage and in
 // undo/redo, but it must not reach the network.
@@ -117,14 +118,20 @@ describe('selection does not schedule a Firestore sync (KAN-35)', () => {
   });
 
   // Guards against the naive fix of dropping SELECT_TAB_CONTAINER_ACTION from
-  // actionsToCapture, which would stop the sync by also dropping selection out
-  // of undo/redo history.
-  test('selecting a session is still captured into undo history', () => {
+  // actionsToCapture, which would stop the sync by also stopping `present`
+  // tracking the screen -- leaving the next undo to restore a stale selection.
+  //
+  // Asserts the without-history action, not `set`: KAN-57 made selection stop
+  // being an undoable step, so reaching `set` here would now be the bug. What
+  // undo/redo does with selection is covered in selectionIsNotUndoable.test.ts;
+  // this only pins that the sync fix did not sever history from the store.
+  test('selecting a session still updates the undo/redo present state', () => {
     const { store, seen } = seededStore();
 
     store.dispatch(selectTabContainer('group-1'));
 
-    expect(seen).toContain(SET_ACTION);
+    expect(seen).toContain(SET_PRESENT_WITHOUT_HISTORY_ACTION);
+    expect(seen).not.toContain(SET_ACTION);
     expect(
       store.getState().undoRedo.present.tabContainerDataState.selectedTabGroupId
     ).toBe('group-1');

--- a/src/tests/redux/selectionIsNotUndoable.test.ts
+++ b/src/tests/redux/selectionIsNotUndoable.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test, vi } from 'vitest';
+
+// common.ts reads window.screen at module load, and this is a node test.
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+import { makeTestStore } from '../setup/makeStore';
+import {
+  saveToTabContainerInternal,
+  selectTabContainer,
+  updateTabGroupTitle,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import { undo, redo } from '../../redux/slices/undoRedoSlice';
+
+// KAN-57. Selecting a session used to go through `set`, the same reducer a
+// content edit uses -- which pushes onto `past` and CLEARS `future`.
+//
+// Clearing redo is correct for a genuine edit: the old redo branch is
+// incompatible with the state the user just moved to. Selection creates no such
+// branch, so it inherited a consequence never meant for it. The measured
+// result was that renaming, undoing, then clicking any other session made the
+// rename permanently unrecoverable.
+//
+// Selection now updates `present` only, so history stays in sync with what is
+// on screen without selection becoming an undoable step of its own.
+
+const buildGroup = (n: number, title: string) => ({
+  tabGroupId: `group-${n}`,
+  title,
+  createdTime: `2026-09-01 09:0${n}:00`,
+  windowCount: 1,
+  tabCount: 1,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: `win-${n}`,
+      windowHeight: 1080,
+      windowWidth: 1920,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 1,
+      title: `Window ${n}`,
+      tabs: [
+        {
+          tabId: `w${n}-t0`,
+          favicon: '',
+          title: `Page ${n}`,
+          url: `https://example.com/${n}`,
+        },
+      ],
+    },
+  ],
+});
+
+// saveToTabContainerInternal unshifts and selects what it just saved, so
+// group-2 is the selected one on entry and group-1 is the one to click to.
+const seeded = () => {
+  const { store, seen } = makeTestStore();
+  store.dispatch(saveToTabContainerInternal(buildGroup(1, 'Alpha')));
+  store.dispatch(saveToTabContainerInternal(buildGroup(2, 'Bravo')));
+  seen.length = 0;
+  return { store, seen };
+};
+
+const titleOf = (
+  store: ReturnType<typeof makeTestStore>['store'],
+  id: string
+) =>
+  store
+    .getState()
+    .tabContainerDataState.tabGroups.find((g) => g.tabGroupId === id)?.title;
+
+const redoAvailable = (store: ReturnType<typeof makeTestStore>['store']) =>
+  store.getState().undoRedo.future.length > 0;
+
+const pastDepth = (store: ReturnType<typeof makeTestStore>['store']) =>
+  store.getState().undoRedo.past.length;
+
+describe('selection is not an undoable step (KAN-57)', () => {
+  // The control, and the reason this whole file cannot just assert "never
+  // clear future". Clearing redo after a real edit is correct undo semantics
+  // and must survive the fix; without this test, deleting the `state.future =
+  // []` line outright would pass everything else here.
+  test('a content edit still clears the redo stack', () => {
+    const { store } = seeded();
+
+    store.dispatch(
+      updateTabGroupTitle({ tabGroupId: 'group-2', editableTitle: 'RENAMED' })
+    );
+    store.dispatch(undo());
+    expect(redoAvailable(store)).toBe(true);
+
+    // A second, genuinely new edit. This is the case redo-clearing exists for.
+    store.dispatch(
+      updateTabGroupTitle({ tabGroupId: 'group-2', editableTitle: 'OTHER' })
+    );
+
+    expect(redoAvailable(store)).toBe(false);
+  });
+
+  // The headline defect. Measured before the fix: redoAvailable went true ->
+  // false on the click, and the rename could never be recovered.
+  test('selecting a session preserves the redo stack', () => {
+    const { store } = seeded();
+
+    store.dispatch(
+      updateTabGroupTitle({ tabGroupId: 'group-2', editableTitle: 'RENAMED' })
+    );
+    store.dispatch(undo());
+    expect(redoAvailable(store)).toBe(true);
+    expect(titleOf(store, 'group-2')).toBe('Bravo');
+
+    store.dispatch(selectTabContainer('group-1'));
+
+    expect(redoAvailable(store)).toBe(true);
+  });
+
+  // The recovery has to actually work, not merely be advertised by a
+  // non-empty stack.
+  test('the redo still recovers the edit after a selection', () => {
+    const { store } = seeded();
+
+    store.dispatch(
+      updateTabGroupTitle({ tabGroupId: 'group-2', editableTitle: 'RENAMED' })
+    );
+    store.dispatch(undo());
+    store.dispatch(selectTabContainer('group-1'));
+    store.dispatch(redo());
+
+    expect(titleOf(store, 'group-2')).toBe('RENAMED');
+  });
+
+  // Documented consequence, not an accident. `UndoableStates` is just
+  // `{ tabContainerDataState }`, and that slice holds the content AND the
+  // selection, so a snapshot cannot carry one without the other: redo restores
+  // the selection that was live when the edit happened.
+  //
+  // Measured: click group-1, redo, and the selection returns to group-2.
+  // Left as-is rather than preserving the current selection through a redo,
+  // because landing on the session whose edit was just restored is the more
+  // defensible behaviour -- the user sees what changed. Pinned here so that a
+  // future change to it has to be deliberate.
+  test('redo restores the selection that was live when the edit was made', () => {
+    const { store } = seeded();
+
+    store.dispatch(
+      updateTabGroupTitle({ tabGroupId: 'group-2', editableTitle: 'RENAMED' })
+    );
+    store.dispatch(undo());
+    store.dispatch(selectTabContainer('group-1'));
+    expect(store.getState().tabContainerDataState.selectedTabGroupId).toBe(
+      'group-1'
+    );
+
+    store.dispatch(redo());
+
+    expect(store.getState().tabContainerDataState.selectedTabGroupId).toBe(
+      'group-2'
+    );
+  });
+
+  // The control for the pair below.
+  test('a content edit still grows the undo stack', () => {
+    const { store } = seeded();
+    const before = pastDepth(store);
+
+    store.dispatch(
+      updateTabGroupTitle({ tabGroupId: 'group-2', editableTitle: 'RENAMED' })
+    );
+
+    expect(pastDepth(store)).toBe(before + 1);
+  });
+
+  test('selecting a session does not grow the undo stack', () => {
+    const { store } = seeded();
+    const before = pastDepth(store);
+
+    store.dispatch(selectTabContainer('group-1'));
+
+    expect(pastDepth(store)).toBe(before);
+  });
+
+  // Undo must skip past the selection to the last real edit, rather than
+  // spending itself undoing a click.
+  test('undo after a selection undoes the content edit, not the selection', () => {
+    const { store } = seeded();
+
+    store.dispatch(
+      updateTabGroupTitle({ tabGroupId: 'group-2', editableTitle: 'RENAMED' })
+    );
+    store.dispatch(selectTabContainer('group-1'));
+    store.dispatch(undo());
+
+    expect(titleOf(store, 'group-2')).toBe('Bravo');
+  });
+
+  // Carried over from the KAN-35 suite, where it guarded against dropping
+  // SELECT_TAB_CONTAINER_ACTION out of `actionsToCapture` entirely. That
+  // remains the hazard: history must keep tracking what is on screen, or the
+  // next undo restores a stale selection. Only the mechanism changed --
+  // `present` is now updated without touching either stack.
+  test('undo history still tracks the current selection', () => {
+    const { store } = seeded();
+
+    store.dispatch(selectTabContainer('group-1'));
+
+    expect(
+      store.getState().undoRedo.present.tabContainerDataState.selectedTabGroupId
+    ).toBe('group-1');
+  });
+});


### PR DESCRIPTION
Closes KAN-57.

## What was wrong

Rename a session, undo it, then click any other session — the rename is **permanently unrecoverable**. Measured against a real store:

```
rename group-2 "Bravo" -> "RENAMED"
undo()                        -> title=Bravo, redoAvailable=true
selectTabContainer('group-1') -> redoAvailable=false     ← gone
```

**The ticket understated this.** It described the trigger as search typing. A plain click does it too, which makes this a mainstream interaction rather than an edge case — and means the same-id guard the ticket suggested would only have reduced how often *search* trips it while leaving the click path fully broken.

## Root cause

Selection went through `set`, the same reducer a content edit uses:

```ts
set: (state, action) => {
  state.past.push(state.present);
  state.present = action.payload;
  state.future = [];          // ← clears redo
},
```

Clearing redo is correct for a genuine edit — the old redo branch is incompatible with the state the user just moved to. Selection creates no such branch, so it inherited a consequence never meant for it.

Search made it louder rather than causing it: the effect at `TabGroupEntryContainer.tsx:47-51` selects the first filtered result on every keystroke (and, unlike the click handler twelve lines below, has no same-id guard). Four characters pushed four entries — `past 2 → 6` — and wiped redo.

## The fix

Selection routes to a new `setPresentWithoutHistory`, which updates `present` and touches neither stack:

- `present` still has to move, or the next undo restores a stale selection.
- `past` must not grow — otherwise Cmd+Z spends itself undoing clicks.
- `future` must not be cleared — the actual defect.

Kept distinct from `setPresentStartup` despite the identical body, because sharing it would make a name that says *startup* carry the selection path too.

`actionsToIgnoreForSync` becomes `viewStateOnlyActions`, since the same list now governs two decisions — not synced (KAN-35) and not an undoable step (KAN-57). Both are the same claim, that view state is not data, applied to the two things that branch decides.

## One existing test changed rather than broke

The KAN-35 test `selecting a session is still captured into undo history` asserted selection reaches `set`. That was the *mechanism* for its real intent — "history must keep tracking the screen, don't drop selection from `actionsToCapture`". The intent survives and is still asserted; only the action changed. Renamed to `selecting a session still updates the undo/redo present state`, because the old name would now be a lie.

## Known, pinned consequence

Redo still drags the selection back to the session whose edit it restores. `UndoableStates` is just `{ tabContainerDataState }`, and that slice holds content *and* selection, so a snapshot cannot carry one without the other. Left as-is — landing on the session that just changed is the more defensible behaviour — but there is now a test pinning it, so any future change has to be deliberate.

## Evidence

**Mutation test** — routed selection back through `set`:

```
× typing four characters adds no undo entries
× typing does not destroy a pending redo
× selecting a session still updates the undo/redo present state
× selecting a session preserves the redo stack
× the redo still recovers the edit after a selection
× selecting a session does not grow the undo stack
× undo after a selection undoes the content edit, not the selection
Tests  7 failed | 402 passed (409)
```

All 7 red, every control green — `a content edit still clears the redo stack`, `a content edit still grows the undo stack`, and both KAN-35 sync assertions were untouched. That first control matters most: it stops "never clear future" being a passing answer.

**Full gate:**

```
Test Files  46 passed (46)
     Tests  410 passed (410)          (was 400 across 45 files)

8 passed (5.4s)                        Playwright, real built extension

app tsc   0 errors
e2e tsc   0 errors
lint      0 errors, 28 warnings        (unchanged baseline)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)