### PR TITLE
Stop selection inflating the container timestamp (KAN-58)

### DIFF
--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -417,10 +417,15 @@ export const deleteTab = createAsyncThunk(
   }
 );
 
-// Only content changes advance a session's timestamp. Selection must not:
-// selectTabContainer already bumps the container-wide lastModified on every
-// click and on every search keystroke, and letting that reach per-session
-// timestamps would make browsing on one device outrank a real edit on another.
+// Only content changes advance a session's timestamp, because a timestamp is
+// what the merge ranks copies by: letting browsing move one would make this
+// device's stale copy outrank a real edit on another.
+//
+// Selection now stamps nothing at all -- neither here nor the container-wide
+// timestamp (KAN-58). It used to move the container one, which reached these
+// sessions anyway through sessionTimestamp's fallback for any session lacking
+// its own; keeping selection out of `touch` only ever confined that to legacy
+// data rather than preventing it.
 function touch(group: tabContainerData): void {
   group.lastModified = Date.now();
 }
@@ -520,6 +525,14 @@ export const tabContainerDataStateSlice = createSlice({
     },
 
     // select tab group by tabGroupId
+    //
+    // Deliberately does NOT stamp `state.lastModified` (KAN-58). Selection is
+    // view state, and the container timestamp is the merge's fallback for any
+    // session carrying none of its own (sessionTimestamp, mergeTabData.ts) --
+    // so advancing it here made this device's stale copies of those sessions
+    // outrank another device's real edits, and fed `signature()` a difference
+    // that forced a write. Still persisted to localStorage: the selection has
+    // to survive a reload, it just must not look like an edit.
     selectTabContainer: (state, action: PayloadAction<string>) => {
       state.selectedTabGroupId = action.payload;
       state.tabGroups.forEach((tabGroup) => {
@@ -529,7 +542,6 @@ export const tabContainerDataStateSlice = createSlice({
           tabGroup.isSelected = false;
         }
       });
-      state.lastModified = Date.now();
 
       // update localstorage
       saveToLocalStorage('tabContainerData', state);

--- a/src/tests/redux/selectionDoesNotInflateTimestamp.test.ts
+++ b/src/tests/redux/selectionDoesNotInflateTimestamp.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test, vi } from 'vitest';
+
+// common.ts reads window.screen at module load, and this is a node test.
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+import { makeTestStore } from '../setup/makeStore';
+import {
+  replaceState,
+  selectTabContainer,
+  updateTabGroupTitle,
+  TabMasterContainer,
+  tabContainerData,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import { mergeTabContainers } from '../../utils/functions/mergeTabData';
+
+// KAN-58. `selectTabContainer` used to stamp the container-wide `lastModified`
+// on every click and every search keystroke.
+//
+// That is not cosmetic. `sessionTimestamp` (mergeTabData.ts:35-40) falls back
+// to the container's timestamp for any session that has none of its own, and
+// `touch()` only stamps the session it edits -- so a container stays partially
+// legacy indefinitely. Sessions written before per-session timestamps existed,
+// and never edited since, permanently inherit the container value.
+//
+// Browsing on device A therefore made A's stale copies of those sessions
+// outrank device B's genuine edits on the next sync, and B's edit was lost.
+// The same inflated value also feeds `signature()`, so it flipped
+// `changedFromCloud` to true and forced a write.
+
+// Deliberately WITHOUT `lastModified`: this is what a session saved before
+// per-session timestamps existed looks like, and the only shape that reaches
+// the container-level fallback.
+const legacySession = (id: string, title: string): tabContainerData => ({
+  tabGroupId: id,
+  title,
+  createdTime: '2026-01-01 09:00:00',
+  windowCount: 1,
+  tabCount: 1,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: `win-${id}`,
+      windowHeight: 1080,
+      windowWidth: 1920,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 1,
+      title: 'Window',
+      tabs: [
+        {
+          tabId: `${id}-t0`,
+          favicon: '',
+          title: 'Page',
+          url: 'https://example.com/',
+        },
+      ],
+    },
+  ],
+});
+
+// An old, fixed instant, so the assertions do not depend on the wall clock.
+const T = 1_700_000_000_000;
+
+const legacyContainer = (): TabMasterContainer => ({
+  lastModified: T,
+  selectedTabGroupId: 'group-1',
+  tabGroups: [
+    { ...legacySession('group-1', 'Alpha'), isSelected: true },
+    legacySession('group-2', 'Bravo'),
+  ],
+  deletedTabGroups: [],
+});
+
+const storeWithLegacyData = () => {
+  const { store } = makeTestStore();
+  store.dispatch(replaceState(legacyContainer()));
+  return store;
+};
+
+describe('selection does not inflate the container timestamp (KAN-58)', () => {
+  // The control. `lastModified` must still track real edits, or the merge
+  // loses its ordering signal entirely and "never stamp it" would pass every
+  // other test in this file.
+  test('a content edit still advances the container timestamp', () => {
+    const store = storeWithLegacyData();
+
+    store.dispatch(
+      updateTabGroupTitle({ tabGroupId: 'group-1', editableTitle: 'RENAMED' })
+    );
+
+    expect(store.getState().tabContainerDataState.lastModified).toBeGreaterThan(
+      T
+    );
+  });
+
+  test('selecting a session leaves the container timestamp alone', () => {
+    const store = storeWithLegacyData();
+
+    store.dispatch(selectTabContainer('group-2'));
+
+    expect(store.getState().tabContainerDataState.lastModified).toBe(T);
+  });
+
+  test('the selection itself still takes effect', () => {
+    const store = storeWithLegacyData();
+
+    store.dispatch(selectTabContainer('group-2'));
+
+    const state = store.getState().tabContainerDataState;
+    expect(state.selectedTabGroupId).toBe('group-2');
+    expect(
+      state.tabGroups.find((g) => g.tabGroupId === 'group-2')?.isSelected
+    ).toBe(true);
+  });
+});
+
+// The consequence, end to end. These merge a real post-browsing local state
+// against a cloud copy in which the other device genuinely edited a legacy
+// session, and assert the edit survives.
+describe('browsing does not outrank another device (KAN-58)', () => {
+  // Device B edited group-1 shortly after T, which stamps that session with
+  // its own timestamp. group-2 stays legacy on both sides.
+  const cloudWithEdit = (): TabMasterContainer => ({
+    lastModified: T + 100,
+    selectedTabGroupId: null,
+    tabGroups: [
+      {
+        ...legacySession('group-1', 'EDITED ON DEVICE B'),
+        lastModified: T + 100,
+      },
+      legacySession('group-2', 'Bravo'),
+    ],
+    deletedTabGroups: [],
+  });
+
+  const titleAfterMerge = (local: TabMasterContainer) =>
+    mergeTabContainers(
+      local,
+      cloudWithEdit(),
+      T + 10_000
+    ).merged.tabGroups.find((g) => g.tabGroupId === 'group-1')?.title;
+
+  // The control for the test below: proves the scenario is built correctly and
+  // that the cloud edit wins when nothing has inflated the local timestamp. If
+  // this ever fails, the test below proves nothing about browsing.
+  test("device B's edit wins when device A has not browsed", () => {
+    const store = storeWithLegacyData();
+
+    expect(titleAfterMerge(store.getState().tabContainerDataState)).toBe(
+      'EDITED ON DEVICE B'
+    );
+  });
+
+  // The defect. Selection is the only difference from the control above.
+  test("device B's edit survives device A merely clicking around", () => {
+    const store = storeWithLegacyData();
+
+    store.dispatch(selectTabContainer('group-2'));
+    store.dispatch(selectTabContainer('group-1'));
+
+    expect(titleAfterMerge(store.getState().tabContainerDataState)).toBe(
+      'EDITED ON DEVICE B'
+    );
+  });
+
+  // Browsing must not manufacture a write either: the inflated timestamp fed
+  // `signature()`, so it made the merge look different from the cloud even
+  // though no content had changed.
+  test('clicking around does not make the merge look changed from the cloud', () => {
+    const store = storeWithLegacyData();
+
+    store.dispatch(selectTabContainer('group-2'));
+
+    const local = store.getState().tabContainerDataState;
+    // Cloud identical to the untouched local container, so the only thing that
+    // could differ is a timestamp the browsing moved.
+    const { changedFromCloud } = mergeTabContainers(
+      local,
+      legacyContainer(),
+      T + 10_000
+    );
+
+    expect(changedFromCloud).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes KAN-58. Third and last of the "view state is not data" thread, after KAN-35 (#159) and KAN-57 (#160).

## What was wrong

`selectTabContainer` stamped `state.lastModified` on every click and every search keystroke.

That is not cosmetic. `sessionTimestamp` falls back to the container's timestamp for any session carrying none of its own:

```ts
function sessionTimestamp(group, container) {
  return group.lastModified ?? container.lastModified;
}
```

and `touch()` only stamps the session it edits — so a container stays **partially legacy indefinitely**. Sessions written before per-session timestamps existed, and never edited since, permanently inherit the container value.

## The data loss, demonstrated

Two tests that differ only by two `selectTabContainer` dispatches:

| test | before the fix |
|---|---|
| `device B's edit wins when device A has not browsed` | passes |
| `device B's edit survives device A merely clicking around` | **`expected 'Alpha' to be 'EDITED ON DEVICE B'`** |

Device B's edit is silently replaced by device A's stale copy, because A clicked around. The control on the row above proves the scenario is built correctly and that browsing is the only variable.

## And a spurious write

The same inflated value feeds `signature()`, which is what `changedFromCloud` is computed from — so browsing also made the merge look different from the cloud and forced a write of content that had not changed. Covered by `clicking around does not make the merge look changed from the cloud`.

## Audit before removing the stamp

The ticket asked for this explicitly. Every reader of the container timestamp:

| site | use | affected? |
|---|---|---|
| `mergeTabData.ts:39` | per-session fallback | **the defect** |
| `mergeTabData.ts:216` | `Math.max` into merged output | still correct |
| `firebase.ts:83` | persists it | no |
| `local.ts:495` | validates it is a number | no |
| `SettingsDetailsContainer.tsx:144` | stamps it on import | no |
| `undoRedoSlice.ts:46,55` | stamps on undo/redo | no |
| sync thunk | branches on `changedFromCloud`/`changedFromLocal` only — never a timestamp comparison | no |

Nothing depended on selection advancing it, and the full suite confirms it: **no existing test changed.**

Content reducers still stamp it, so the merge keeps its ordering signal — that is the control in the new file, and without it "never stamp it" would pass everything else. `saveToTabContainerInternal` stamps it directly before delegating to this reducer, so saving is unaffected. Selection is still written to localStorage; it has to survive a reload, it just must not look like an edit.

Also corrects the comment on `touch()`, which described selection bumping the container timestamp as a live fact the function was working around.

## Evidence

**Mutation test** — restored `state.lastModified = Date.now()`:

```
× selecting a session leaves the container timestamp alone
× device B's edit survives device A merely clicking around
× clicking around does not make the merge look changed from the cloud
Tests  3 failed | 413 passed (416)
```

All 3 targets red, all 3 controls green.

**Full gate:**

```
Test Files  47 passed (47)
     Tests  416 passed (416)          (was 410 across 46 files)

8 passed (5.1s)                        Playwright, real built extension

app tsc   0 errors
e2e tsc   0 errors
lint      0 errors, 28 warnings        (unchanged baseline)
```

## Scope note

The user-facing blast radius is narrow — only containers holding sessions written before per-session timestamps and never edited since, on a multi-device account. Zero impact on data saved by current versions. That is why it was filed P4 despite being a data-loss shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)