### PR TITLE
Make the header and icon controls real, keyboard-operable buttons (KAN-56, KAN-62, KAN-63)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -20,11 +20,20 @@ Deliberately manual. It is not part of `npm test` and no CI job runs it.
   filters, and the settings panel opens and closes.
 - `service-worker.spec.ts` — the lazy-load placeholder swap, and that the
   worker's listeners are registered at all.
+- `a11y-controls.spec.ts` — the header affordances are exposed as named
+  buttons and are operable by Enter and Space, and presentational icons stay
+  out of the accessibility tree.
 
 The service-worker spec is the reason this harness exists. Everything in the
 golden path is a popup-DOM assertion the jsdom component suite already covers;
 the placeholder swap runs in the service worker (because the popup is destroyed
 the moment a restored window takes focus) and cannot be expressed in jsdom.
+
+The a11y spec is the second thing jsdom cannot express. `dom-accessibility-api`,
+which backs Testing Library's `getByRole(name:)`, computes a name from an
+`aria-label` without applying the `generic`-role naming prohibition, so a jsdom
+version of those assertions passes against the broken code. Only a real
+accessibility tree can tell the two apart — see KAN-56.
 
 ## When something fails
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -20,9 +20,10 @@ Deliberately manual. It is not part of `npm test` and no CI job runs it.
   filters, and the settings panel opens and closes.
 - `service-worker.spec.ts` — the lazy-load placeholder swap, and that the
   worker's listeners are registered at all.
-- `a11y-controls.spec.ts` — the header affordances are exposed as named
-  buttons and are operable by Enter and Space, and presentational icons stay
-  out of the accessibility tree.
+- `a11y-controls.spec.ts` — the header affordances and the icon buttons are
+  exposed as named buttons and are operable by Enter and Space without also
+  scrolling the page, and presentational icons stay out of the accessibility
+  tree.
 
 The service-worker spec is the reason this harness exists. Everything in the
 golden path is a popup-DOM assertion the jsdom component suite already covers;

--- a/e2e/a11y-controls.spec.ts
+++ b/e2e/a11y-controls.spec.ts
@@ -1,0 +1,117 @@
+import type { BrowserContext, Page } from '@playwright/test';
+
+import { test, expect } from './fixtures/extension';
+import { buildContainer, buildSession, seedSessions } from './fixtures/seed';
+
+// These specs assert on ROLE plus accessible name, never on the raw
+// `[aria-label=...]` attribute. That distinction is the whole point of
+// KAN-56: an `aria-label` on a div with no role sits on the implicit
+// `generic` role, where naming is prohibited, so assistive tech drops it --
+// while a CSS attribute selector still matches it happily. A test written
+// against the attribute passes against the broken code and proves nothing.
+//
+// jsdom is not an option here for the same reason. `dom-accessibility-api`,
+// which backs Testing Library's `getByRole(name:)`, computes a name from
+// `aria-label` without applying the prohibition, so a vitest version of these
+// assertions would be green today.
+
+const RESEARCH = buildSession({
+  tabGroupId: 'session-research',
+  title: 'Research',
+});
+
+async function openPopup(
+  context: BrowserContext,
+  extensionId: string
+): Promise<Page> {
+  await seedSessions(context, buildContainer([RESEARCH]));
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/index.html`);
+  return page;
+}
+
+test.describe('accessible controls', () => {
+  // The control for every negative assertion below. It exercises the same
+  // component (Icon), the same prop (ariaLabel) and the same query, differing
+  // only in that this Icon owns its own onClick and so renders role="button".
+  // If this test ever fails, a zero count elsewhere in this file means the
+  // harness is broken, not that the app is.
+  test('CONTROL: an Icon that owns its onClick is exposed as a named button', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+
+    await expect(page.getByRole('button', { name: 'settings' })).toHaveCount(1);
+  });
+
+  test('the settings back control is a button with an accessible name (KAN-56)', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+    await page.getByRole('button', { name: 'settings' }).click();
+    await expect(page.getByText('Themes')).toBeVisible();
+
+    await expect(page.getByRole('button', { name: 'go back' })).toHaveCount(1);
+  });
+
+  test('the search back control is a button with an accessible name (KAN-56)', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+    await page.getByRole('button', { name: 'search' }).click();
+    await expect(page.locator('input#searchInput')).toBeVisible();
+
+    await expect(page.getByRole('button', { name: 'back' })).toHaveCount(1);
+  });
+
+  test('the search control is a button with an accessible name (KAN-56)', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+
+    await expect(page.getByRole('button', { name: 'search' })).toHaveCount(1);
+  });
+
+  // The other half of the Icon change: a presentational icon is hidden from
+  // the tree, not merely unnamed. Material Symbols renders its glyph as
+  // ligature TEXT, so without aria-hidden this button's content reads
+  // "arrow_back Back" -- which is exactly why golden-path.spec.ts:138 has to
+  // pass `exact: true` to stop "arrow_back" substring-matching "Back".
+  test('a presentational icon is hidden from the accessibility tree (KAN-56)', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+    await page.getByRole('button', { name: 'settings' }).click();
+    await expect(page.getByText('Themes')).toBeVisible();
+
+    await expect(
+      page.getByRole('button', { name: 'go back' })
+    ).toMatchAriaSnapshot(`- button "go back": Back`);
+  });
+
+  // KAN-62. The settings back affordance carries tabIndex={0} and an onClick
+  // but no key handler, so it takes focus and then does nothing -- WCAG 2.1.1,
+  // Level A. Enter and Space are asserted separately because a handler that
+  // covers only Enter (as the search pane's does) still fails a user who
+  // reaches for Space, which is what a real button honours.
+  for (const key of ['Enter', 'Space'] as const) {
+    test(`the settings back control is operable with ${key} (KAN-62)`, async ({
+      context,
+      extensionId,
+    }) => {
+      const page = await openPopup(context, extensionId);
+      await page.getByRole('button', { name: 'settings' }).click();
+      await expect(page.getByText('Themes')).toBeVisible();
+
+      await page.getByRole('button', { name: 'go back' }).focus();
+      await page.keyboard.press(key);
+
+      await expect(page.locator('input#name')).toBeVisible();
+    });
+  }
+});

--- a/e2e/a11y-controls.spec.ts
+++ b/e2e/a11y-controls.spec.ts
@@ -94,6 +94,56 @@ test.describe('accessible controls', () => {
     ).toMatchAriaSnapshot(`- button "go back": Back`);
   });
 
+  // Icon renders div[role=button] rather than a real <button>, because
+  // Button.tsx nests an Icon inside its own <button> and nested buttons are
+  // invalid HTML. That means its key handling is hand-rolled, and a
+  // hand-rolled handler is exactly where Space gets forgotten. Enter is the
+  // control: it passes today, so a Space failure is a gap in the handler
+  // rather than in the way this test drives the keyboard.
+  for (const key of ['Enter', 'Space'] as const) {
+    test(`an Icon button is operable with ${key}`, async ({
+      context,
+      extensionId,
+    }) => {
+      const page = await openPopup(context, extensionId);
+
+      await page.getByRole('button', { name: 'settings' }).focus();
+      await page.keyboard.press(key);
+
+      await expect(page.getByText('Themes')).toBeVisible();
+    });
+  }
+
+  // Space on a role=button that does not preventDefault scrolls the page --
+  // the classic hand-rolled-button bug. Asserted on defaultPrevented rather
+  // than on scroll position, because the popup is short enough that there may
+  // be nothing to scroll, which would make a scroll assertion pass for the
+  // wrong reason. The listener goes on document in the bubble phase, so it
+  // runs after React's root handler has had its say.
+  test('Space on an Icon button does not also scroll the page', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+
+    await page.evaluate(() => {
+      (window as unknown as { prevented: boolean[] }).prevented = [];
+      document.addEventListener('keydown', (e) => {
+        (window as unknown as { prevented: boolean[] }).prevented.push(
+          e.defaultPrevented
+        );
+      });
+    });
+
+    await page.getByRole('button', { name: 'settings' }).focus();
+    await page.keyboard.press('Space');
+
+    const prevented = await page.evaluate(
+      () => (window as unknown as { prevented: boolean[] }).prevented
+    );
+    expect(prevented).toEqual([true]);
+  });
+
   // KAN-62. The settings back affordance carries tabIndex={0} and an onClick
   // but no key handler, so it takes focus and then does nothing -- WCAG 2.1.1,
   // Level A. Enter and Space are asserted separately because a handler that

--- a/e2e/golden-path.spec.ts
+++ b/e2e/golden-path.spec.ts
@@ -126,18 +126,17 @@ test.describe('golden path', () => {
 
     await page.locator('[aria-label="settings"]').click();
 
-    // Asserted on a settings-only heading rather than the back control: the
-    // back affordance carries its aria-label on an inner Icon that has no
-    // onClick, so Icon renders no role="button" and the label is not exposed
-    // as an interactive element. The click handler lives on the wrapping div,
-    // which is what the visible "Back" text belongs to -- so that text is both
-    // what a user sees and what is actually clickable. (The a11y gap is real
-    // but out of scope here; see KAN-56.)
+    // Asserted on a settings-only heading, because the back control is not
+    // unique to this panel -- the search pane has one too.
     await expect(page.getByText('Themes')).toBeVisible();
 
-    // exact, because the Material icon renders its name as the ligature text
-    // `arrow_back`, which substring-matches "Back" and trips strict mode.
-    await page.getByText('Back', { exact: true }).click();
+    // Addressed by role and accessible name rather than by visible text. That
+    // became possible with KAN-56: the affordance is now a real <button>, so
+    // this line exercises the same path a screen-reader user takes. It also
+    // sidesteps the reason the old version needed `exact: true` -- the
+    // Material icon renders its name as the ligature text `arrow_back`, which
+    // substring-matches "Back" and trips strict mode.
+    await page.getByRole('button', { name: 'go back' }).click();
     await expect(page.locator('input#name')).toBeVisible();
   });
 });

--- a/src/components/common/ClickableRow.tsx
+++ b/src/components/common/ClickableRow.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { css } from '@emotion/react';
+
+interface ClickableRowProps {
+  /**
+   * Required, not optional. The children of a row are an Icon plus a label,
+   * and the Icon renders its Material Symbols glyph as ligature text, so
+   * name-from-content computes something like "arrow_back Back". There is no
+   * useful default; every row has to say what it is.
+   */
+  ariaLabel: string;
+  onClick: () => void;
+  tooltipText?: string;
+  style?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * A button whose visible content is composed of other components.
+ *
+ * This exists because three header affordances -- the settings Back, the
+ * search Back and the search opener -- each hand-rolled "a div that behaves
+ * like a button", and each arrived at a different level of correctness: none
+ * carried role="button", two handled Enter but not Space, and one handled no
+ * key at all, leaving it focusable but impossible to activate (KAN-62).
+ *
+ * Rendering a real <button> rather than <div role="button"> is the point: the
+ * role, the tab order, Enter, Space and the focus ring all come from the
+ * platform instead of from four props that a fourth call site could forget.
+ */
+const ClickableRow: React.FC<ClickableRowProps> = ({
+  ariaLabel,
+  onClick,
+  tooltipText,
+  style,
+  children,
+}) => {
+  // The UA stylesheet for <button> is what makes this swap risky, so the
+  // reset is explicit rather than `all: unset` -- `all` would also drop the
+  // inherited font and colour these rows rely on, and would reset the
+  // focus-visible outline that makes the control usable by keyboard.
+  //
+  // text-align and align-items are the two that actually bite: Chrome centres
+  // button content, and these rows are left-aligned flex rows.
+  const rowStyle = css`
+    appearance: none;
+    background: none;
+    border: none;
+    margin: 0;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+    text-align: inherit;
+    align-items: stretch;
+    cursor: pointer;
+    ${style && style}
+  `;
+
+  return (
+    <button
+      type="button"
+      title={tooltipText}
+      aria-label={ariaLabel}
+      css={rowStyle}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default ClickableRow;

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -57,10 +57,22 @@ const Icon: React.FC<IconProps> = ({
 }) => {
   const COLORS = useThemeColors();
 
+  // role="button" promises Enter AND Space. This has to be hand-rolled rather
+  // than handed to a native <button>, because Button.tsx renders a <button>
+  // that contains an Icon, and nested buttons are invalid HTML -- the browser
+  // recovers by unnesting the DOM.
+  //
+  // Forwarding to the element's own click() rather than calling onClick(e)
+  // directly is what lets onClick stay a MouseEventHandler honestly: React
+  // dispatches a real MouseEvent to the existing handler. Calling it with the
+  // keyboard event needed an `as any`, which compiled while handing every
+  // caller an object missing every mouse-specific field.
   function handleKeyPress(e: React.KeyboardEvent<HTMLDivElement>) {
-    if (e.key === 'Enter' && onClick) {
-      onClick(e as any);
-    }
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    // Space scrolls the page by default; Enter is harmless but is prevented
+    // too so the two keys cannot drift apart again.
+    e.preventDefault();
+    e.currentTarget.click();
   }
 
   // Define keyframe animation

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -4,22 +4,40 @@ import { css, keyframes } from '@emotion/react';
 
 import { useThemeColors } from '../../hooks/useThemeColors';
 
-interface IconProps {
+interface IconBaseProps {
   type: string;
   faviconUrl?: string;
-  onClick?: MouseEventHandler;
   disable?: boolean;
   focusable?: boolean;
   animationFrom?: string;
   animationTo?: string;
   animationDuration?: string;
   backgroundColor?: string;
-  ariaLabel?: string;
   tooltipText?: string;
   text?: string;
   size?: string;
   style?: string;
 }
+
+/**
+ * An Icon is either a control or a decoration, and the two are not allowed to
+ * blur into each other.
+ *
+ * With its own onClick it renders role="button" and must be named. Without
+ * one it is presentational: it is hidden from assistive tech, and it may not
+ * carry an ariaLabel at all -- a bare aria-label would land on the implicit
+ * `generic` role, where naming is prohibited, so assistive tech drops it while
+ * a CSS attribute selector still matches. That silent gap was KAN-56, and this
+ * union is what makes it a compile error rather than a thing to remember.
+ *
+ * When the click handler belongs on a wrapper rather than the icon, reach for
+ * ClickableRow instead of labelling the icon and hoping the label surfaces.
+ */
+type IconProps = IconBaseProps &
+  (
+    | { onClick: MouseEventHandler; ariaLabel: string }
+    | { onClick?: never; ariaLabel?: never }
+  );
 
 const Icon: React.FC<IconProps> = ({
   type,
@@ -99,6 +117,11 @@ const Icon: React.FC<IconProps> = ({
     <div
       title={tooltipText}
       aria-label={ariaLabel}
+      // Presentational icons are hidden outright rather than merely unnamed.
+      // The glyph renders as ligature text ("arrow_back", "add_box"), which
+      // would otherwise leak into the accessible name of whatever button
+      // contains it -- Button's inner Icon is exactly that case.
+      aria-hidden={onClick ? undefined : true}
       tabIndex={onClick && focusable ? 0 : -1}
       css={containerStyle}
       onClick={!disable ? onClick : undefined}

--- a/src/components/home/leftpane/HeroContainerLeft.tsx
+++ b/src/components/home/leftpane/HeroContainerLeft.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { css } from '@emotion/react';
 
 import Icon from '../../common/Icon';
+import ClickableRow from '../../common/ClickableRow';
 import MenuContainer from './MenuContainer';
 import { NormalLabel } from '../../common/Label';
 import { useFontFamily } from '../../../hooks/useFontFamily';
@@ -33,12 +34,6 @@ export default function HeroContainer() {
     dispatch(closeSearchPanel());
   };
 
-  function handleKeyPress(e: React.KeyboardEvent<HTMLDivElement>) {
-    if (e.key === 'Enter') {
-      handleClickSearch();
-    }
-  }
-
   const containerStyle = css`
     display: flex;
     justify-content: space-between;
@@ -52,45 +47,37 @@ export default function HeroContainer() {
 
   return isSearchPanel ? (
     <div css={containerStyle}>
-      <div
-        css={css`
-          display: flex;
-        `}
+      <ClickableRow
+        ariaLabel="back"
+        tooltipText={t('Go back')}
         onClick={handleBackClick}
-        onKeyDown={(e) => handleKeyPress(e)}
-        title={t('Go back')}
-        tabIndex={0}
+        style="display: flex;"
       >
-        <Icon ariaLabel="back" type="arrow_back" />
+        <Icon type="arrow_back" />
         <NormalLabel
           value={t('Back')}
           size="1.125rem"
           color={COLORS.TEXT_COLOR}
           style="padding-left: 8px; cursor: pointer;"
         />
-      </div>
+      </ClickableRow>
     </div>
   ) : (
     <div css={containerStyle}>
-      <div
-        css={css`
-          display: flex;
-          align-items: center;
-          min-width: 0;
-        `}
+      <ClickableRow
+        ariaLabel="search"
+        tooltipText={t('Search')}
         onClick={handleClickSearch}
-        onKeyDown={(e) => handleKeyPress(e)}
-        title={t('Search')}
-        tabIndex={0}
+        style="display: flex; align-items: center; min-width: 0;"
       >
-        <Icon ariaLabel="search" type="search" />
+        <Icon type="search" />
         <NormalLabel
           value={t('Tab Keeper')}
           size="1.125rem"
           color={COLORS.TEXT_COLOR}
           style="cursor: pointer;"
         />
-      </div>
+      </ClickableRow>
       <div
         css={css`
           flex-shrink: 0;

--- a/src/components/settings/leftpane/MenuContainerSettings.tsx
+++ b/src/components/settings/leftpane/MenuContainerSettings.tsx
@@ -1,8 +1,7 @@
 import { useDispatch } from 'react-redux';
 
-import { css } from '@emotion/react';
-
 import Icon from '../../common/Icon';
+import ClickableRow from '../../common/ClickableRow';
 import { NormalLabel } from '../../common/Label';
 import { AppDispatch } from '../../../redux/store';
 import { useThemeColors } from '../../../hooks/useThemeColors';
@@ -16,7 +15,7 @@ export default function MenuContainer() {
   const COLORS = useThemeColors();
   const { t } = useTranslation();
 
-  const containerStyle = css`
+  const containerStyle = `
     display: flex;
     justify-content: space-around;
     align-items: center;
@@ -30,19 +29,19 @@ export default function MenuContainer() {
   };
 
   return (
-    <div
-      css={containerStyle}
+    <ClickableRow
+      ariaLabel="go back"
+      tooltipText={t('Go back')}
       onClick={handleBackClick}
-      title={t('Go back')}
-      tabIndex={0}
+      style={containerStyle}
     >
-      <Icon ariaLabel="go back" type="arrow_back" />
+      <Icon type="arrow_back" />
       <NormalLabel
         value={t('Back')}
         size="1.125rem"
         color={COLORS.TEXT_COLOR}
         style="padding-left: 8px; cursor: pointer;"
       />
-    </div>
+    </ClickableRow>
   );
 }

--- a/src/tests/components/iconKeyboardActivation.test.tsx
+++ b/src/tests/components/iconKeyboardActivation.test.tsx
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'vitest';
+import { act, fireEvent, screen } from '@testing-library/react';
+
+import MenuContainer from '../../components/home/leftpane/MenuContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import { setSyncStatus } from '../../redux/slices/globalStateSlice';
+
+// KAN-63 changed how an Icon turns a keypress into its onClick: it used to
+// call onClick(e as any) directly, and now forwards to the element's own
+// click() so React dispatches a real MouseEvent.
+//
+// The sync icon is the one that matters. It is the entry point to
+// syncStateWithFirestore, and it is the only Icon whose `disable` flips at
+// runtime -- so it is where a change to the activation path could either stop
+// sync working or let it fire when it must not.
+//
+// jsdom is the right oracle here, unlike the accessible-name assertions in
+// e2e/a11y-controls.spec.ts: this is about which actions reach the store, not
+// about what a real accessibility tree exposes.
+
+const SYNC_PENDING = 'global/syncStateWithFirestore/pending';
+
+const syncIcon = () => screen.getByRole('button', { name: 'sync' });
+
+describe('Icon keyboard activation reaches the same handler as a click', () => {
+  // The control. If the sync thunk stopped being dispatched by a plain mouse
+  // click, every keyboard assertion below would fail for a reason that has
+  // nothing to do with the keyboard.
+  test('CONTROL: clicking the sync icon dispatches the sync thunk', async () => {
+    const { seen } = await renderWithProviders(<MenuContainer />);
+    seen.length = 0;
+
+    await act(async () => {
+      fireEvent.click(syncIcon());
+    });
+
+    expect(seen).toContain(SYNC_PENDING);
+  });
+
+  for (const key of [
+    { key: 'Enter', name: 'Enter' },
+    { key: ' ', name: 'Space' },
+  ]) {
+    test(`${key.name} on the sync icon dispatches the sync thunk`, async () => {
+      const { seen } = await renderWithProviders(<MenuContainer />);
+      seen.length = 0;
+
+      await act(async () => {
+        fireEvent.keyDown(syncIcon(), { key: key.key });
+      });
+
+      expect(seen).toContain(SYNC_PENDING);
+    });
+  }
+
+  // The behaviour that changed, and the reason this file exists.
+  //
+  // Icon only wires onClick onto the element when `disable` is false, but the
+  // old key handler called the onClick PROP directly and so never consulted
+  // that guard. Pressing Enter on the sync icon mid-sync therefore started a
+  // second sync -- the re-entrancy this codebase has fixed before. Routing
+  // through click() means the guard applies to the keyboard too.
+  test('a disabled sync icon does not dispatch on Enter', async () => {
+    const { store, seen } = await renderWithProviders(<MenuContainer />);
+
+    await act(async () => {
+      store.dispatch(setSyncStatus('loading'));
+    });
+    seen.length = 0;
+
+    await act(async () => {
+      fireEvent.keyDown(syncIcon(), { key: 'Enter' });
+    });
+
+    expect(seen).not.toContain(SYNC_PENDING);
+  });
+
+  // Paired with the negative above: the very same icon, in the very same
+  // render, still syncs once it is enabled again. Without this, the assertion
+  // above would pass against an Icon that had stopped responding to the
+  // keyboard entirely.
+  test('the same icon syncs again once it is re-enabled', async () => {
+    const { store, seen } = await renderWithProviders(<MenuContainer />);
+
+    await act(async () => {
+      store.dispatch(setSyncStatus('loading'));
+    });
+    await act(async () => {
+      fireEvent.keyDown(syncIcon(), { key: 'Enter' });
+    });
+    await act(async () => {
+      store.dispatch(setSyncStatus('idle'));
+    });
+    seen.length = 0;
+
+    await act(async () => {
+      fireEvent.keyDown(syncIcon(), { key: 'Enter' });
+    });
+
+    expect(seen).toContain(SYNC_PENDING);
+  });
+});


### PR DESCRIPTION
Fixes KAN-56, KAN-62 and KAN-63. Three defects in the same family: controls
that look like buttons, are focusable like buttons, and then do not behave
like buttons.

## What was wrong

Three header affordances -- the settings Back, the search Back and the search
opener -- were each a hand-rolled "div that behaves like a button", and each
had drifted to a different level of correctness.

- **None** carried `role="button"`. All three put their `aria-label` on an
  inner `Icon` that has no `onClick` of its own, so the label landed on the
  implicit `generic` role, where ARIA **prohibits** naming. Assistive tech
  dropped it while a CSS attribute selector still matched, and clicks still
  worked because they bubbled to the wrapper -- which is exactly why it went
  unnoticed. (KAN-56)
- The settings one handled **no key at all**. It took focus and could then not
  be activated, so the only way out of the settings panel was a mouse.
  WCAG 2.1.1 Keyboard, Level A. (KAN-62)
- Separately, `Icon`'s own handler covered Enter but not Space, so all 22 icon
  buttons scrolled the page instead of activating, and it reached `onClick`
  through an `as any` that passed a `KeyboardEvent` to a `MouseEventHandler`.
  (KAN-63)

KAN-56's description misattributed its own confirmed instance -- it called
`HeroContainerLeft.tsx:55-70` "the settings Back affordance", but that is the
*search panel's* Back; the settings one lives in `MenuContainerSettings.tsx`,
a file the ticket never named. It also asserted the control "is still operable
(the parent is focusable and handles Enter/Space)", which is false for the
settings instance and only half true elsewhere. Both corrections are recorded
on the ticket.

The audit KAN-56 left open resolves to exactly **3 of 25** `ariaLabel` call
sites; the other 22 pass `onClick` straight to `Icon`, or go through `Button`,
which renders a real `<button>` and carries its label correctly.

## What changed

`ClickableRow` renders a real `<button>`, so the role, the tab order, Enter,
Space and the focus ring come from the platform rather than from four props a
fourth call site could forget.

`Icon`'s props became a discriminated union: an `onClick` now **requires** an
`ariaLabel`, and without one the icon is presentational and may not carry a
label at all. Reintroducing the exact KAN-56 defect is now a compile error
rather than a silent runtime drop. Presentational icons are also `aria-hidden`,
which keeps the Material ligature text (`arrow_back`) out of the accessible
name of any button containing them.

`Icon` itself could **not** become a `<button>`: `Button.tsx` renders a
`<button>` that contains an `Icon`, and nested buttons are invalid HTML. So it
stays a `div[role="button"]` and its key handler was fixed by hand -- the one
place here where hand-rolled button semantics are justified. Forwarding to the
element's own `click()` lets React dispatch a real `MouseEvent`, so the
`as any` is gone rather than relocated. Lint warnings 28 -> 27.

## Evidence

RED first, against the built artifact at 1d9f949, with a control that passed
throughout -- so the failures are the app's, not the harness's:

```
✓ CONTROL: an Icon that owns its onClick is exposed as a named button
✘ settings back is a button with an accessible name (KAN-56)
✘ search back is a button with an accessible name (KAN-56)
✘ search control is a button with an accessible name (KAN-56)
✘ settings back is operable with Enter (KAN-62)
✘ settings back is operable with Space (KAN-62)

✓ an Icon button is operable with Enter     <- control for the pair below
✘ an Icon button is operable with Space     (KAN-63)
```

Five mutations, each **positively confirmed in the bundle** before being
believed. That check is not ceremony: one mutation failed to compile, so the
build never ran, and the next test pass would otherwise have silently
re-tested the previous mutation's bundle and reported a confident false result.

| Mutation | Result |
|---|---|
| `<button>` -> `<div role="button">` | only the 2 keyboard tests fail |
| drop `aria-label` | the 6 name-dependent tests fail |
| drop `aria-hidden` | only the tree snapshot fails: `"arrow_back Back"` vs `"Back"` |
| `Icon` Enter-only | only the 2 Space tests fail; KAN-56 and KAN-62 unmoved |
| drop `preventDefault` | only the scroll test fails |

The type guard was mutation-tested too: reintroducing the KAN-56 defect
produces `TS2322` at that line.

**Layout is unchanged, not just believed to be.** Pixel baselines recorded
from the *pre-fix* build across the home, settings and search screens all
still match after the `<div>` -> `<button>` swap, so the UA stylesheet reset is
complete. The baselines were confirmed deterministic before anything changed,
and the focus ring was checked separately since baselines only cover the
unfocused state.

## Why the tests are E2E and not jsdom

`dom-accessibility-api`, which backs Testing Library's `getByRole(name:)`,
computes a name from an `aria-label` **without** applying the `generic`-role
naming prohibition. A jsdom version of these assertions is green against the
broken code. Only a real accessibility tree distinguishes the two, so the
regression tests run in Playwright against the shipped artifact. This is
recorded in `e2e/README.md` so the next person does not "simplify" them into
vitest.

## Verification

457 unit tests / 52 files, 18 E2E (8 pre-existing), app tsc 0, e2e tsc 0,
lint 0 errors + 27 warnings, prettier clean apart from the pre-existing
`e2e/README.md` failure on main.

## Late finding: a keyboard-only sync re-entrancy

Checking that Firestore sync still worked after the `Icon` change turned up a
defect none of the three tickets described.

`Icon` wires `onClick` onto the element only when `disable` is false, but the
old key handler called the `onClick` **prop** directly and never consulted
that guard. The sync icon is the only `Icon` whose `disable` flips at runtime
(`MenuContainer.tsx:54-56`, while `syncStatus === 'loading'`) and it stays
focusable throughout -- so pressing Enter on it *during* a sync started a
second `syncStateWithFirestore` while one was in flight. Mouse users were
never affected, because the mouse path went through the guarded element
handler. That is why it went unseen.

Routing through the element's own `click()` applies the guard to the keyboard
too, so KAN-63's fix closes this as a side effect. Covered by
`src/tests/components/iconKeyboardActivation.test.tsx`; mutating `Icon` back
to the pre-KAN-63 handler:

```
✓ CONTROL: clicking the sync icon dispatches the sync thunk
✓ Enter on the sync icon dispatches the sync thunk
✘ Space on the sync icon dispatches the sync thunk
✘ a disabled sync icon does not dispatch on Enter
✓ the same icon syncs again once it is re-enabled
```

The last case is the positive control for the negative one: it proves the
disabled assertion is not passing merely because the icon stopped responding
to the keyboard.

Unit tests are now 462 across 53 files.

## Not in scope

- Six more `e.key === 'Enter'` handlers on non-Icon rows
  (`TabGroupEntry`, `WindowEntryContainer` x3, `HeroContainerRight`,
  `SettingsCategoryContainer`) look like the same defect class and are not
  touched here. `TextBox`'s Enter handler is correct as-is -- Space must type
  a space in a text field.
- All 25 `ariaLabel` values are hardcoded English while their `tooltipText`
  siblings are translated, so screen-reader users on the other nine locales
  hear English.

Neither is filed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

