### PR TITLE
Put every enabled control in the keyboard tab order (KAN-64, 66, 67, 68)

### DIFF
--- a/e2e/a11y-controls.spec.ts
+++ b/e2e/a11y-controls.spec.ts
@@ -15,6 +15,13 @@ import { buildContainer, buildSession, seedSessions } from './fixtures/seed';
 // `aria-label` without applying the prohibition, so a vitest version of these
 // assertions would be green today.
 
+// The title is deliberately left as "Research" even though it substring-
+// matches the "search" control: `getByRole(name:)` matches a SUBSTRING unless
+// `exact: true` is passed, and this fixture is the cheapest standing reminder
+// of that. It is the same hazard golden-path.spec.ts:138 already guards
+// against, where the ligature text "arrow_back" substring-matches "Back".
+// KAN-64 made it bite for real, because the session row is now a button named
+// after its title.
 const RESEARCH = buildSession({
   tabGroupId: 'session-research',
   title: 'Research',
@@ -61,7 +68,7 @@ test.describe('accessible controls', () => {
     extensionId,
   }) => {
     const page = await openPopup(context, extensionId);
-    await page.getByRole('button', { name: 'search' }).click();
+    await page.getByRole('button', { name: 'search', exact: true }).click();
     await expect(page.locator('input#searchInput')).toBeVisible();
 
     await expect(page.getByRole('button', { name: 'back' })).toHaveCount(1);
@@ -73,7 +80,9 @@ test.describe('accessible controls', () => {
   }) => {
     const page = await openPopup(context, extensionId);
 
-    await expect(page.getByRole('button', { name: 'search' })).toHaveCount(1);
+    await expect(
+      page.getByRole('button', { name: 'search', exact: true })
+    ).toHaveCount(1);
   });
 
   // The other half of the Icon change: a presentational icon is hidden from
@@ -164,4 +173,188 @@ test.describe('accessible controls', () => {
       await expect(page.locator('input#name')).toBeVisible();
     });
   }
+});
+
+// Clicks the session row near its left edge, over the title, rather than at
+// its geometric centre.
+//
+// The Open/Switch/Delete block is absolutely positioned over the right-hand
+// ~170px of a ~321px row and appears on hover, so the centre of the row is
+// underneath it. Nothing about that changed in KAN-64 -- the same pixels
+// belonged to the same icons before -- but the DOM relationship did: those
+// icons used to be DESCENDANTS of the clickable container, and Playwright
+// permits a click whose hit target is a descendant of the locator. Now that
+// the action is on an inner ClickableRow they are SIBLINGS, so the same click
+// is reported as intercepted.
+//
+// A user selects a session by clicking its title, which is what this does.
+async function selectSession(page: Page): Promise<void> {
+  await page
+    .getByRole('button', { name: 'Research' })
+    .click({ position: { x: 20, y: 20 } });
+}
+
+// Walks the real tab order from the top of the document and returns the
+// accessible name of each stop. This is the only way to test reachability
+// honestly: `locator.focus()` succeeds on a tabindex=-1 element, so a test
+// that focuses a control directly proves nothing about whether a keyboard
+// user could ever have got there.
+async function tabOrderNames(page: Page, steps: number): Promise<string[]> {
+  await page.locator('body').press('Tab');
+  const names: string[] = [];
+  for (let i = 0; i < steps; i++) {
+    names.push(
+      await page.evaluate(() => {
+        const el = document.activeElement;
+        if (!el || el === document.body) return '<body>';
+        // Accessible-name precedence, simplified to the three sources this app
+        // actually uses: aria-label, then content, then title. `title` is not
+        // decoration here -- the theme buttons carry no aria-label and no text,
+        // so it is the only name they have.
+        return (
+          el.getAttribute('aria-label') ||
+          el.textContent?.trim() ||
+          el.getAttribute('title') ||
+          '<unnamed>'
+        );
+      })
+    );
+    await page.keyboard.press('Tab');
+  }
+  return names;
+}
+
+test.describe('controls are reachable by keyboard', () => {
+  // KAN-64. Four list rows were `tabIndex={0}` divs with an onClick and no
+  // role: they took a tab stop, were exposed as `generic` -- where ARIA
+  // PROHIBITS naming, so the name was dropped -- and ignored Space.
+  //
+  // These have to run in a real browser for the same reason the KAN-56
+  // assertions do: dom-accessibility-api names a role-less div happily, so a
+  // jsdom version of `getByRole('button', { name })` is green against the
+  // broken code.
+  test('the session row is a button with an accessible name (KAN-64)', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+
+    await expect(page.getByRole('button', { name: 'Research' })).toHaveCount(1);
+  });
+
+  test('the settings category row is a button with an accessible name (KAN-64)', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+    await page.getByRole('button', { name: 'settings' }).click();
+
+    // "Display" is the category ROW; "Themes" is a heading inside the pane it
+    // opens. The row is the control KAN-64 is about.
+    await expect(page.getByRole('button', { name: 'Display' })).toHaveCount(1);
+  });
+
+  test('the window and tab rows are buttons with accessible names (KAN-64)', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+    await selectSession(page);
+
+    await expect(
+      page.getByRole('button', { name: 'Morning reading' })
+    ).toHaveCount(1);
+    await expect(
+      page.getByRole('button', { name: 'Open in new tab: Example Domain' })
+    ).toHaveCount(1);
+  });
+
+  // Enter is the control. It worked before this change on every one of these
+  // rows, so a Space failure is a gap in the row's own key handling rather
+  // than in the way this test drives the keyboard.
+  for (const key of ['Enter', 'Space'] as const) {
+    test(`the session row is operable with ${key} (KAN-64)`, async ({
+      context,
+      extensionId,
+    }) => {
+      const page = await openPopup(context, extensionId);
+
+      await page.getByRole('button', { name: 'Research' }).focus();
+      await page.keyboard.press(key);
+
+      await expect(
+        page.getByRole('button', { name: 'Morning reading' })
+      ).toBeVisible();
+    });
+  }
+
+  // KAN-68. These eight controls had `focusable` wired to mouse-hover state,
+  // so they were never in the tab order at all. Asserted by walking the real
+  // tab order rather than by focusing them directly.
+  test('session row actions are reachable by Tab (KAN-68)', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+
+    const names = await tabOrderNames(page, 12);
+
+    expect(names).toContain('open all windows');
+    expect(names).toContain('switch to session');
+    expect(names).toContain('delete session');
+  });
+
+  // Delete tab and Delete window group are the two that matter most: unlike
+  // the session actions, they have no alternate path anywhere in the UI, so
+  // before this change they could not be performed without a mouse at all.
+  test('window and tab actions are reachable by Tab (KAN-68)', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+    await selectSession(page);
+    await expect(
+      page.getByRole('button', { name: 'Morning reading' })
+    ).toBeVisible();
+
+    const names = await tabOrderNames(page, 20);
+
+    expect(names).toContain('delete window group');
+    expect(names).toContain('delete');
+  });
+
+  // The other half of KAN-68: being in the tab order is useless if focus
+  // lands on something painted at opacity 0. Hover is a pointer-only signal,
+  // so :focus-within is what reveals these to a keyboard user.
+  test('focusing a row action reveals it (KAN-68)', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+    const actions = page.locator('div:has(> [aria-label="delete session"])');
+
+    // The control: unfocused and unhovered, the block really is invisible, so
+    // the assertion below can tell the two states apart.
+    await expect(actions).toHaveCSS('opacity', '0');
+
+    await page.getByRole('button', { name: 'delete session' }).focus();
+
+    await expect(actions).toHaveCSS('opacity', '1');
+  });
+
+  // KAN-67. `focusableButton` had no default, so `tabIndex={onClick &&
+  // focusableButton ? 0 : -1}` put 32 of 36 clickable Buttons out of the tab
+  // order -- the whole settings pane among them.
+  test('settings buttons are reachable by Tab (KAN-67)', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+    await page.getByRole('button', { name: 'settings' }).click();
+    await expect(page.getByText('Themes')).toBeVisible();
+
+    const names = await tabOrderNames(page, 25);
+
+    expect(names.join('|')).toMatch(/Light/);
+  });
 });

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -15,7 +15,6 @@ interface ButtonProps {
   tooltipText?: string;
   iconSize?: string;
   iconStyle?: string;
-  focusableButton?: boolean;
   style?: string;
 }
 
@@ -28,7 +27,6 @@ const Button: React.FC<ButtonProps> = ({
   tooltipText,
   iconSize,
   iconStyle,
-  focusableButton,
   style,
 }) => {
   const COLORS = useThemeColors();
@@ -71,19 +69,26 @@ const Button: React.FC<ButtonProps> = ({
   // No wrapper element: the button must be the flex child itself, otherwise a
   // width: 100% passed through `style` resolves against a shrink-wrapped div
   // and collapses back to the button's own text width.
+  //
+  // Deliberately no tabIndex. A <button> is keyboard-focusable by default, so
+  // the only thing this element could ever compute here is a way to LOSE that
+  // -- which is precisely what it used to do. `focusableButton` had no default
+  // value, so `tabIndex={onClick && focusableButton ? 0 : -1}` put 32 of the
+  // 36 clickable call sites out of the tab order, taking the whole settings
+  // pane with them (KAN-67). The prop is gone rather than defaulted to true:
+  // a prop whose only power is to break something breaks it the moment a call
+  // site forgets, and 32 of 36 forgot.
   return (
     <button
       title={tooltipText}
       aria-label={ariaLabel}
       css={buttonStyle}
       onClick={onClick}
-      tabIndex={onClick && focusableButton ? 0 : -1}
     >
       {iconType && (
         <Icon
           type={iconType}
           disable={true}
-          focusable={true}
           size={iconSize}
           style={iconSpacing}
         />

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -7,8 +7,15 @@ import { useThemeColors } from '../../hooks/useThemeColors';
 interface IconBaseProps {
   type: string;
   faviconUrl?: string;
+  /**
+   * Whether the control is currently unavailable. Drives everything that
+   * follows from that -- the aria-disabled state, the pointer cursor and the
+   * hover highlight -- so there is exactly one prop to get right.
+   *
+   * It deliberately does NOT remove the icon from the tab order. See the
+   * comment on aria-disabled below.
+   */
   disable?: boolean;
-  focusable?: boolean;
   animationFrom?: string;
   animationTo?: string;
   animationDuration?: string;
@@ -44,7 +51,6 @@ const Icon: React.FC<IconProps> = ({
   faviconUrl,
   onClick,
   disable,
-  focusable = true,
   animationFrom,
   animationTo,
   animationDuration,
@@ -106,17 +112,23 @@ const Icon: React.FC<IconProps> = ({
     ${hoverAnimation}
   `;
 
+  // An icon affords a click when it has one to give and is not disabled. This
+  // used to key off a separate `focusable` prop, which also drove the tab
+  // index -- so call sites reached for it to control the look and silently
+  // edited the tab order (KAN-68).
+  const isActionable = Boolean(onClick) && !disable;
+
   const containerStyle = css`
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
     padding: 4px;
-    cursor: ${focusable ? 'pointer' : 'default'};
+    cursor: ${isActionable ? 'pointer' : 'default'};
     user-select: none;
     transition: background-color 0.2s;
     background-color: ${backgroundColor};
-    ${focusable &&
+    ${isActionable &&
     `&:hover {
       background-color: ${hoverColor};
     }`}
@@ -134,7 +146,17 @@ const Icon: React.FC<IconProps> = ({
       // would otherwise leak into the accessible name of whatever button
       // contains it -- Button's inner Icon is exactly that case.
       aria-hidden={onClick ? undefined : true}
-      tabIndex={onClick && focusable ? 0 : -1}
+      // Announced as unavailable, but still reachable -- deliberately, and
+      // against KAN-66's stated direction. The sync icon disables WHILE you
+      // are operating it: press Enter, the thunk starts, `disable` flips true.
+      // A control that leaves the tab order at that instant drops focus to
+      // <body> and loses the user's place. aria-disabled states the fact
+      // without the focus loss, which is what it exists for.
+      aria-disabled={disable ? true : undefined}
+      // Hover state must never reach this: it is a pointer-only signal, and
+      // routing it here is what made eight row controls keyboard-unreachable
+      // (KAN-68).
+      tabIndex={onClick ? 0 : -1}
       css={containerStyle}
       onClick={!disable ? onClick : undefined}
       onKeyDown={(e) => handleKeyPress(e)}

--- a/src/components/home/leftpane/MenuContainer.tsx
+++ b/src/components/home/leftpane/MenuContainer.tsx
@@ -76,7 +76,6 @@ export default function MenuContainer() {
         onClick={handleClickUndo}
         style={isUndoable ? 'opacity: 1;' : 'opacity: 0.3;'}
         disable={!isUndoable}
-        focusable={isUndoable}
       />
       <Icon
         ariaLabel="redo"
@@ -85,7 +84,6 @@ export default function MenuContainer() {
         onClick={handleClickRedo}
         style={isRedoable ? 'opacity: 1;' : 'opacity: 0.3;'}
         disable={!isRedoable}
-        focusable={isRedoable}
       />
       <Icon
         ariaLabel="sync"

--- a/src/components/home/leftpane/TabGroupEntry.tsx
+++ b/src/components/home/leftpane/TabGroupEntry.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 
 import { css } from '@emotion/react';
 
+import ClickableRow from '../../common/ClickableRow';
 import Icon from '../../common/Icon';
 import { NormalLabel } from '../../common/Label';
 import { RootState } from '../../../redux/store';
@@ -19,7 +20,13 @@ import { useTranslation } from 'react-i18next';
 
 interface TabGroupEntryProps {
   tabGroupData: tabContainerData;
-  onTabGroupClick: MouseEventHandler;
+  /**
+   * Takes no event. It was typed MouseEventHandler while its only caller
+   * passed a zero-argument arrow, which is what let the old keyboard path get
+   * away with `onTabGroupClick(e as any)` -- handing a KeyboardEvent to
+   * something the compiler believed was a MouseEventHandler.
+   */
+  onTabGroupClick: () => void;
   onOpenAllClick: MouseEventHandler;
   onFocusClick: MouseEventHandler;
   onDeleteClick: MouseEventHandler;
@@ -55,13 +62,9 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
   const { title, createdTime, createdAt, windowCount, tabCount, isSelected } =
     tabGroupData;
 
-  function handleKeyPress(e: React.KeyboardEvent<HTMLDivElement>) {
-    if (e.key === 'Enter') {
-      onTabGroupClick(e as any);
-    }
-  }
-
-  const leftStyle = css`
+  // A plain string, not css``, because it is handed to ClickableRow's `style`
+  // prop, which composes it into the button's own reset.
+  const leftStyle = `
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -83,6 +86,13 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
     align-items: center;
     opacity: ${isHovered ? 1 : 0};
     transition: opacity 0.1s ease-out;
+    /* Hover reveals these to a pointer; focus-within is the same reveal for
+       the keyboard. Without it the controls are in the tab order (KAN-68) but
+       land on something invisible, which is arguably worse than not reaching
+       them at all. */
+    &:focus-within {
+      opacity: 1;
+    }
   `;
 
   const containerStyle = css`
@@ -99,16 +109,28 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
     background-color: ${isSelected && COLORS.SELECTION_COLOR};
   `;
 
+  // The row's primary action lives on the inner ClickableRow, not on this
+  // container, and that placement is the whole fix for KAN-64. The container
+  // was a role-less div carrying tabIndex={0} and onClick: focusable, but
+  // exposed as `generic`, where ARIA prohibits naming -- so it reached the
+  // tab order as an anonymous stop that announced nothing.
+  //
+  // It cannot simply become a <button> or gain role="button" either, because
+  // the Open/Switch/Delete controls are inside it and nesting buttons is
+  // invalid HTML. Moving the action onto the left column instead makes them
+  // siblings. `leftStyle` is width: 100%, so the clickable area is unchanged;
+  // the action block is absolutely positioned on top of it.
   return (
     <div
-      tabIndex={0}
       css={containerStyle}
-      onClick={onTabGroupClick}
-      onKeyDown={(e) => handleKeyPress(e)}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      <div css={leftStyle}>
+      <ClickableRow
+        ariaLabel={title}
+        onClick={onTabGroupClick}
+        style={leftStyle}
+      >
         <NormalLabel
           style="max-width: 100%;"
           value={title}
@@ -138,7 +160,7 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
               no offset, kept only for sessions saved before createdAt. */}
           {getPrettyDate(createdAt ?? createdTime)}
         </div>
-      </div>
+      </ClickableRow>
       {!isSearchPanel && (
         <div css={rightStyle}>
           <Icon
@@ -149,7 +171,6 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
             backgroundColor={
               isSelected ? COLORS.SELECTION_COLOR : COLORS.HOVER_COLOR
             }
-            focusable={isHovered ? true : false}
             onClick={(e) => {
               e.stopPropagation();
               onOpenAllClick(e);
@@ -164,7 +185,6 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
             backgroundColor={
               isSelected ? COLORS.SELECTION_COLOR : COLORS.HOVER_COLOR
             }
-            focusable={isHovered ? true : false}
             onClick={(e) => {
               e.stopPropagation();
               onFocusClick(e);
@@ -179,7 +199,6 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
             backgroundColor={
               isSelected ? COLORS.SELECTION_COLOR : COLORS.HOVER_COLOR
             }
-            focusable={isHovered ? true : false}
             onClick={(e) => {
               e.stopPropagation();
               onDeleteClick(e);

--- a/src/components/home/leftpane/UserInputContainer.tsx
+++ b/src/components/home/leftpane/UserInputContainer.tsx
@@ -104,7 +104,6 @@ export default function UserInputContainer() {
         ariaLabel="search"
         onClick={filterResults}
         style="padding: 12px; flex-shrink: 0;"
-        focusableButton={true}
       />
     </div>
   ) : (
@@ -169,7 +168,6 @@ export default function UserInputContainer() {
           onClick={() => createTabGroup('current-window')}
           style={`width: 40px; height: 100%; padding: 0; flex-shrink: 0;
                   border: none; border-right: 1px solid ${COLORS.BORDER_COLOR};`}
-          focusableButton={true}
         />
         <Button
           tooltipText={t('Save every open window as a session')}
@@ -177,7 +175,6 @@ export default function UserInputContainer() {
           iconType="library_add"
           onClick={() => createTabGroup('all-windows')}
           style="width: 58px; height: 100%; padding: 0; flex-shrink: 0; border: none;"
-          focusableButton={true}
         />
       </div>
     </div>

--- a/src/components/home/rightpane/HeroContainerRight.tsx
+++ b/src/components/home/rightpane/HeroContainerRight.tsx
@@ -233,6 +233,10 @@ export default function HeroContainerRight() {
               transform: translateY(-50%);
               opacity: ${isContainerHovered ? 1 : 0};
               transition: opacity 0.1s ease-out;
+              /* The keyboard's equivalent of the hover reveal (KAN-68). */
+              &:focus-within {
+                opacity: 1;
+              }
               ${isSearchPanel && 'visibility: hidden;'}
             `}
           >
@@ -246,7 +250,6 @@ export default function HeroContainerRight() {
                   e.stopPropagation();
                   startEditing();
                 }}
-                focusable={isContainerHovered}
               />
             )}
           </div>
@@ -318,7 +321,6 @@ export default function HeroContainerRight() {
             tooltipText={t('Add current window')}
             ariaLabel="add current window"
             iconType="add"
-            focusableButton={isContainerHovered}
             onClick={handleAddCurrWindowClick}
             iconSize="1.3rem"
             iconStyle={`

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { css } from '@emotion/react';
 
+import ClickableRow from '../../common/ClickableRow';
 import Icon from '../../common/Icon';
 import { NormalLabel } from '../../common/Label';
 import { useFontFamily } from '../../../hooks/useFontFamily';
@@ -25,7 +26,12 @@ interface WindowEntryContainerProps {
   tabs: tabData[];
   tabGroupId: string;
   windowId: string;
-  onWindowTitleClick: MouseEventHandler;
+  /**
+   * Takes no event -- its only caller passes a zero-argument arrow. It was
+   * typed MouseEventHandler, which is what let the keyboard path activate it
+   * through `handleWindowClick(e as any)` with a KeyboardEvent.
+   */
+  onWindowTitleClick: () => void;
   onUpdateWindowGroupTitle: (newTitle: string) => void;
   onAddCurrTabToWindowClick: MouseEventHandler;
   onDeleteClick: MouseEventHandler;
@@ -91,6 +97,13 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     transform: translateY(-50%);
     opacity: ${isParentHovered ? 1 : 0};
     transition: opacity 0.1s ease-out;
+    /* The keyboard's equivalent of the hover reveal (KAN-68). */
+    &:focus-within {
+      opacity: 1;
+    }
+    /* Left below the focus-within rule on purpose: during search these
+       controls do not apply, and visibility:hidden removes them from the tab
+       order as well as from view, so there is nothing inside to focus. */
     ${isSearchPanel && 'visibility: hidden;'}
   `;
 
@@ -109,7 +122,8 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     }
   `;
 
-  const childLeftStyle = css`
+  // A plain string, not css``: handed to ClickableRow's `style` prop.
+  const childLeftStyle = `
     display: flex;
     align-items: center;
     flex-grow: 1;
@@ -123,9 +137,20 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     transform: translateY(-50%);
     opacity: ${hoveredChildIndex === index ? 1 : 0};
     transition: opacity 0.1s ease-out;
+    /* The keyboard's equivalent of the hover reveal (KAN-68). Delete tab has
+       no alternate path anywhere in the UI, so this row is the only way to
+       reach it. */
+    &:focus-within {
+      opacity: 1;
+    }
   `;
 
-  const parentLinkStyle = css`
+  // A plain string, not css``, because ClickableRow's `style` prop takes a
+  // string. The two non-button branches below therefore have to wrap it as
+  // css(parentLinkStyle): Emotion's `css` PROP rejects a bare string outright
+  // ("Strings are not allowed as css prop values"), even though the `css`
+  // FUNCTION accepts one. One declaration still serves all three branches.
+  const parentLinkStyle = `
     text-decoration: none;
     color: inherit;
     display: flex;
@@ -134,7 +159,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     flex-grow: 1;
     min-width: 0;
     padding-right: 9px;
-    ${!isSearchPanel && 'cursor: pointer;'}
+    ${!isSearchPanel ? 'cursor: pointer;' : ''}
   `;
 
   const windowChildLinkStyle = css`
@@ -172,11 +197,12 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     }
   };
 
-  const handleWindowClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    e.stopPropagation();
-    if (!isSearchPanel && !isEditing) {
-      onWindowTitleClick(e);
-    }
+  // No stopPropagation and no isSearchPanel/isEditing guard any more: this is
+  // only wired up on the branch where it is a real action, so it can no longer
+  // be reached in a state where it does nothing, and the container it sits in
+  // has no click handler of its own to bubble into.
+  const handleWindowClick = () => {
+    onWindowTitleClick();
   };
 
   const handleTabClick = (url: string) => {
@@ -194,24 +220,9 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     setWindowOpenState((state) => !state);
   }
 
-  function handleKeyPressOnWindow(e: React.KeyboardEvent<HTMLDivElement>) {
-    if (e.key === 'Enter') {
-      handleWindowClick(e as any);
-    }
-  }
-
-  function handleKeyPressOnEditDone(e: React.KeyboardEvent<HTMLDivElement>) {
+  function handleKeyPressOnEditDone(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === 'Enter') {
       handleBlur();
-    }
-  }
-
-  function handleKeyPressOnTab(
-    e: React.KeyboardEvent<HTMLDivElement>,
-    url: string
-  ) {
-    if (e.key === 'Enter') {
-      handleTabClick(url);
     }
   }
 
@@ -230,14 +241,22 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
             onClick={handleAccordionClick}
           />
           <Icon type="web_asset" style={NON_INTERACTIVE_ICON_STYLE} />
-          <div
-            css={parentLinkStyle}
-            tabIndex={0}
-            onClick={(e) => handleWindowClick(e)}
-            onKeyDown={(e) => handleKeyPressOnWindow(e)}
-            title={!isSearchPanel ? t('Open in new window') : undefined}
-          >
-            {isEditing && !isSearchPanel ? (
+          {/* Three shapes, because only one of them is a control (KAN-64).
+              This used to be a single role-less div carrying tabIndex={0} and
+              onClick -- focusable, exposed as `generic` where naming is
+              prohibited, and activating via `handleWindowClick(e as any)`.
+
+              Editing: an <input> may not live inside a <button>; clicking it
+              would activate the button and it could not hold focus.
+
+              Searching: handleWindowClick is a no-op while isSearchPanel, so
+              rendering a button here would be focusable and inert -- exactly
+              the KAN-62 defect this codebase just fixed. It renders as static
+              text instead.
+
+              Otherwise: a real button. */}
+          {isEditing && !isSearchPanel ? (
+            <div css={css(parentLinkStyle)}>
               <input
                 value={newTitle}
                 onBlur={handleBlur}
@@ -261,18 +280,31 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                   }
                 `}
               />
-            ) : (
+            </div>
+          ) : isSearchPanel ? (
+            <div css={css(parentLinkStyle)}>
               <NormalLabel
                 value={title}
                 color={COLORS.TEXT_COLOR}
                 size="0.9rem"
-                style={`
-                padding-left: 8px;
-                ${!isSearchPanel && 'cursor: pointer'};
-                height: 100%; max-width: 100%;`}
+                style="padding-left: 8px; height: 100%; max-width: 100%;"
               />
-            )}
-          </div>
+            </div>
+          ) : (
+            <ClickableRow
+              ariaLabel={title}
+              tooltipText={t('Open in new window')}
+              onClick={handleWindowClick}
+              style={parentLinkStyle}
+            >
+              <NormalLabel
+                value={title}
+                color={COLORS.TEXT_COLOR}
+                size="0.9rem"
+                style="padding-left: 8px; cursor: pointer; height: 100%; max-width: 100%;"
+              />
+            </ClickableRow>
+          )}
         </div>
         <div css={parentRightStyle}>
           {isEditing && !isSearchPanel ? (
@@ -285,7 +317,6 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                 e.stopPropagation();
                 handleBlur();
               }}
-              focusable={isParentHovered}
             />
           ) : (
             <Icon
@@ -297,7 +328,6 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                 e.stopPropagation();
                 startEditing();
               }}
-              focusable={isParentHovered}
             />
           )}
 
@@ -311,7 +341,6 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                 e.stopPropagation();
                 onAddCurrTabToWindowClick(e);
               }}
-              focusable={isParentHovered}
             />
           )}
           {!isEditing && !isSearchPanel && (
@@ -324,7 +353,6 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                 e.stopPropagation();
                 onDeleteClick(e);
               }}
-              focusable={isParentHovered}
             />
           )}
         </div>
@@ -342,12 +370,15 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                 onMouseEnter={() => setHoveredChildIndex(index)}
                 onMouseLeave={() => setHoveredChildIndex(null)}
               >
-                <div
-                  css={childLeftStyle}
-                  tabIndex={0}
+                {/* The name reuses the string the tooltip already carried,
+                    so no new hardcoded English enters the app -- the 25
+                    untranslated aria-labels of KAN-65 stay one clean sweep.
+                    The favicon Icon inside is presentational and aria-hidden,
+                    so it does not leak into the name. */}
+                <ClickableRow
+                  ariaLabel={t('Open in new tab') + ': ' + title}
                   onClick={() => handleTabClick(url)}
-                  onKeyDown={(e) => handleKeyPressOnTab(e, url)}
-                  title={t('Open in new tab') + ': ' + title}
+                  style={childLeftStyle}
                 >
                   <Icon
                     faviconUrl={resolveFaviconUrl(favicon, url)}
@@ -362,7 +393,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                       style="padding-left: 4px; height: 100%; max-width: 100%;"
                     />
                   </div>
-                </div>
+                </ClickableRow>
                 <div css={childRightStyle(index)}>
                   <Icon
                     tooltipText={t('Delete tab')}
@@ -373,7 +404,6 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                       e.stopPropagation();
                       dispatch(deleteTab({ tabGroupId, windowId, tabId }));
                     }}
-                    focusable={hoveredChildIndex === index}
                   />
                 </div>
               </div>

--- a/src/components/settings/leftpane/SettingsCategoryContainer.tsx
+++ b/src/components/settings/leftpane/SettingsCategoryContainer.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { css } from '@emotion/react';
 
+import ClickableRow from '../../common/ClickableRow';
 import Divider from '../../common/Divider';
 import { NormalLabel } from '../../common/Label';
 import { useThemeColors } from '../../../hooks/useThemeColors';
@@ -33,15 +34,6 @@ const SettingsCategoryContainer: React.FC = () => {
     dispatch(selectCategory(name));
   };
 
-  function handleKeyPress(
-    e: React.KeyboardEvent<HTMLDivElement>,
-    name: SettingsCategory
-  ) {
-    if (e.key === 'Enter') {
-      handleSelectCategoryClick(name);
-    }
-  }
-
   const containerStyle = css`
     display: flex;
     flex-direction: column;
@@ -52,15 +44,19 @@ const SettingsCategoryContainer: React.FC = () => {
     user-select: none;
   `;
 
-  const selectableStyle = (isSelected: boolean) => css`
+  // A plain string, not css``: handed to ClickableRow's `style` prop. width
+  // is explicit because a <button> shrink-wraps its content where the div it
+  // replaced stretched to fill the flex column.
+  const selectableStyle = (isSelected: boolean) => `
     cursor: pointer;
     transition: background-color 0.2s;
+    width: 100%;
     &:hover {
-      background-color: ${!isSelected && COLORS.HOVER_COLOR};
+      background-color: ${!isSelected ? COLORS.HOVER_COLOR : 'unset'};
     }
-    background-color: ${isSelected
-      ? COLORS.SELECTION_COLOR
-      : COLORS.PRIMARY_COLOR};
+    background-color: ${
+      isSelected ? COLORS.SELECTION_COLOR : COLORS.PRIMARY_COLOR
+    };
     padding: 15px clamp(10px, 12%, 38px);
   `;
 
@@ -74,18 +70,21 @@ const SettingsCategoryContainer: React.FC = () => {
             // element to hang the key on. `name` is the SettingsCategory enum
             // value, unique across the list by construction.
             <Fragment key={name}>
-              <div
-                css={selectableStyle(isSelected)}
+              {/* KAN-64: was a role-less div with tabIndex={0} and onClick,
+                  so it took a tab stop, announced nothing (naming is
+                  prohibited on `generic`) and ignored Space. The label is
+                  already translated, so the name costs no new i18n key. */}
+              <ClickableRow
+                ariaLabel={t(name)}
                 onClick={() => handleSelectCategoryClick(name)}
-                onKeyDown={(e) => handleKeyPress(e, name)}
-                tabIndex={0}
+                style={selectableStyle(isSelected)}
               >
                 <NormalLabel
                   value={t(name)}
                   size="1rem"
                   color={COLORS.LABEL_L1_COLOR}
                 />
-              </div>
+              </ClickableRow>
               <Divider />
             </Fragment>
           );

--- a/src/components/settings/rightpane/Account/LoggedIn.tsx
+++ b/src/components/settings/rightpane/Account/LoggedIn.tsx
@@ -38,7 +38,6 @@ const LoggedIn: React.FC = () => {
         <Icon
           type={`cloud_done`}
           disable={true}
-          focusable={false}
           style={'padding-right: 4px;'}
         />
         <NormalLabel

--- a/src/components/settings/rightpane/Account/NotLoggedIn.tsx
+++ b/src/components/settings/rightpane/Account/NotLoggedIn.tsx
@@ -35,12 +35,7 @@ const NotLoggedIn: React.FC = () => {
   return (
     <div css={containerStyle}>
       <div css={iconLabelContainer}>
-        <Icon
-          type={`cloud_off`}
-          disable={true}
-          focusable={false}
-          style={'padding-right: 4px;'}
-        />
+        <Icon type={`cloud_off`} disable={true} style={'padding-right: 4px;'} />
         <NormalLabel
           value={t(`Cloud Sync Inactive`)}
           size="1.1rem"

--- a/src/tests/components/keyboardReachability.test.tsx
+++ b/src/tests/components/keyboardReachability.test.tsx
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'vitest';
+import { act, screen } from '@testing-library/react';
+
+import Button from '../../components/common/Button';
+import Icon from '../../components/common/Icon';
+import MenuContainer from '../../components/home/leftpane/MenuContainer';
+import TabGroupEntry from '../../components/home/leftpane/TabGroupEntry';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import { setSyncStatus } from '../../redux/slices/globalStateSlice';
+import { tabContainerData } from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-67 and KAN-68 are one defect wearing two prop names. Both `Button`'s
+// `focusableButton` and `Icon`'s `focusable` computed a tabIndex that could
+// only ever SUBTRACT the focusability the platform already grants, and both
+// were driven by something that has nothing to do with the keyboard --
+// `focusableButton` by nothing at all (it had no default, so 32 of 36 call
+// sites silently opted out), `focusable` by mouse-hover state.
+//
+// jsdom is the right oracle for this file, unlike the accessible-name
+// assertions in e2e/a11y-controls.spec.ts. `tabindex` is a plain DOM
+// attribute that jsdom reflects faithfully; an accessible NAME is a computed
+// property that dom-accessibility-api gets wrong. The distinction is why the
+// name assertions live in Playwright and these do not.
+//
+// KAN-66 rides along: `disable` set no `aria-disabled`, so a disabled control
+// announced as enabled. It is fixed here by adding the state rather than by
+// removing focus -- see the comment on that test.
+
+const TAB_ORDER_EXCLUDED = '-1';
+
+const tabIndexOf = (el: HTMLElement) => el.getAttribute('tabindex');
+
+const SESSION: tabContainerData = {
+  tabGroupId: 'session-1',
+  title: 'Research',
+  createdTime: '01/01/2026, 10:00:00',
+  createdAt: 1767261600000,
+  windowCount: 1,
+  tabCount: 2,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [],
+};
+
+const noop = () => {};
+
+describe('enabled controls are reachable by keyboard', () => {
+  // The control for every assertion below. It proves these queries can still
+  // OBSERVE tabindex="-1" when it is genuinely present -- without it, a suite
+  // of "is not -1" assertions would pass just as happily against a harness
+  // that had stopped rendering tabindex at all.
+  //
+  // A presentational Icon is the right control because it is deliberately
+  // outside the tab order both before and after this change: with no onClick
+  // there is nothing to activate.
+  test('CONTROL: a presentational Icon stays outside the tab order', async () => {
+    const { container } = await renderWithProviders(<Icon type="web_asset" />);
+
+    const icon = container.firstElementChild as HTMLElement;
+    expect(tabIndexOf(icon)).toBe(TAB_ORDER_EXCLUDED);
+  });
+
+  test('a Button with an onClick is in the tab order (KAN-67)', async () => {
+    await renderWithProviders(<Button text="Delete all data" onClick={noop} />);
+
+    const button = screen.getByRole('button', { name: 'Delete all data' });
+    expect(tabIndexOf(button)).not.toBe(TAB_ORDER_EXCLUDED);
+  });
+
+  // The eight controls of KAN-68 were gated on mouse-hover state. This
+  // renders the row and never hovers it, which is exactly the situation a
+  // keyboard user is in.
+  test('session row actions are in the tab order without hover (KAN-68)', async () => {
+    await renderWithProviders(
+      <TabGroupEntry
+        tabGroupData={SESSION}
+        onTabGroupClick={noop}
+        onOpenAllClick={noop}
+        onFocusClick={noop}
+        onDeleteClick={noop}
+      />
+    );
+
+    for (const name of [
+      'open all windows',
+      'switch to session',
+      'delete session',
+    ]) {
+      const control = screen.getByRole('button', { name });
+      expect(tabIndexOf(control), name).not.toBe(TAB_ORDER_EXCLUDED);
+    }
+  });
+
+  // KAN-66. The fix ADDS aria-disabled rather than removing the control from
+  // the tab order, against the ticket's stated direction. The sync icon
+  // disables while you are operating it: press Enter, sync starts, `disable`
+  // flips true. Taking it out of the tab order at that instant would drop
+  // focus to <body> and lose the user's place -- the keyboard equivalent of
+  // the re-entrancy KAN-63 closed. aria-disabled fixes the false "enabled"
+  // announcement without the focus loss.
+  test('a disabled Icon announces its state and keeps focus (KAN-66)', async () => {
+    const { store } = await renderWithProviders(<MenuContainer />);
+
+    await act(async () => {
+      store.dispatch(setSyncStatus('loading'));
+    });
+
+    const sync = screen.getByRole('button', { name: 'sync' });
+    expect(sync).toHaveAttribute('aria-disabled', 'true');
+    expect(tabIndexOf(sync)).not.toBe(TAB_ORDER_EXCLUDED);
+  });
+
+  // Paired with the assertion above: the same icon must NOT claim to be
+  // disabled when it is not. Without this, setting aria-disabled
+  // unconditionally would pass the test above.
+  test('an enabled Icon does not claim to be disabled (KAN-66)', async () => {
+    await renderWithProviders(<MenuContainer />);
+
+    const sync = screen.getByRole('button', { name: 'sync' });
+    expect(sync).not.toHaveAttribute('aria-disabled');
+  });
+});


### PR DESCRIPTION
Four defects in one family: controls a mouse can reach and a keyboard cannot. Two were already filed (KAN-64, KAN-66); two were found while scoping them and filed as part of this work (KAN-67, KAN-68).

## KAN-67 — 32 of 36 buttons were out of the tab order

`Button.tsx` computed `tabIndex={onClick && focusableButton ? 0 : -1}` from a prop with **no default value**, so a real `<button>` left the tab order unless the call site opted back in. 32 of the 36 call sites that pass an `onClick` did not opt in.

That took the entire settings pane with it: all five theme pickers, the auto-sync and lazy-load toggles, Export/Import JSON, delete-all-data, every control in Sign In / Create Account / Forgot Password, and the three share buttons.

The prop is **deleted** rather than defaulted to `true`. A `<button>` is keyboard-focusable by default, so the prop's only power was to subtract that — and a prop that can only break something breaks it the moment a call site forgets. `Button` now sets no `tabIndex` at all.

## KAN-68 — eight row controls were gated on mouse hover

`Icon`'s `focusable` prop drove **both** the tab index and the cursor/hover highlight. Eight call sites fed it mouse-hover state to get the styling and silently removed the controls from the tab order:

| Site | Controls |
|---|---|
| `TabGroupEntry.tsx` | Open session, Switch to session, Delete session |
| `WindowEntryContainer.tsx` (window) | Save changes, Rename window group, Add current tab, Delete window group |
| `WindowEntryContainer.tsx` (tab) | Delete tab |
| `HeroContainerRight.tsx` | Rename session |

Impact was not uniform. The session actions had an alternate path via `HeroContainerRight`; **rename window, add current tab, delete window group and delete tab had none**, so those four could not be performed without a mouse at all.

`focusable` is deleted and both its jobs move onto `disable` — which is what the remaining honest callers already meant, `MenuContainer` having passed `disable={!isUndoable}` and `focusable={isUndoable}` together. The four hover-reveal containers now also open on `:focus-within`, so focus cannot land on something painted at `opacity: 0`. `parentRightStyle`'s `visibility: hidden` during search stays: those controls genuinely do not apply there, and `visibility` correctly removes them from the tab order too.

## KAN-66 — disabled controls announced as enabled

`disable` set no `aria-disabled`. Fixed by **adding the state and keeping the control focusable**, against the ticket's stated direction and with Justine's sign-off.

The sync icon's `disable` flips *while you are operating it*: press Enter, the thunk starts, `disable` becomes true on the element that currently holds focus. Leaving the tab order at that instant drops focus to `<body>` — the keyboard counterpart of the re-entrancy KAN-63 closed. The activation guard is unaffected: `Icon` only wires `onClick` when `disable` is false, and the key handler forwards to the element's own `click()`.

## KAN-64 — four unnamed, role-less rows

Four rows were `tabIndex={0}` divs with an `onClick` and no `role`: a tab stop exposed as `generic`, where ARIA prohibits naming, so the name was dropped while Space did nothing.

All four become `ClickableRow` — **contrary to the ticket's premise** that nested `Icon` buttons ruled it out. In every one of the four, the actions are *siblings* of the clickable region, not children, so moving the click target onto the inner region that already existed is enough. The sub-regions were already there, so this was a wrapper swap rather than the restructure the ticket anticipated.

Two branches deliberately stay non-buttons, both in the window row: **while editing**, because an `<input>` inside a `<button>` cannot hold focus; and **while searching**, because the handler is a no-op there and a focusable inert button is exactly KAN-62.

Names reuse strings that are already translated or already user-supplied, so **no new hardcoded English enters the app** and KAN-65 stays one clean sweep.

Both `as any` casts that survived KAN-63 are gone with the divs, and `onTabGroupClick` / `onWindowTitleClick` are retyped `() => void` — every caller already passed a zero-argument arrow, which is what let the casts compile.

## Testing

```
Test Files  54 passed (54)
     Tests  467 passed (467)     # was 462 / 53 files
        27 passed                 # Playwright E2E, was 18

tsc: 0    typecheck:e2e: 0    lint: 0 errors, 25 warnings   # warnings were 27
```

Split by what each layer can actually judge: `tabindex` is a plain DOM attribute jsdom reflects faithfully, so reachability assertions live in `keyboardReachability.test.tsx`; an accessible **name** is computed, and `dom-accessibility-api` names an `aria-label` on a role-less div without applying the `generic` prohibition — so those assertions run against a real accessibility tree in `e2e/a11y-controls.spec.ts`. Every negative assertion is paired with a positive control.

**Mutation-tested.** Each of the five changes was reverted separately; each killed its own tests and left the controls green. The KAN-64 mutation initially failed to compile (TS6133) and was caught by the artifact check before it could silently re-test the previous bundle. The `:focus-within` mutation was verified in both directions (6 → 5 → 6 occurrences in `dist`), and the restored build hashes back to the pre-mutation artifact.

**Verified live in Chrome**, real Tab walk:

```
1 search <button>   2 undo aria-disabled=true   3 redo aria-disabled=true
4 sync   5 settings   6 <input>   7 save current window   8 save session
9 "Example Domain" <button>   ← the session row (KAN-64)
10 open all windows            ← its action (KAN-68)
```

In settings: `go back`, the five named category buttons, then **Light** and **Warm Light** — previously unreachable. Space on the settings icon opened the pane. Home and settings panes are **pixel-identical to main** (built main and compared); the "Data Managem…" truncation is pre-existing.

## Two notes for the reviewer

Two pre-existing KAN-56 tests went red mid-way and it was **not** a regression: `getByRole(name:)` matches a **substring**, and the fixture session "Re*search*" collided with the `search` control. Fixed with `exact: true` and documented on the fixture — the file already guards the same hazard for `arrow_back`/`Back`.

Making the row actions siblings rather than descendants also changed Playwright's actionability verdict on a row click: the action overlay covers the row's centre, and a *sibling* overlay counts as interception where a *descendant* does not. Same pixels, same user-visible behaviour. Tests now click the row over its title, as a user does — written up in `selectSession`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)