### PR TITLE
Translate every accessible name (KAN-65)

### DIFF
--- a/e2e/a11y-controls.spec.ts
+++ b/e2e/a11y-controls.spec.ts
@@ -49,7 +49,7 @@ test.describe('accessible controls', () => {
   }) => {
     const page = await openPopup(context, extensionId);
 
-    await expect(page.getByRole('button', { name: 'settings' })).toHaveCount(1);
+    await expect(page.getByRole('button', { name: 'Settings' })).toHaveCount(1);
   });
 
   test('the settings back control is a button with an accessible name (KAN-56)', async ({
@@ -57,10 +57,10 @@ test.describe('accessible controls', () => {
     extensionId,
   }) => {
     const page = await openPopup(context, extensionId);
-    await page.getByRole('button', { name: 'settings' }).click();
+    await page.getByRole('button', { name: 'Settings' }).click();
     await expect(page.getByText('Themes')).toBeVisible();
 
-    await expect(page.getByRole('button', { name: 'go back' })).toHaveCount(1);
+    await expect(page.getByRole('button', { name: 'Go back' })).toHaveCount(1);
   });
 
   test('the search back control is a button with an accessible name (KAN-56)', async ({
@@ -68,10 +68,10 @@ test.describe('accessible controls', () => {
     extensionId,
   }) => {
     const page = await openPopup(context, extensionId);
-    await page.getByRole('button', { name: 'search', exact: true }).click();
+    await page.getByRole('button', { name: 'Search', exact: true }).click();
     await expect(page.locator('input#searchInput')).toBeVisible();
 
-    await expect(page.getByRole('button', { name: 'back' })).toHaveCount(1);
+    await expect(page.getByRole('button', { name: 'Go back' })).toHaveCount(1);
   });
 
   test('the search control is a button with an accessible name (KAN-56)', async ({
@@ -81,7 +81,7 @@ test.describe('accessible controls', () => {
     const page = await openPopup(context, extensionId);
 
     await expect(
-      page.getByRole('button', { name: 'search', exact: true })
+      page.getByRole('button', { name: 'Search', exact: true })
     ).toHaveCount(1);
   });
 
@@ -95,12 +95,12 @@ test.describe('accessible controls', () => {
     extensionId,
   }) => {
     const page = await openPopup(context, extensionId);
-    await page.getByRole('button', { name: 'settings' }).click();
+    await page.getByRole('button', { name: 'Settings' }).click();
     await expect(page.getByText('Themes')).toBeVisible();
 
     await expect(
-      page.getByRole('button', { name: 'go back' })
-    ).toMatchAriaSnapshot(`- button "go back": Back`);
+      page.getByRole('button', { name: 'Go back' })
+    ).toMatchAriaSnapshot(`- button "Go back": Back`);
   });
 
   // Icon renders div[role=button] rather than a real <button>, because
@@ -116,7 +116,7 @@ test.describe('accessible controls', () => {
     }) => {
       const page = await openPopup(context, extensionId);
 
-      await page.getByRole('button', { name: 'settings' }).focus();
+      await page.getByRole('button', { name: 'Settings' }).focus();
       await page.keyboard.press(key);
 
       await expect(page.getByText('Themes')).toBeVisible();
@@ -144,7 +144,7 @@ test.describe('accessible controls', () => {
       });
     });
 
-    await page.getByRole('button', { name: 'settings' }).focus();
+    await page.getByRole('button', { name: 'Settings' }).focus();
     await page.keyboard.press('Space');
 
     const prevented = await page.evaluate(
@@ -164,10 +164,10 @@ test.describe('accessible controls', () => {
       extensionId,
     }) => {
       const page = await openPopup(context, extensionId);
-      await page.getByRole('button', { name: 'settings' }).click();
+      await page.getByRole('button', { name: 'Settings' }).click();
       await expect(page.getByText('Themes')).toBeVisible();
 
-      await page.getByRole('button', { name: 'go back' }).focus();
+      await page.getByRole('button', { name: 'Go back' }).focus();
       await page.keyboard.press(key);
 
       await expect(page.locator('input#name')).toBeVisible();
@@ -247,7 +247,7 @@ test.describe('controls are reachable by keyboard', () => {
     extensionId,
   }) => {
     const page = await openPopup(context, extensionId);
-    await page.getByRole('button', { name: 'settings' }).click();
+    await page.getByRole('button', { name: 'Settings' }).click();
 
     // "Display" is the category ROW; "Themes" is a heading inside the pane it
     // opens. The row is the control KAN-64 is about.
@@ -299,9 +299,9 @@ test.describe('controls are reachable by keyboard', () => {
 
     const names = await tabOrderNames(page, 12);
 
-    expect(names).toContain('open all windows');
-    expect(names).toContain('switch to session');
-    expect(names).toContain('delete session');
+    expect(names).toContain('Open');
+    expect(names).toContain('Switch');
+    expect(names).toContain('Delete');
   });
 
   // Delete tab and Delete window group are the two that matter most: unlike
@@ -319,8 +319,8 @@ test.describe('controls are reachable by keyboard', () => {
 
     const names = await tabOrderNames(page, 20);
 
-    expect(names).toContain('delete window group');
-    expect(names).toContain('delete');
+    expect(names).toContain('Delete window group');
+    expect(names).toContain('Delete tab');
   });
 
   // The other half of KAN-68: being in the tab order is useless if focus
@@ -331,13 +331,13 @@ test.describe('controls are reachable by keyboard', () => {
     extensionId,
   }) => {
     const page = await openPopup(context, extensionId);
-    const actions = page.locator('div:has(> [aria-label="delete session"])');
+    const actions = page.locator('div:has(> [aria-label="Delete"])');
 
     // The control: unfocused and unhovered, the block really is invisible, so
     // the assertion below can tell the two states apart.
     await expect(actions).toHaveCSS('opacity', '0');
 
-    await page.getByRole('button', { name: 'delete session' }).focus();
+    await page.getByRole('button', { name: 'Delete', exact: true }).focus();
 
     await expect(actions).toHaveCSS('opacity', '1');
   });
@@ -350,7 +350,7 @@ test.describe('controls are reachable by keyboard', () => {
     extensionId,
   }) => {
     const page = await openPopup(context, extensionId);
-    await page.getByRole('button', { name: 'settings' }).click();
+    await page.getByRole('button', { name: 'Settings' }).click();
     await expect(page.getByText('Themes')).toBeVisible();
 
     const names = await tabOrderNames(page, 25);

--- a/e2e/golden-path.spec.ts
+++ b/e2e/golden-path.spec.ts
@@ -100,7 +100,7 @@ test.describe('golden path', () => {
 
     // Asserted, never clicked: invoking it spawns real browser windows on the
     // machine running the test.
-    const openAll = page.locator('[aria-label="open all windows"]').first();
+    const openAll = page.locator('[aria-label="Open"]').first();
     await expect(openAll).toBeVisible();
     await expect(openAll).toBeEnabled();
   });
@@ -111,7 +111,7 @@ test.describe('golden path', () => {
   }) => {
     const { page } = await openPopup(context, extensionId);
 
-    await page.locator('[aria-label="search"]').click();
+    await page.locator('[aria-label="Search"]').click();
     await page.locator('input#searchInput').fill('Holiday');
 
     await expect(page.getByText('Holiday').first()).toBeVisible();
@@ -124,7 +124,7 @@ test.describe('golden path', () => {
   }) => {
     const { page } = await openPopup(context, extensionId);
 
-    await page.locator('[aria-label="settings"]').click();
+    await page.locator('[aria-label="Settings"]').click();
 
     // Asserted on a settings-only heading, because the back control is not
     // unique to this panel -- the search pane has one too.
@@ -136,7 +136,7 @@ test.describe('golden path', () => {
     // sidesteps the reason the old version needed `exact: true` -- the
     // Material icon renders its name as the ligature text `arrow_back`, which
     // substring-matches "Back" and trips strict mode.
-    await page.getByRole('button', { name: 'go back' }).click();
+    await page.getByRole('button', { name: 'Go back' }).click();
     await expect(page.locator('input#name')).toBeVisible();
   });
 });

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -93,5 +93,6 @@
   "RequestUserReviewText": "Würden Sie uns eine positive Bewertung hinterlassen?",
   "Maybe Later": "Vielleicht später",
   "Never Remind Again": "Nicht mehr erinnern",
-  "Restored on this device, but syncing failed.": "Auf diesem Gerät wiederhergestellt, aber die Synchronisierung ist fehlgeschlagen."
+  "Restored on this device, but syncing failed.": "Auf diesem Gerät wiederhergestellt, aber die Synchronisierung ist fehlgeschlagen.",
+  "Save changes": "Änderungen speichern"
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -93,5 +93,6 @@
   "Maybe Later": "Maybe Later",
   "Never Remind Again": "Never Remind Again",
   "Sync unavailable: your saved account token could not be read.": "Sync unavailable: your saved account token could not be read.",
-  "Restored on this device, but syncing failed.": "Restored on this device, but syncing failed."
+  "Restored on this device, but syncing failed.": "Restored on this device, but syncing failed.",
+  "Save changes": "Save changes"
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -93,5 +93,6 @@
   "RequestUserReviewText": "¿Nos dejarías una buena reseña?",
   "Maybe Later": "Más tarde",
   "Never Remind Again": "No recordar más",
-  "Restored on this device, but syncing failed.": "Restaurado en este dispositivo, pero falló la sincronización."
+  "Restored on this device, but syncing failed.": "Restaurado en este dispositivo, pero falló la sincronización.",
+  "Save changes": "Guardar cambios"
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -93,5 +93,6 @@
   "RequestUserReviewText": "Pourriez-vous nous laisser un bon avis?",
   "Maybe Later": "Peut-être plus tard",
   "Never Remind Again": "Ne plus rappeler",
-  "Restored on this device, but syncing failed.": "Restauré sur cet appareil, mais la synchronisation a échoué."
+  "Restored on this device, but syncing failed.": "Restauré sur cet appareil, mais la synchronisation a échoué.",
+  "Save changes": "Enregistrer les modifications"
 }

--- a/public/locales/hi/translation.json
+++ b/public/locales/hi/translation.json
@@ -93,5 +93,6 @@
   "RequestUserReviewText": "क्या आप हमें एक सकारात्मक समीक्षा देंगे?",
   "Maybe Later": "बाद में",
   "Never Remind Again": "फिर से याद न करें",
-  "Restored on this device, but syncing failed.": "इस डिवाइस पर पुनर्स्थापित किया गया, लेकिन सिंक विफल रहा।"
+  "Restored on this device, but syncing failed.": "इस डिवाइस पर पुनर्स्थापित किया गया, लेकिन सिंक विफल रहा।",
+  "Save changes": "परिवर्तन सहेजें"
 }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -93,5 +93,6 @@
   "RequestUserReviewText": "Ti dispiacerebbe lasciarci una recensione positiva?",
   "Maybe Later": "Più tardi",
   "Never Remind Again": "Non ricordare più",
-  "Restored on this device, but syncing failed.": "Ripristinato su questo dispositivo, ma la sincronizzazione non è riuscita."
+  "Restored on this device, but syncing failed.": "Ripristinato su questo dispositivo, ma la sincronizzazione non è riuscita.",
+  "Save changes": "Salva modifiche"
 }

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -93,5 +93,6 @@
   "RequestUserReviewText": "ポジティブなレビューをいただけませんか？",
   "Maybe Later": "後で",
   "Never Remind Again": "再度お知らせしない",
-  "Restored on this device, but syncing failed.": "このデバイスに復元しましたが、同期に失敗しました。"
+  "Restored on this device, but syncing failed.": "このデバイスに復元しましたが、同期に失敗しました。",
+  "Save changes": "変更を保存"
 }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -93,5 +93,6 @@
   "RequestUserReviewText": "Você se importaria de nos deixar uma avaliação positiva?",
   "Maybe Later": "Mais tarde",
   "Never Remind Again": "Não lembrar mais",
-  "Restored on this device, but syncing failed.": "Restaurado neste dispositivo, mas a sincronização falhou."
+  "Restored on this device, but syncing failed.": "Restaurado neste dispositivo, mas a sincronização falhou.",
+  "Save changes": "Salvar alterações"
 }

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -93,5 +93,6 @@
   "RequestUserReviewText": "Не могли бы вы оставить нам положительный отзыв?",
   "Maybe Later": "Позже",
   "Never Remind Again": "Больше не напоминать",
-  "Restored on this device, but syncing failed.": "Восстановлено на этом устройстве, но синхронизация не удалась."
+  "Restored on this device, but syncing failed.": "Восстановлено на этом устройстве, но синхронизация не удалась.",
+  "Save changes": "Сохранить изменения"
 }

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -93,5 +93,6 @@
   "RequestUserReviewText": "您介意给我们一个好评吗？",
   "Maybe Later": "稍后再说",
   "Never Remind Again": "不再提醒",
-  "Restored on this device, but syncing failed.": "已在此设备上恢复，但同步失败。"
+  "Restored on this device, but syncing failed.": "已在此设备上恢复，但同步失败。",
+  "Save changes": "保存更改"
 }

--- a/src/components/home/leftpane/HeroContainerLeft.tsx
+++ b/src/components/home/leftpane/HeroContainerLeft.tsx
@@ -48,7 +48,7 @@ export default function HeroContainer() {
   return isSearchPanel ? (
     <div css={containerStyle}>
       <ClickableRow
-        ariaLabel="back"
+        ariaLabel={t('Go back')}
         tooltipText={t('Go back')}
         onClick={handleBackClick}
         style="display: flex;"
@@ -65,7 +65,7 @@ export default function HeroContainer() {
   ) : (
     <div css={containerStyle}>
       <ClickableRow
-        ariaLabel="search"
+        ariaLabel={t('Search')}
         tooltipText={t('Search')}
         onClick={handleClickSearch}
         style="display: flex; align-items: center; min-width: 0;"

--- a/src/components/home/leftpane/MenuContainer.tsx
+++ b/src/components/home/leftpane/MenuContainer.tsx
@@ -70,7 +70,7 @@ export default function MenuContainer() {
   return (
     <div css={containerStyle}>
       <Icon
-        ariaLabel="undo"
+        ariaLabel={t('Undo')}
         tooltipText={t('Undo')}
         type="undo"
         onClick={handleClickUndo}
@@ -78,7 +78,7 @@ export default function MenuContainer() {
         disable={!isUndoable}
       />
       <Icon
-        ariaLabel="redo"
+        ariaLabel={t('Redo')}
         tooltipText={t('Redo')}
         type="redo"
         onClick={handleClickRedo}
@@ -86,14 +86,14 @@ export default function MenuContainer() {
         disable={!isRedoable}
       />
       <Icon
-        ariaLabel="sync"
+        ariaLabel={t('Sync now')}
         tooltipText={t('Sync now')}
         type={syncIconType}
         onClick={handleClickSync}
         disable={isDisabled}
       />
       <Icon
-        ariaLabel="settings"
+        ariaLabel={t('Settings')}
         tooltipText={t('Settings')}
         type="settings"
         onClick={handleClickSettings}

--- a/src/components/home/leftpane/TabGroupEntry.tsx
+++ b/src/components/home/leftpane/TabGroupEntry.tsx
@@ -166,7 +166,7 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
           <Icon
             tooltipText={t('Open session')}
             text={t('Open')}
-            ariaLabel="open all windows"
+            ariaLabel={t('Open')}
             type="reopen_window"
             backgroundColor={
               isSelected ? COLORS.SELECTION_COLOR : COLORS.HOVER_COLOR
@@ -180,7 +180,7 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
           <Icon
             tooltipText={t('Switch to session')}
             text={t('Switch')}
-            ariaLabel="switch to session"
+            ariaLabel={t('Switch')}
             type="filter_center_focus"
             backgroundColor={
               isSelected ? COLORS.SELECTION_COLOR : COLORS.HOVER_COLOR
@@ -194,7 +194,7 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
           <Icon
             tooltipText={t('Delete session')}
             text={t('Delete')}
-            ariaLabel="delete session"
+            ariaLabel={t('Delete')}
             type="delete"
             backgroundColor={
               isSelected ? COLORS.SELECTION_COLOR : COLORS.HOVER_COLOR

--- a/src/components/home/leftpane/UserInputContainer.tsx
+++ b/src/components/home/leftpane/UserInputContainer.tsx
@@ -101,7 +101,7 @@ export default function UserInputContainer() {
       <Button
         tooltipText={t('Search')}
         iconType="search"
-        ariaLabel="search"
+        ariaLabel={t('Search')}
         onClick={filterResults}
         style="padding: 12px; flex-shrink: 0;"
       />
@@ -162,7 +162,7 @@ export default function UserInputContainer() {
       <div css={saveGroupStyle}>
         <Button
           tooltipText={t('Save current window as a session')}
-          ariaLabel="save current window"
+          ariaLabel={t('Save current window as a session')}
           iconType="add_box"
           iconSize="20px"
           onClick={() => createTabGroup('current-window')}
@@ -171,7 +171,7 @@ export default function UserInputContainer() {
         />
         <Button
           tooltipText={t('Save every open window as a session')}
-          ariaLabel="save session"
+          ariaLabel={t('Save every open window as a session')}
           iconType="library_add"
           onClick={() => createTabGroup('all-windows')}
           style="width: 58px; height: 100%; padding: 0; flex-shrink: 0; border: none;"

--- a/src/components/home/rightpane/HeroContainerRight.tsx
+++ b/src/components/home/rightpane/HeroContainerRight.tsx
@@ -243,7 +243,7 @@ export default function HeroContainerRight() {
             {!isEditing && !isSearchPanel && (
               <Icon
                 tooltipText={t('Rename session')}
-                ariaLabel="rename session"
+                ariaLabel={t('Rename session')}
                 type="edit"
                 backgroundColor={COLORS.SECONDARY_COLOR}
                 onClick={(e) => {
@@ -283,7 +283,7 @@ export default function HeroContainerRight() {
         >
           <Icon
             tooltipText={t('Open session')}
-            ariaLabel="open all windows"
+            ariaLabel={t('Open session')}
             type="reopen_window"
             onClick={() => {
               const goToURLText: string = t('Go to URL');
@@ -292,7 +292,7 @@ export default function HeroContainerRight() {
           />
           <Icon
             tooltipText={t('Switch to session')}
-            ariaLabel="switch to session"
+            ariaLabel={t('Switch to session')}
             type="filter_center_focus"
             onClick={() => {
               dispatch(
@@ -306,7 +306,7 @@ export default function HeroContainerRight() {
           />
           <Icon
             tooltipText={t('Delete session')}
-            ariaLabel="delete session"
+            ariaLabel={t('Delete session')}
             type="delete"
             onClick={() => dispatch(deleteTabContainer(tabGroupId))}
           />
@@ -319,7 +319,7 @@ export default function HeroContainerRight() {
           <Button
             text={t('Add window')}
             tooltipText={t('Add current window')}
-            ariaLabel="add current window"
+            ariaLabel={t('Add window')}
             iconType="add"
             onClick={handleAddCurrWindowClick}
             iconSize="1.3rem"

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -236,7 +236,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
         <div css={parentLeftStyle}>
           <Icon
             tooltipText={windowOpenState ? t('Collapse') : t('Expand')}
-            ariaLabel={windowOpenState ? 'collapse' : 'expand'}
+            ariaLabel={windowOpenState ? t('Collapse') : t('Expand')}
             type={windowOpenState ? 'expand_less' : 'expand_more'}
             onClick={handleAccordionClick}
           />
@@ -309,8 +309,8 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
         <div css={parentRightStyle}>
           {isEditing && !isSearchPanel ? (
             <Icon
-              tooltipText="Save changes"
-              ariaLabel="save changes"
+              tooltipText={t('Save changes')}
+              ariaLabel={t('Save changes')}
               type="done"
               backgroundColor={COLORS.HOVER_COLOR}
               onClick={(e) => {
@@ -321,7 +321,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
           ) : (
             <Icon
               tooltipText={t('Rename window group')}
-              ariaLabel="rename window group"
+              ariaLabel={t('Rename window group')}
               type="edit"
               backgroundColor={COLORS.HOVER_COLOR}
               onClick={(e) => {
@@ -334,7 +334,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
           {!isEditing && !isSearchPanel && (
             <Icon
               tooltipText={t('Add current tab')}
-              ariaLabel="add current tab"
+              ariaLabel={t('Add current tab')}
               type="add"
               backgroundColor={COLORS.HOVER_COLOR}
               onClick={(e) => {
@@ -346,7 +346,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
           {!isEditing && !isSearchPanel && (
             <Icon
               tooltipText={t('Delete window group')}
-              ariaLabel="delete window group"
+              ariaLabel={t('Delete window group')}
               type="delete"
               backgroundColor={COLORS.HOVER_COLOR}
               onClick={(e) => {
@@ -397,7 +397,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                 <div css={childRightStyle(index)}>
                   <Icon
                     tooltipText={t('Delete tab')}
-                    ariaLabel="delete"
+                    ariaLabel={t('Delete tab')}
                     type="delete"
                     backgroundColor={COLORS.HOVER_COLOR}
                     onClick={(e) => {

--- a/src/components/settings/leftpane/MenuContainerSettings.tsx
+++ b/src/components/settings/leftpane/MenuContainerSettings.tsx
@@ -30,7 +30,7 @@ export default function MenuContainer() {
 
   return (
     <ClickableRow
-      ariaLabel="go back"
+      ariaLabel={t('Go back')}
       tooltipText={t('Go back')}
       onClick={handleBackClick}
       style={containerStyle}

--- a/src/tests/components/UserInputContainer.test.tsx
+++ b/src/tests/components/UserInputContainer.test.tsx
@@ -34,7 +34,9 @@ describe('UserInputContainer', () => {
     });
 
     await screen.findByDisplayValue('Kagi Search');
-    await userEvent.click(screen.getByLabelText('save session'));
+    await userEvent.click(
+      screen.getByLabelText('Save all open windows as a session')
+    );
 
     expect(seen).toContain(SAVE_TAB_CONTAINER_ACTION);
     const { tabGroups } = store.getState().tabContainerDataState;
@@ -78,7 +80,9 @@ describe('UserInputContainer save scope', () => {
     });
 
     await screen.findByDisplayValue('Kagi Search');
-    await userEvent.click(screen.getByLabelText('save session'));
+    await userEvent.click(
+      screen.getByLabelText('Save all open windows as a session')
+    );
 
     const { tabGroups } = store.getState().tabContainerDataState;
     expect(tabGroups[0].windows).toHaveLength(2);
@@ -91,7 +95,9 @@ describe('UserInputContainer save scope', () => {
     });
 
     await screen.findByDisplayValue('Kagi Search');
-    await userEvent.click(screen.getByLabelText('save current window'));
+    await userEvent.click(
+      screen.getByLabelText('Save current window as a session')
+    );
 
     const { tabGroups } = store.getState().tabContainerDataState;
     expect(tabGroups[0].windows).toHaveLength(1);
@@ -114,13 +120,13 @@ describe('UserInputContainer save scope', () => {
   }
 
   test('saving every window says so', async () => {
-    expect(await toastAfterClicking('save session')).toBe(
+    expect(await toastAfterClicking('Save all open windows as a session')).toBe(
       TOAST_MESSAGES.SAVE_ALL_WINDOWS_SUCCESS
     );
   });
 
   test('saving only the current window says so instead', async () => {
-    expect(await toastAfterClicking('save current window')).toBe(
+    expect(await toastAfterClicking('Save current window as a session')).toBe(
       TOAST_MESSAGES.SAVE_CURRENT_WINDOW_SUCCESS
     );
   });
@@ -145,9 +151,11 @@ describe('UserInputContainer save scope', () => {
       screen.getByLabelText(label).querySelector('.material-symbols-outlined')
         ?.textContent;
 
-    expect(glyph('save session')).toBeTruthy();
-    expect(glyph('save current window')).toBeTruthy();
-    expect(glyph('save session')).not.toBe(glyph('save current window'));
+    expect(glyph('Save all open windows as a session')).toBeTruthy();
+    expect(glyph('Save current window as a session')).toBeTruthy();
+    expect(glyph('Save all open windows as a session')).not.toBe(
+      glyph('Save current window as a session')
+    );
   });
 
   // The tooltip is the only place either button says what it does in words,
@@ -164,21 +172,27 @@ describe('UserInputContainer save scope', () => {
     await renderWithProviders(<UserInputContainer />, { seed: twoWindows });
     await screen.findByDisplayValue('Kagi Search');
 
-    expect(tooltip('save session').toLowerCase()).toContain('all');
+    expect(
+      tooltip('Save all open windows as a session').toLowerCase()
+    ).toContain('all');
   });
 
   test('the current-window tooltip says it saves the current window', async () => {
     await renderWithProviders(<UserInputContainer />, { seed: twoWindows });
     await screen.findByDisplayValue('Kagi Search');
 
-    expect(tooltip('save current window').toLowerCase()).toContain('current');
+    expect(tooltip('Save current window as a session').toLowerCase()).toContain(
+      'current'
+    );
   });
 
   test('the two buttons do not share a tooltip', async () => {
     await renderWithProviders(<UserInputContainer />, { seed: twoWindows });
     await screen.findByDisplayValue('Kagi Search');
 
-    expect(tooltip('save session')).not.toBe(tooltip('save current window'));
+    expect(tooltip('Save all open windows as a session')).not.toBe(
+      tooltip('Save current window as a session')
+    );
   });
 
   // Enter in the name box has always meant "save everything". A second button

--- a/src/tests/components/iconKeyboardActivation.test.tsx
+++ b/src/tests/components/iconKeyboardActivation.test.tsx
@@ -20,7 +20,7 @@ import { setSyncStatus } from '../../redux/slices/globalStateSlice';
 
 const SYNC_PENDING = 'global/syncStateWithFirestore/pending';
 
-const syncIcon = () => screen.getByRole('button', { name: 'sync' });
+const syncIcon = () => screen.getByRole('button', { name: 'Sync now' });
 
 describe('Icon keyboard activation reaches the same handler as a click', () => {
   // The control. If the sync thunk stopped being dispatched by a plain mouse

--- a/src/tests/components/keyboardReachability.test.tsx
+++ b/src/tests/components/keyboardReachability.test.tsx
@@ -81,11 +81,7 @@ describe('enabled controls are reachable by keyboard', () => {
       />
     );
 
-    for (const name of [
-      'open all windows',
-      'switch to session',
-      'delete session',
-    ]) {
+    for (const name of ['Open', 'Switch', 'Delete']) {
       const control = screen.getByRole('button', { name });
       expect(tabIndexOf(control), name).not.toBe(TAB_ORDER_EXCLUDED);
     }
@@ -105,7 +101,7 @@ describe('enabled controls are reachable by keyboard', () => {
       store.dispatch(setSyncStatus('loading'));
     });
 
-    const sync = screen.getByRole('button', { name: 'sync' });
+    const sync = screen.getByRole('button', { name: 'Sync now' });
     expect(sync).toHaveAttribute('aria-disabled', 'true');
     expect(tabIndexOf(sync)).not.toBe(TAB_ORDER_EXCLUDED);
   });
@@ -116,7 +112,7 @@ describe('enabled controls are reachable by keyboard', () => {
   test('an enabled Icon does not claim to be disabled (KAN-66)', async () => {
     await renderWithProviders(<MenuContainer />);
 
-    const sync = screen.getByRole('button', { name: 'sync' });
+    const sync = screen.getByRole('button', { name: 'Sync now' });
     expect(sync).not.toHaveAttribute('aria-disabled');
   });
 });

--- a/src/tests/components/listKeys.test.tsx
+++ b/src/tests/components/listKeys.test.tsx
@@ -76,7 +76,7 @@ describe('list identity across deletions (KAN-28)', () => {
     });
 
     // All three start expanded, so every accordion icon reads "collapse".
-    const accordions = await screen.findAllByLabelText('collapse');
+    const accordions = await screen.findAllByLabelText('Collapse');
     expect(accordions).toHaveLength(3);
 
     // Collapse the middle window only.

--- a/src/tests/components/renameDrafts.test.tsx
+++ b/src/tests/components/renameDrafts.test.tsx
@@ -190,7 +190,7 @@ describe('rename drafts survive the prop moving underneath them (KAN-51)', () =>
       });
 
       await userEvent.click(
-        await screen.findByLabelText('rename window group')
+        await screen.findByLabelText('Rename window group')
       );
 
       expect(screen.getByRole<HTMLInputElement>('textbox').value).toBe(
@@ -221,7 +221,7 @@ describe('rename drafts survive the prop moving underneath them (KAN-51)', () =>
       );
 
       await userEvent.click(
-        await screen.findByLabelText('rename window group')
+        await screen.findByLabelText('Rename window group')
       );
       const input = screen.getByRole<HTMLInputElement>('textbox');
 
@@ -284,7 +284,7 @@ describe('rename drafts survive the prop moving underneath them (KAN-51)', () =>
         }
       );
 
-      const accordions = await screen.findAllByLabelText('collapse');
+      const accordions = await screen.findAllByLabelText('Collapse');
       expect(accordions).toHaveLength(2);
 
       // Collapse the SECOND window. Slot 1 in group-1 is collapsed; if the
@@ -299,7 +299,7 @@ describe('rename drafts survive the prop moving underneath them (KAN-51)', () =>
 
       expect(await screen.findByText('Charlie Page')).toBeTruthy();
       expect(screen.getByText('Delta Page')).toBeTruthy();
-      expect(screen.queryAllByLabelText('collapse')).toHaveLength(2);
+      expect(screen.queryAllByLabelText('Collapse')).toHaveLength(2);
     });
   });
 });

--- a/src/tests/components/undoShortcutScope.test.tsx
+++ b/src/tests/components/undoShortcutScope.test.tsx
@@ -238,7 +238,7 @@ describe('undo/redo shortcuts yield to native text editing (KAN-52)', () => {
 
       // By aria-label, not by title text: the session title also renders in
       // the left pane entry, so findByText('Research') matches two elements.
-      await userEvent.click(await screen.findByLabelText('rename session'));
+      await userEvent.click(await screen.findByLabelText('Rename session'));
       const input = screen.getByDisplayValue('Research');
 
       const before = seen.length;

--- a/src/tests/locales/accessibleNames.test.tsx
+++ b/src/tests/locales/accessibleNames.test.tsx
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { act } from '@testing-library/react';
+
+import HeroContainerRight from '../../components/home/rightpane/HeroContainerRight';
+import TabGroupEntry from '../../components/home/leftpane/TabGroupEntry';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import { initTestI18n, testI18n } from '../setup/i18nForTests';
+import {
+  saveToTabContainerInternal,
+  selectTabContainer,
+  tabContainerData,
+} from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-65. Every ariaLabel used to be a hardcoded English string sitting beside
+// a translated tooltipText, so nine of the ten locales heard English.
+//
+// Reads the source tree and the locale files through import.meta.glob rather
+// than node:fs, for the reason keyCoverage.test.ts documents at length:
+// tsconfig's `types` array is deliberately without "node".
+const allSources = import.meta.glob('/src/components/**/*.tsx', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
+
+// KAN-69: SignIn, CreateAccount and ForgotPassword have no importers anywhere
+// in src/ and are already tree-shaken out of the artifact (their strings do not
+// appear in dist at all). Their ~8 hardcoded English strings are therefore
+// invisible to users, and translating UI nobody can open would have meant ~72
+// machine-translated strings for nothing. Excluded until KAN-69 decides whether
+// they are deleted or wired up; delete this list when it does.
+const DEAD_FILES = /Account\/(SignIn|CreateAccount|ForgotPassword)\.tsx$/;
+
+// Commented-out JSX still matches the literal patterns below --
+// UserInputContainer keeps a `{/* <Button text="Search" ... /> */}` line -- and
+// a commented string is not shipped to anyone.
+const stripComments = (src: string) =>
+  src.replace(/\{\/\*[\s\S]*?\*\/\}/g, '').replace(/^\s*\/\/.*$/gm, '');
+
+const sources = Object.fromEntries(
+  Object.entries(allSources)
+    .filter(([file]) => !DEAD_FILES.test(file))
+    .map(([file, src]) => [file, stripComments(src)])
+);
+
+const localeFiles = import.meta.glob('/public/locales/*/translation.json', {
+  import: 'default',
+  eager: true,
+}) as Record<string, Record<string, string>>;
+
+// A string literal handed straight to ariaLabel. `ariaLabel={t('...')}` and
+// `ariaLabel={title}` do not match, which is the point.
+const HARDCODED_LABEL = /ariaLabel="([^"]*)"/g;
+
+// Likewise for the two sibling props that turned out to carry untranslated
+// English of their own -- WindowEntryContainer's tooltipText="Save changes"
+// and SignIn's VISIBLE text="Sign In". The ticket only described ariaLabel.
+const HARDCODED_TOOLTIP = /tooltipText="([^"]*)"/g;
+const HARDCODED_TEXT = /\btext="([^"]*)"/g;
+
+const findAll = (src: string, re: RegExp) =>
+  [...src.matchAll(new RegExp(re.source, 'g'))].map((m) => m[1]);
+
+describe('no user-facing string is hardcoded English', () => {
+  // The control. If this ever fails, the glob has stopped seeing the source
+  // tree and every "zero hardcoded strings" assertion below is vacuous.
+  test('CONTROL: the component sources are actually being read', () => {
+    const files = Object.keys(sources);
+    expect(files.length).toBeGreaterThan(10);
+    expect(files.join('|')).toMatch(/MenuContainer\.tsx/);
+    // Something translated really is in there, so the scan sees real content.
+    expect(Object.values(sources).join('\n')).toMatch(/t\('Undo'\)/);
+
+    // And the KAN-69 exclusion removes exactly the three dead files -- an
+    // over-broad regex here would silently hide real offenders.
+    expect(Object.keys(allSources).length - Object.keys(sources).length).toBe(
+      3
+    );
+  });
+
+  for (const [prop, re] of [
+    ['ariaLabel', HARDCODED_LABEL],
+    ['tooltipText', HARDCODED_TOOLTIP],
+    ['text', HARDCODED_TEXT],
+  ] as const) {
+    test(`no component passes a literal ${prop}`, () => {
+      const offenders: string[] = [];
+      for (const [file, src] of Object.entries(sources)) {
+        for (const value of findAll(src, re)) {
+          offenders.push(`${file}  ${prop}="${value}"`);
+        }
+      }
+      expect(offenders).toEqual([]);
+    });
+  }
+});
+
+// A factory rather than a shared constant: saveToTabContainerInternal's
+// reducer mutates what it is handed and Immer freezes it, so a session reused
+// across the ten locale cases arrives at the second dispatch already frozen
+// and throws "Cannot assign to read only property 'lastModified'".
+const buildSession = (): tabContainerData => ({
+  tabGroupId: 'group-1',
+  title: 'Research',
+  createdTime: '2026-08-31 09:00:00',
+  createdAt: Date.UTC(2026, 7, 31, 9, 0, 0),
+  windowCount: 1,
+  tabCount: 1,
+  isAutoSave: false,
+  isSelected: true,
+  windows: [
+    {
+      windowId: 'win-1',
+      windowHeight: 1080,
+      windowWidth: 1920,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 1,
+      title: 'Morning reading',
+      tabs: [
+        {
+          tabId: 't1',
+          favicon: '',
+          title: 'Kagi Search',
+          url: 'https://kagi.com/',
+        },
+      ],
+    },
+  ],
+});
+
+const noop = () => {};
+
+// The text a sighted user reads off the control. Two things have to come out:
+// the Material Symbols glyph, which renders as its ligature NAME ("delete",
+// "reopen_window") and is not text anyone sees, and anything already hidden
+// from assistive tech.
+function visibleTextOf(el: Element): string {
+  const clone = el.cloneNode(true) as Element;
+  clone
+    .querySelectorAll('.material-symbols-outlined, [aria-hidden="true"]')
+    .forEach((n) => n.remove());
+  return (clone.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+const norm = (s: string) => s.toLowerCase().replace(/\s+/g, ' ').trim();
+
+// testI18n is created but NOT initialised at import time -- renderWithProviders
+// is what calls init. addResourceBundle and changeLanguage do not exist on an
+// uninitialised instance, so this has to run before either is touched.
+beforeEach(async () => {
+  await initTestI18n();
+});
+
+afterEach(async () => {
+  // changeLanguage mutates the shared test instance, so a leaked locale would
+  // silently run every later test in the wrong language.
+  await testI18n.changeLanguage('en');
+});
+
+// WCAG 2.5.3 Label in Name, Level A: when a control has visible text, its
+// accessible name must contain that text.
+//
+// This is the test that rules out KAN-65's own suggested fix. The ticket
+// proposes reusing each control's tooltipText key as its label, and measured
+// across all ten locales that fails 22 of 40 cases -- "Switch" against a
+// tooltip reading "Close current windows and open this session" fails in
+// every locale, and "Add window" fails in seven.
+//
+// jsdom is a sound oracle here, unlike the accessible-NAME assertions in
+// e2e/a11y-controls.spec.ts: this compares an aria-label attribute against
+// rendered text content, both of which jsdom reflects faithfully. No
+// computed-name algorithm is involved.
+describe('Label in Name holds in every locale (WCAG 2.5.3)', () => {
+  for (const [file, dict] of Object.entries(localeFiles)) {
+    const locale = file.split('/')[3];
+
+    test(`${locale}: labelled controls contain their visible text`, async () => {
+      const { container } = await renderWithProviders(
+        <>
+          <TabGroupEntry
+            tabGroupData={buildSession()}
+            onTabGroupClick={noop}
+            onOpenAllClick={noop}
+            onFocusClick={noop}
+            onDeleteClick={noop}
+          />
+          <HeroContainerRight />
+        </>,
+        {
+          seedStore: (store) => {
+            store.dispatch(saveToTabContainerInternal(buildSession()));
+            store.dispatch(selectTabContainer('group-1'));
+          },
+        }
+      );
+
+      // The language switch has to happen AFTER the render, not before.
+      // renderWithProviders calls initTestI18n() itself, and init({ lng: 'en' })
+      // resets the language -- so switching first left every case running
+      // English labels against English text and passing vacuously. The count
+      // control below did not catch it, because the COUNT was right and only
+      // the language was wrong.
+      testI18n.addResourceBundle(locale, 'translation', dict, true, true);
+      await act(async () => {
+        await testI18n.changeLanguage(locale);
+      });
+
+      // CONTROL: prove the locale is actually live in the DOM before trusting
+      // anything below. `en` is exempt only because it is the fallback.
+      expect(testI18n.language).toBe(locale);
+      if (locale !== 'en') {
+        expect(dict['Open']).toBeTruthy();
+        expect(container.textContent).toContain(dict['Open']);
+      }
+
+      const checked: string[] = [];
+      const failures: string[] = [];
+
+      // Only glyph controls -- an Icon or Button whose visible text sits
+      // beside a Material Symbols glyph. Their text IS the control's label,
+      // which is what 2.5.3 governs.
+      //
+      // Composite rows are deliberately excluded. The session row is a
+      // ClickableRow named after its session title while its text content also
+      // carries the window/tab counts and the created date; those are
+      // supplementary CONTENT, not part of the label, so requiring the name to
+      // contain all of them would be wrong rather than strict.
+      for (const el of container.querySelectorAll('[aria-label]')) {
+        if (!el.querySelector('.material-symbols-outlined')) continue;
+        const visible = visibleTextOf(el);
+        if (!visible) continue;
+        const name = el.getAttribute('aria-label') ?? '';
+        checked.push(visible);
+        if (!norm(name).includes(norm(visible))) {
+          failures.push(
+            `name "${name}" does not contain visible text "${visible}"`
+          );
+        }
+      }
+
+      // Without this the loop above passes trivially on a render that produced
+      // no labelled control with visible text at all.
+      expect(checked.length).toBeGreaterThanOrEqual(4);
+      expect(failures).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
All 25 `ariaLabel` call sites passed a hardcoded English string while the `tooltipText` beside them on the very same element was translated:

```jsx
<Icon
  tooltipText={t('Sync now')}   // translated
  ariaLabel="sync"              // English, always
/>
```

So a sighted German user hovered and read German, and a German screen-reader user heard "sync". Nine of the ten locales were affected — and the group least able to work around it.

## The ticket's suggested fix does not work

KAN-65 proposes reusing each control's `tooltipText` key as its label. For the four controls that carry **visible text**, that breaks **WCAG 2.5.3 Label in Name** (Level A): the accessible name must contain the visible text.

Measured across all ten locales before writing any code — it fails **22 of 40** cases:

| Control | Visible | Passes |
|---|---|---|
| Open | "Open" | 10/10 |
| **Switch** | "Switch" | **0/10** — tooltip is "Close current windows and open this session" |
| Delete | "Delete" | 7/10 — fails `fr`, `hi`, `pt` |
| **Add window** | "Add window" | **3/10** — German separable verbs, Japanese を vs に |

## The rule applied instead

Makes 2.5.3 true by construction rather than by review:

- **has visible text** → reuse that text's own key, so the name equals the visible label exactly
- **no visible text** → reuse its `tooltipText` key

That needed exactly **one** new key (`Save changes`) across ten locales, against the ~250 strings a parallel set of label keys would have cost. The trade-off is that the 21 tooltip-derived names inherit the tooltip's length — accurate, and matching what sighted users read.

## Beyond the ticket

**Fixed:** `WindowEntryContainer`'s `tooltipText="Save changes"` was the one tooltip in the app still passed as a literal. The ticket's premise was that all tooltips are translated.

**Deliberately not fixed:** ~8 hardcoded English strings in `SignIn`, `CreateAccount` and `ForgotPassword`. None of those three has an importer anywhere in `src/`, and they are already tree-shaken out of the artifact — `grep -c "Trouble logging in" dist/assets/index-*.js` → `0`. Translating them meant ~72 machine-translated strings for UI nobody can open. Filed as **KAN-69**; the new guard excludes that directory and points there. This also prompted a correction on **KAN-67**, which listed those eight among its 32 keyboard-unreachable buttons — 24 was the number with real user impact.

**Recorded, not fixed:** `fr`, `hi` and `pt` translate *Delete* two different ways in the same UI — the French button reads "Effacer", its tooltip "Supprimer". Pre-existing and unrelated to labels.

## Testing

```
Test Files  55 passed (55)      Tests  481 passed (481)    # +14
        27 passed                                          # Playwright E2E
tsc: 0    typecheck:e2e: 0    lint: 0 errors, 25 warnings
```

New `src/tests/locales/accessibleNames.test.tsx` does two things: a **source guard** that no component passes a literal `ariaLabel`, `tooltipText` or `text`, and a **locale-parameterised Label in Name check** across all ten.

### The suite passed vacuously at first

Worth flagging for anyone touching locale tests. `renderWithProviders` calls `initTestI18n()` itself, and `init({ lng: 'en' })` reset the language **after** the test had switched it — so every case ran English labels against English text and went green. The existing count control did not catch it, because the count was right and only the *language* was wrong. The suite now asserts the locale is live in the DOM before trusting anything below it.

### Mutation-tested

| Mutation | Result |
|---|---|
| Apply the ticket's own suggested fix (`t('Switch')` → `t('Switch to session')`) | all 10 locales red |
| Revert one label to a literal | source guard red |
| Drop the new key from `de` only | `keyCoverage` red |
| Re-introduce the language-reset bug | 9 locales red, `expected 'en' to be 'de'` |

### Verified live

Real extension in Chrome, switched to German. All 27 labels render German, zero English remain, user data ("Example Domain", "Delta") correctly untranslated:

```
Suchen · Rückgängig · Wiederholen · Jetzt synchronisieren · Einstellungen
Aktuelles Fenster als Sitzung speichern · Alle offenen Fenster als Sitzung speichern
Öffnen · Wechseln · Löschen · Sitzung umbenennen · Tab löschen · …
```

The row controls read `Öffnen`/`Wechseln`/`Löschen` — identical to their visible button text, which is exactly the 2.5.3 property. Under the ticket's approach "Wechseln" would have been named "Aktuelle Fenster schließen und diese Sitzung öffnen". Profile restored to `en` afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)