### PR TITLE
Read a gzip-compressed Firestore document (KAN-6 phase 1)

### DIFF
--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -10,7 +10,6 @@ import { getAuth, onAuthStateChanged, signInAnonymously } from 'firebase/auth';
 
 import { AppDispatch } from '../redux/store';
 import { setLoggedOut, setSignedIn } from '../redux/slices/globalStateSlice';
-import { TabMasterContainer } from '../redux/slices/tabContainerDataStateSlice';
 // https://firebase.google.com/docs/web/setup#available-libraries
 
 // Firebase configuration
@@ -58,9 +57,23 @@ export const signInUserAnonymously = () => {
     });
 };
 
+// What a document decodes to before anything has proven its shape.
+//
+// This read used to declare Promise<TabMasterContainer> while assigning
+// unproven DocumentData fields into it, which is a claim it cannot support:
+// the document is user-syncable data that another client version may have
+// written. Saying `unknown` here forces the single narrowing to happen at
+// isValidTabMasterContainer in syncStateWithFirestore, where it belongs.
+export interface CloudCandidate {
+  lastModified: unknown;
+  tabGroups: unknown;
+  selectedTabGroupId: unknown;
+  deletedTabGroups: unknown;
+}
+
 export const fetchDataFromFirestore = async (
   userId: string
-): Promise<TabMasterContainer> => {
+): Promise<CloudCandidate> => {
   try {
     // Fetch your data based on the signed-in user's ID
     const tabData = await getDoc(doc(db, 'tabGroupData', userId));

--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -9,6 +9,7 @@ import { doc, getDoc, getFirestore } from 'firebase/firestore/lite';
 import { getAuth, onAuthStateChanged, signInAnonymously } from 'firebase/auth';
 
 import { AppDispatch } from '../redux/store';
+import { decompressFromBytes } from '../utils/functions/compression';
 import { setLoggedOut, setSignedIn } from '../redux/slices/globalStateSlice';
 // https://firebase.google.com/docs/web/setup#available-libraries
 
@@ -71,6 +72,52 @@ export interface CloudCandidate {
   deletedTabGroups: unknown;
 }
 
+// A Firestore Bytes value exposes toUint8Array(); a test or a future caller may
+// pass the array directly. Anything else - including the absent field on every
+// document written today - is not a compressed payload.
+function asUint8Array(value: unknown): Uint8Array | null {
+  if (value instanceof Uint8Array) return value;
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'toUint8Array' in value &&
+    typeof (value as { toUint8Array: unknown }).toUint8Array === 'function'
+  ) {
+    return (value as { toUint8Array: () => Uint8Array }).toUint8Array();
+  }
+  return null;
+}
+
+// Phase 1 of KAN-6: understand both shapes, write neither differently.
+//
+// tabGroupsZ is gzipped JSON in a Firestore Bytes field. A document that lacks
+// it is a document written by any client shipped to date, and its plain
+// tabGroups array is returned untouched.
+async function readTabGroups(data: {
+  tabGroups?: unknown;
+  tabGroupsZ?: unknown;
+}): Promise<unknown> {
+  const packed = asUint8Array(data.tabGroupsZ);
+  if (packed === null) return data.tabGroups;
+
+  try {
+    const parsed: unknown = JSON.parse(await decompressFromBytes(packed));
+    if (!Array.isArray(parsed)) {
+      console.warn('tabGroupsZ decoded to a non-array; treating as unreadable');
+      return undefined;
+    }
+    return parsed;
+  } catch (error) {
+    // Deliberately undefined, never []. "Could not decode" and "no sessions"
+    // must stay distinguishable: an empty array reads as a valid empty account
+    // and would be written straight over the document, destroying data we
+    // merely failed to read. undefined fails isValidTabMasterContainer, which
+    // stops the sync without writing.
+    console.warn('tabGroupsZ did not decode; treating as unreadable:', error);
+    return undefined;
+  }
+}
+
 export const fetchDataFromFirestore = async (
   userId: string
 ): Promise<CloudCandidate> => {
@@ -94,7 +141,7 @@ export const fetchDataFromFirestore = async (
       const data = tabData.data();
       return {
         lastModified: data.lastModified,
-        tabGroups: data.tabGroups,
+        tabGroups: await readTabGroups(data),
         selectedTabGroupId: data.selectedTabGroupId,
         deletedTabGroups: data.deletedTabGroups,
       };

--- a/src/redux/slices/globalStateSlice.ts
+++ b/src/redux/slices/globalStateSlice.ts
@@ -9,6 +9,9 @@ import {
   saveToFirestore,
 } from '../../utils/functions/external';
 import {
+  bytesToMB,
+  estimateFirestoreBytes,
+  FIRESTORE_MAX_DOCUMENT_BYTES,
   isValidTabMasterContainer,
   loadFromLocalStorage,
   saveToLocalStorage,
@@ -66,6 +69,21 @@ export const saveToFirestoreIfDirty = createAsyncThunk(
 
     try {
       if (state.globalState.isDirty) {
+        // Firestore rejects an over-limit document, and the rejection leaves
+        // isDirty set, so every later change retries the same doomed write and
+        // sync wedges with nothing on screen to explain it. readImportedContainer
+        // already refuses this on the import path; this is the same refusal on
+        // the sync path, phrased the same way.
+        const bytes = estimateFirestoreBytes(state.tabContainerDataState);
+        if (bytes > FIRESTORE_MAX_DOCUMENT_BYTES) {
+          const message =
+            `too large to sync (${bytesToMB(bytes)} MB of a ` +
+            `${bytesToMB(FIRESTORE_MAX_DOCUMENT_BYTES)} MB limit). ` +
+            `Remove some sessions and try again.`;
+          thunkAPI.dispatch(showToast({ toastText: message, duration: 6000 }));
+          throw new Error(message);
+        }
+
         await saveToFirestore(
           state.globalState.userId!,
           state.tabContainerDataState

--- a/src/redux/slices/globalStateSlice.ts
+++ b/src/redux/slices/globalStateSlice.ts
@@ -91,8 +91,31 @@ export const syncStateWithFirestore = createAsyncThunk(
     const state = thunkAPI.getState() as RootState;
 
     // load from Firestore
-    const tabDataFromCloud: TabMasterContainer | undefined =
-      await loadFromFirestore(state.globalState.userId!, thunkAPI);
+    const cloudCandidate = await loadFromFirestore(
+      state.globalState.userId!,
+      thunkAPI
+    );
+
+    // The cloud side gets the same treatment localStorage gets below. Without
+    // this, an unrecognised document reaches mergeTabContainers and throws
+    // `side.tabGroups is not iterable`, rejecting the thunk with no message.
+    //
+    // Unreadable is deliberately NOT treated as absent. "Absent" falls through
+    // to the local-only branch, which writes local state over the document -
+    // and a document we failed to parse may be a NEWER FORMAT rather than
+    // corruption, so overwriting would destroy data we merely could not read.
+    // Stop instead: keep local data, leave the document untouched, report it.
+    if (
+      cloudCandidate !== undefined &&
+      !isValidTabMasterContainer(cloudCandidate)
+    ) {
+      console.warn(
+        'Unreadable Firestore document for this user; leaving it untouched.'
+      );
+      thunkAPI.dispatch(setSyncStatus('error'));
+      return;
+    }
+    const tabDataFromCloud: TabMasterContainer | undefined = cloudCandidate;
 
     // localStorage is user-writable and survives extension updates, so whatever
     // comes back here is genuinely unknown. Validate before the sync can act on

--- a/src/tests/config/compressedRead.test.ts
+++ b/src/tests/config/compressedRead.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+const firestore = vi.hoisted(() => ({ getDoc: vi.fn() }));
+
+vi.mock('firebase/app', () => ({ initializeApp: vi.fn(() => ({})) }));
+vi.mock('firebase/auth', () => ({
+  getAuth: vi.fn(() => ({})),
+  onAuthStateChanged: vi.fn(),
+  signInAnonymously: vi.fn(),
+}));
+vi.mock('firebase/firestore/lite', () => ({
+  doc: vi.fn(() => ({})),
+  getFirestore: vi.fn(() => ({})),
+  setDoc: vi.fn(),
+  getDoc: firestore.getDoc,
+}));
+
+import { fetchDataFromFirestore } from '../../config/firebase';
+import { compressToBytes } from '../../utils/functions/compression';
+
+const sessions = [
+  { tabGroupId: 'a', title: 'Alpha', lastModified: 1000, createdAt: 1000 },
+];
+
+// A Firestore Bytes value is an object exposing toUint8Array(); the reader must
+// accept that as well as a bare Uint8Array, because the lite SDK hands back the
+// former and tests construct the latter.
+const asBytesValue = (bytes: Uint8Array) => ({ toUint8Array: () => bytes });
+
+describe('the reader understands both document shapes', () => {
+  beforeEach(() => firestore.getDoc.mockReset());
+
+  it('reads a legacy uncompressed document unchanged', async () => {
+    firestore.getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({
+        lastModified: 1000,
+        selectedTabGroupId: 'a',
+        tabGroups: sessions,
+        deletedTabGroups: [{ tabGroupId: 'gone', deletedAt: 900 }],
+      }),
+    });
+    const read = await fetchDataFromFirestore('u1');
+    expect(read.tabGroups).toEqual(sessions);
+    expect(read.deletedTabGroups).toEqual([
+      { tabGroupId: 'gone', deletedAt: 900 },
+    ]);
+  });
+
+  it('reads a compressed document to the identical container', async () => {
+    const packed = await compressToBytes(JSON.stringify(sessions));
+    firestore.getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({
+        lastModified: 1000,
+        selectedTabGroupId: 'a',
+        tabGroupsZ: asBytesValue(packed),
+        deletedTabGroups: [{ tabGroupId: 'gone', deletedAt: 900 }],
+      }),
+    });
+    const read = await fetchDataFromFirestore('u1');
+    expect(read.tabGroups).toEqual(sessions);
+    // Tombstones stay plain fields and must survive untouched.
+    expect(read.deletedTabGroups).toEqual([
+      { tabGroupId: 'gone', deletedAt: 900 },
+    ]);
+  });
+
+  it('accepts a bare Uint8Array as well as a Bytes value', async () => {
+    const packed = await compressToBytes(JSON.stringify(sessions));
+    firestore.getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({
+        lastModified: 1000,
+        selectedTabGroupId: 'a',
+        tabGroupsZ: packed,
+      }),
+    });
+    const read = await fetchDataFromFirestore('u1');
+    expect(read.tabGroups).toEqual(sessions);
+  });
+
+  // "Could not decode" and "no sessions" must never be conflated: an empty
+  // array reads as a valid, empty account and would be written straight over
+  // the document. undefined fails isValidTabMasterContainer, which stops the
+  // sync without writing (Task 1).
+  it('yields undefined tabGroups when tabGroupsZ will not decode', async () => {
+    firestore.getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({
+        lastModified: 1000,
+        selectedTabGroupId: null,
+        tabGroupsZ: asBytesValue(new Uint8Array([9, 9, 9, 9])),
+      }),
+    });
+    const read = await fetchDataFromFirestore('u1');
+    expect(read.tabGroups).toBeUndefined();
+  });
+
+  it('yields undefined tabGroups when tabGroupsZ decodes to a non-array', async () => {
+    const packed = await compressToBytes('{"not":"an array"}');
+    firestore.getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({
+        lastModified: 1000,
+        selectedTabGroupId: null,
+        tabGroupsZ: asBytesValue(packed),
+      }),
+    });
+    const read = await fetchDataFromFirestore('u1');
+    expect(read.tabGroups).toBeUndefined();
+  });
+
+  it('prefers tabGroupsZ when a document somehow carries both', async () => {
+    const packed = await compressToBytes(JSON.stringify(sessions));
+    firestore.getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({
+        lastModified: 1000,
+        selectedTabGroupId: 'a',
+        tabGroups: [{ tabGroupId: 'stale', title: 'Stale' }],
+        tabGroupsZ: asBytesValue(packed),
+      }),
+    });
+    const read = await fetchDataFromFirestore('u1');
+    expect(read.tabGroups).toEqual(sessions);
+  });
+});

--- a/src/tests/redux/syncCloudValidation.test.ts
+++ b/src/tests/redux/syncCloudValidation.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Inlined rather than imported: a vi.hoisted block runs before the module
+// graph is evaluated, and common.ts reads window.screen at module load.
+// Keep in step with src/tests/setup/domStub.ts.
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+const mocks = vi.hoisted(() => ({
+  loadFromFirestore: vi.fn(async (): Promise<unknown> => undefined),
+  saveToFirestore: vi.fn<(userId: string, data: unknown) => Promise<void>>(
+    async () => undefined
+  ),
+}));
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: mocks.loadFromFirestore,
+  saveToFirestore: mocks.saveToFirestore,
+  displayToast: vi.fn(),
+}));
+
+import {
+  setUserId,
+  syncStateWithFirestore,
+} from '../../redux/slices/globalStateSlice';
+import { replaceState } from '../../redux/slices/tabContainerDataStateSlice';
+import { makeTestStore } from '../setup/makeStore';
+import { buildContainer, buildSession } from '../fixtures/sessionFixture';
+
+const localOnly = buildContainer([buildSession()]);
+
+describe('an unreadable cloud document stops the sync without writing', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mocks.loadFromFirestore.mockReset();
+    mocks.saveToFirestore.mockReset().mockResolvedValue(undefined);
+    localStorage.setItem('tabContainerData', JSON.stringify(localOnly));
+  });
+
+  // The exact shape an old client produces when sessions move to another
+  // field: every whitelisted key present, tabGroups absent. Verified against
+  // the real mergeTabContainers to throw `side.tabGroups is not iterable`.
+  const unreadable = {
+    lastModified: 5000,
+    selectedTabGroupId: null,
+    tabGroups: undefined,
+    deletedTabGroups: [],
+  };
+
+  it('does not throw', async () => {
+    mocks.loadFromFirestore.mockResolvedValue(unreadable);
+    const { store } = makeTestStore();
+    store.dispatch(setUserId('u1'));
+    await expect(
+      store.dispatch(syncStateWithFirestore()).unwrap()
+    ).resolves.not.toThrow();
+  });
+
+  it('never writes over a document it could not read', async () => {
+    mocks.loadFromFirestore.mockResolvedValue(unreadable);
+    const { store } = makeTestStore();
+    store.dispatch(setUserId('u1'));
+    await store.dispatch(syncStateWithFirestore());
+    expect(mocks.saveToFirestore).not.toHaveBeenCalled();
+  });
+
+  // The assertion that actually separates "guarded" from "crashed". Both leave
+  // local data alone, so session-survival proves nothing here; only the
+  // reporting differs. syncStateWithFirestore has no `rejected` extraReducer,
+  // so the pre-fix crash left syncStatus on 'idle' - the sync died looking
+  // exactly like a sync that had not run.
+  it('reports the failure instead of dying silently', async () => {
+    mocks.loadFromFirestore.mockResolvedValue(unreadable);
+    const { store } = makeTestStore();
+    store.dispatch(setUserId('u1'));
+    await store.dispatch(syncStateWithFirestore());
+    expect(store.getState().globalState.syncStatus).toBe('error');
+  });
+
+  // Regression guard on the other half of "keep local data, leave the document
+  // untouched". Deliberately seeded into the store, because the guard returns
+  // before anything hydrates it from localStorage. Honest limitation: this also
+  // passes against the pre-fix crash, so it guards future edits to the error
+  // path rather than proving today's fix.
+  it('leaves the local sessions in the store alone', async () => {
+    mocks.loadFromFirestore.mockResolvedValue(unreadable);
+    const { store } = makeTestStore();
+    store.dispatch(setUserId('u1'));
+    store.dispatch(replaceState(localOnly));
+    await store.dispatch(syncStateWithFirestore());
+    expect(store.getState().tabContainerDataState.tabGroups).toHaveLength(
+      localOnly.tabGroups.length
+    );
+  });
+
+  // POSITIVE CONTROL. Without this, all three assertions above pass just as
+  // well against code that never writes or merges anything at all.
+  it('control: a VALID cloud document is still merged and can still write', async () => {
+    const validCloud = buildContainer([
+      buildSession({ tabGroupId: 'cloud-only', title: 'Cloud Only' }),
+    ]);
+    validCloud.lastModified = 9999;
+    mocks.loadFromFirestore.mockResolvedValue(validCloud);
+    const { store } = makeTestStore();
+    store.dispatch(setUserId('u1'));
+    await store.dispatch(syncStateWithFirestore());
+    const titles = store
+      .getState()
+      .tabContainerDataState.tabGroups.map((g) => g.title);
+    expect(titles).toContain('Cloud Only');
+  });
+});

--- a/src/tests/redux/syncSizeGuard.test.ts
+++ b/src/tests/redux/syncSizeGuard.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+const mocks = vi.hoisted(() => ({
+  loadFromFirestore: vi.fn(async (): Promise<unknown> => undefined),
+  saveToFirestore: vi.fn<(userId: string, data: unknown) => Promise<void>>(
+    async () => undefined
+  ),
+}));
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: mocks.loadFromFirestore,
+  saveToFirestore: mocks.saveToFirestore,
+  displayToast: vi.fn(),
+}));
+
+import {
+  setIsDirtyWithoutSync,
+  setUserId,
+  saveToFirestoreIfDirty,
+} from '../../redux/slices/globalStateSlice';
+// replaceState lives on the data slice, not the global slice.
+import { replaceState } from '../../redux/slices/tabContainerDataStateSlice';
+import { makeTestStore } from '../setup/makeStore';
+import { buildContainer, buildSession } from '../fixtures/sessionFixture';
+import { FIRESTORE_MAX_DOCUMENT_BYTES } from '../../utils/functions/local';
+
+// A session whose tab titles alone exceed the document limit. Built from real
+// field names so estimateFirestoreBytes measures the same JSON production does.
+function oversizedContainer() {
+  const filler = 'x'.repeat(2000);
+  const sessions = Array.from({ length: 600 }, (_, i) =>
+    buildSession({ tabGroupId: `big-${i}`, title: `${filler}-${i}` })
+  );
+  return buildContainer(sessions);
+}
+
+describe('the sync write refuses a document Firestore would reject', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mocks.saveToFirestore.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('the fixture really is over the limit (guards the test itself)', () => {
+    const json = JSON.stringify(oversizedContainer());
+    expect(new TextEncoder().encode(json).byteLength).toBeGreaterThan(
+      FIRESTORE_MAX_DOCUMENT_BYTES
+    );
+  });
+
+  it('does not call setDoc with an over-limit container', async () => {
+    const { store } = makeTestStore();
+    store.dispatch(setUserId('u1'));
+    store.dispatch(replaceState(oversizedContainer()));
+    store.dispatch(setIsDirtyWithoutSync());
+    await store.dispatch(saveToFirestoreIfDirty());
+    expect(mocks.saveToFirestore).not.toHaveBeenCalled();
+  });
+
+  it('explains the refusal in MB, like the import guard does', async () => {
+    const { store } = makeTestStore();
+    store.dispatch(setUserId('u1'));
+    store.dispatch(replaceState(oversizedContainer()));
+    store.dispatch(setIsDirtyWithoutSync());
+    const result = await store.dispatch(saveToFirestoreIfDirty());
+    expect(
+      String((result as { error?: { message?: string } }).error?.message)
+    ).toMatch(/too large to sync .* MB of a 1\.0 MB limit/);
+  });
+
+  // POSITIVE CONTROL. "not called" passes trivially against a broken store or
+  // a thunk that never runs, so prove the same setup CAN write.
+  it('control: an under-limit container IS written', async () => {
+    const { store } = makeTestStore();
+    store.dispatch(setUserId('u1'));
+    store.dispatch(replaceState(buildContainer([buildSession()])));
+    store.dispatch(setIsDirtyWithoutSync());
+    await store.dispatch(saveToFirestoreIfDirty());
+    expect(mocks.saveToFirestore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tests/redux/writerVersion.test.ts
+++ b/src/tests/redux/writerVersion.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+const firestore = vi.hoisted(() => ({ setDoc: vi.fn() }));
+
+vi.mock('firebase/app', () => ({ initializeApp: vi.fn(() => ({})) }));
+vi.mock('firebase/auth', () => ({
+  getAuth: vi.fn(() => ({})),
+  onAuthStateChanged: vi.fn(),
+  signInAnonymously: vi.fn(),
+}));
+vi.mock('firebase/firestore/lite', () => ({
+  doc: vi.fn(() => ({})),
+  getFirestore: vi.fn(() => ({})),
+  getDoc: vi.fn(),
+  setDoc: firestore.setDoc,
+}));
+
+import {
+  saveToFirestore,
+  CURRENT_WRITER_VERSION,
+} from '../../utils/functions/external';
+import { buildContainer, buildSession } from '../fixtures/sessionFixture';
+
+describe('every save records which client wrote it', () => {
+  beforeEach(() => firestore.setDoc.mockReset().mockResolvedValue(undefined));
+
+  // The constant is pinned to a literal, not just compared against itself.
+  // `expect(written.writerVersion).toBe(CURRENT_WRITER_VERSION)` alone is a
+  // tautology: before the constant existed the import resolved to undefined and
+  // the assertion reduced to expect(undefined).toBe(undefined), which passes
+  // against a save that stamps nothing at all.
+  it('exports a concrete writer version', () => {
+    expect(CURRENT_WRITER_VERSION).toBe(2);
+  });
+
+  it('stamps writerVersion', async () => {
+    await saveToFirestore('u1', buildContainer([buildSession()]));
+    const written = firestore.setDoc.mock.calls[0][1] as {
+      writerVersion?: number;
+    };
+    expect(written.writerVersion).toBe(2);
+    expect(written.writerVersion).toBe(CURRENT_WRITER_VERSION);
+  });
+
+  // Phase 1 must not move session data. If this ever fails, a write-side
+  // format change has crept in and old clients will crash on it.
+  it('still writes sessions as a plain tabGroups array', async () => {
+    await saveToFirestore('u1', buildContainer([buildSession()]));
+    const written = firestore.setDoc.mock.calls[0][1] as {
+      tabGroups?: unknown;
+      tabGroupsZ?: unknown;
+    };
+    expect(Array.isArray(written.tabGroups)).toBe(true);
+    expect(written.tabGroupsZ).toBeUndefined();
+  });
+
+  it('leaves tombstones untouched alongside the stamp', async () => {
+    const container = buildContainer([buildSession()]);
+    container.deletedTabGroups = [{ tabGroupId: 'gone', deletedAt: 900 }];
+    await saveToFirestore('u1', container);
+    const written = firestore.setDoc.mock.calls[0][1] as {
+      deletedTabGroups?: unknown;
+    };
+    expect(written.deletedTabGroups).toEqual([
+      { tabGroupId: 'gone', deletedAt: 900 },
+    ]);
+  });
+});

--- a/src/tests/utils/functions/compression.test.ts
+++ b/src/tests/utils/functions/compression.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import {
+  compressToBytes,
+  decompressFromBytes,
+} from '../../../utils/functions/compression';
+
+describe('gzip helper', () => {
+  // An INDEPENDENT fixture: produced by node's zlib, outside the module under
+  // test. A pure round-trip test passes even when compress and decompress share
+  // the same bug, so this is the control that makes the round-trip meaningful.
+  it('decodes a gzip blob this module did not produce', async () => {
+    const b64 =
+      'H4sIAAAAAAAAE4uuVipJTHIvyi8t8ExRslLKzssvz9M1VNJRKsksyUlVslLyBokoBKcWF2fm5ynVxgIA5clfqDIAAAA=';
+    const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+    await expect(decompressFromBytes(bytes)).resolves.toBe(
+      '[{"tabGroupId":"known-1","title":"Known Session"}]'
+    );
+  });
+
+  it('round-trips a realistic session payload and actually compresses it', async () => {
+    const big = JSON.stringify(
+      Array.from({ length: 2000 }, (_, i) => ({
+        tabId: `id-${i}`,
+        url: `https://github.com/a/b/c/${i}`,
+        title: `Title number ${i}`,
+      }))
+    );
+    const packed = await compressToBytes(big);
+    expect(packed.byteLength).toBeLessThan(
+      new TextEncoder().encode(big).byteLength / 3
+    );
+    await expect(decompressFromBytes(packed)).resolves.toBe(big);
+  });
+
+  // The document is measured and stored in BYTES, not UTF-16 units. A title in
+  // a non-Latin script is one character and three bytes, and getting that wrong
+  // is the failure that silently truncates someone's sessions.
+  it('round-trips non-Latin text exactly', async () => {
+    const s = JSON.stringify({ t: '日本語のタイトル', u: 'Ünïcødé — ok' });
+    await expect(decompressFromBytes(await compressToBytes(s))).resolves.toBe(s);
+  });
+
+  it('rejects on non-gzip input rather than returning empty', async () => {
+    await expect(
+      decompressFromBytes(new Uint8Array([1, 2, 3, 4, 5]))
+    ).rejects.toThrow();
+  });
+
+  it('round-trips an empty array, the new-user case', async () => {
+    await expect(decompressFromBytes(await compressToBytes('[]'))).resolves.toBe(
+      '[]'
+    );
+  });
+});

--- a/src/tests/utils/functions/compression.test.ts
+++ b/src/tests/utils/functions/compression.test.ts
@@ -37,7 +37,9 @@ describe('gzip helper', () => {
   // is the failure that silently truncates someone's sessions.
   it('round-trips non-Latin text exactly', async () => {
     const s = JSON.stringify({ t: '日本語のタイトル', u: 'Ünïcødé — ok' });
-    await expect(decompressFromBytes(await compressToBytes(s))).resolves.toBe(s);
+    await expect(decompressFromBytes(await compressToBytes(s))).resolves.toBe(
+      s
+    );
   });
 
   it('rejects on non-gzip input rather than returning empty', async () => {
@@ -47,8 +49,8 @@ describe('gzip helper', () => {
   });
 
   it('round-trips an empty array, the new-user case', async () => {
-    await expect(decompressFromBytes(await compressToBytes('[]'))).resolves.toBe(
-      '[]'
-    );
+    await expect(
+      decompressFromBytes(await compressToBytes('[]'))
+    ).resolves.toBe('[]');
   });
 });

--- a/src/utils/functions/compression.ts
+++ b/src/utils/functions/compression.ts
@@ -1,0 +1,64 @@
+// gzip via the platform's own CompressionStream rather than a library.
+//
+// Chrome has shipped CompressionStream since v80, so an extension can rely on
+// it with no polyfill and no dependency. Measured against lz-string on a
+// realistic 1,000-tab container: 58,123 stored bytes versus 92,396, a 4.79x
+// document-limit headroom versus 3.68x, and roughly a seventh of the CPU -
+// while also being async instead of blocking the main thread.
+//
+// The output is binary on purpose. Firestore bills a bytes field at its plain
+// byte length and a string field at its UTF-8 length + 1, so storing the gzip
+// output as Bytes avoids the 4/3 base64 tax that a string-only compressor
+// cannot escape.
+
+const GZIP = 'gzip';
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    total += value.length;
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
+// Writing and reading run concurrently. Awaiting the write first deadlocks once
+// the payload exceeds the stream's internal buffer, which a real session
+// container comfortably does.
+async function pump(
+  transform: CompressionStream | DecompressionStream,
+  input: Uint8Array
+): Promise<Uint8Array> {
+  const writing = (async () => {
+    const writer = transform.writable.getWriter();
+    await writer.write(input);
+    await writer.close();
+  })();
+  // Malformed input rejects BOTH sides. drain() below surfaces the real error;
+  // without this no-op handler the write side's mirrored rejection escapes as
+  // an unhandled promise rejection and pollutes unrelated test files.
+  writing.catch(() => undefined);
+  const out = await drain(transform.readable);
+  await writing;
+  return out;
+}
+
+export async function compressToBytes(text: string): Promise<Uint8Array> {
+  return pump(new CompressionStream(GZIP), new TextEncoder().encode(text));
+}
+
+export async function decompressFromBytes(bytes: Uint8Array): Promise<string> {
+  return new TextDecoder().decode(
+    await pump(new DecompressionStream(GZIP), bytes)
+  );
+}

--- a/src/utils/functions/external.ts
+++ b/src/utils/functions/external.ts
@@ -1,7 +1,11 @@
 // Lite build - see the note in src/config/firebase.ts. Must match the import
 // there, since db is created by that module's getFirestore.
 import { doc, setDoc } from 'firebase/firestore/lite';
-import { db, fetchDataFromFirestore } from '../../config/firebase';
+import {
+  db,
+  fetchDataFromFirestore,
+  CloudCandidate,
+} from '../../config/firebase';
 import {
   saveToFirestoreIfDirty,
   setIsDirty,
@@ -32,9 +36,9 @@ export const displayToast = (
 export async function loadFromFirestore(
   userId: string,
   thunkAPI: any
-): Promise<TabMasterContainer | undefined> {
+): Promise<CloudCandidate | undefined> {
   try {
-    const tabDataFromCloud: TabMasterContainer =
+    const tabDataFromCloud: CloudCandidate =
       await fetchDataFromFirestore(userId);
     // Deliberately not stripped on read. Documents written before the write-side
     // strip still carry embedded favicons, and those render fine locally - a

--- a/src/utils/functions/external.ts
+++ b/src/utils/functions/external.ts
@@ -67,13 +67,29 @@ export async function loadFromFirestore(
   }
 }
 
+// Which client shape last wrote this document.
+//
+// 1 is implied by absence: every version shipped before KAN-6 phase 1. 2 means
+// "this writer can also READ a compressed document", which is the only question
+// phase 2 needs answered before it may compress.
+//
+// A BACKOFF RATCHET, not an authorisation. Seeing 1 proves an old client is
+// still active on the account and phase 2 must not compress. Seeing 2 proves
+// nothing about a second device that has simply not written lately - and an old
+// client crashes in the merge before it can write, so it cannot self-report.
+// Only Web Store adoption data can authorise the flip.
+export const CURRENT_WRITER_VERSION = 2;
+
 // save data to Firestore
 export async function saveToFirestore(
   userId: string,
   data: TabMasterContainer
 ): Promise<void> {
   try {
-    await setDoc(doc(db, 'tabGroupData', userId), stripEmbeddedFavicons(data));
+    await setDoc(doc(db, 'tabGroupData', userId), {
+      ...stripEmbeddedFavicons(data),
+      writerVersion: CURRENT_WRITER_VERSION,
+    });
   } catch (error: any) {
     // Rethrow so the caller leaves isDirty set and the sync indicator shows the
     // real state. Swallowing here reported success while nothing was written.

--- a/src/utils/functions/local.ts
+++ b/src/utils/functions/local.ts
@@ -551,7 +551,11 @@ export const isValidTabMasterContainer = (
   );
 };
 
-const bytesToMB = (bytes: number): string => (bytes / 1048576).toFixed(1);
+// Exported so the sync guard in globalStateSlice phrases its refusal exactly
+// like the import guard below. Two different roundings for the same limit
+// would read as two different limits.
+export const bytesToMB = (bytes: number): string =>
+  (bytes / 1048576).toFixed(1);
 
 // Parse, validate and size-check the contents of an imported backup file.
 //


### PR DESCRIPTION
Phase 1 of a two-release format migration for KAN-6. It teaches clients to **read** a compressed Firestore document and changes nothing about what they **write** — so no client in the field can break.

## What this does

| commit | change |
|---|---|
| `5ce3060` | Validate the cloud document before merging it |
| `2ca8922` | Refuse over-limit Firestore writes instead of wedging sync |
| `83a2d44` | Add a gzip helper over the native `CompressionStream` |
| `4d0da06` | Read a gzip-compressed (`tabGroupsZ`) Firestore document |
| `48b21ce` | Stamp `writerVersion` on every Firestore save |

**Cloud-document validation.** `syncStateWithFirestore` now applies `isValidTabMasterContainer` to the cloud side, the same guard already applied to localStorage. Previously an unrecognised document reached `mergeTabContainers` and threw `side.tabGroups is not iterable`, rejecting the thunk with no message. Unreadable is deliberately **not** treated as absent: "absent" falls through to the local-only branch, which writes local state over the document — and a document we failed to parse may be a *newer format* rather than corruption. It stops instead, keeping local data and leaving the document untouched.

**Write-path size guard.** Firestore rejects an over-limit document, and the rejection leaves `isDirty` set, so every later change retries the same doomed write and sync wedges with nothing on screen to explain it. `readImportedContainer` already refused this on the import path; this is the same refusal on the sync path, phrased identically (hence `bytesToMB` becoming exported — two roundings of one limit read as two limits).

**Compressed read.** `tabGroupsZ` is gzipped JSON in a Firestore Bytes field. A document lacking it is one written by every client shipped to date, and its plain `tabGroups` array is returned untouched. A decode failure returns `undefined`, never `[]` — an empty array reads as a valid empty account and would be written straight back over the document, destroying data we merely failed to read.

**`writerVersion: 2`.** A backoff ratchet, not an authorisation. Seeing `1` (or its absence) proves an old client is still active and phase 2 must not flip. Seeing `2` proves nothing — a second device that hasn't synced lately is invisible, and an old client crashes in the merge before it can write, so it cannot self-report.

## What this deliberately does NOT do

It does not compress anything. The two halves cannot ship together: every version in the Web Store today reads `data.tabGroups` and hands it to `mergeTabContainers`, so a document whose sessions live in `tabGroupsZ` kills them with `TypeError: side.tabGroups is not iterable` (reproduced against the real merge function). Readers must be everywhere **before** any writer flips. Phase 2 is gated on Chrome Web Store per-version adoption; the baseline measurement is recorded on KAN-6.

`writerVersion.test.ts` is the tripwire that keeps this honest — it asserts every save still emits a plain `tabGroups` array and no `tabGroupsZ`.

## Evidence

Run on this branch at `48b21ce`:

```
tests      505 passed (505), 60 files    (was 481/55 on main)
app tsc    exit 0
e2e tsc    exit 0
eslint     0 errors, 25 warnings         (pre-existing)
```

**No dependency added** — `git diff --stat main...HEAD` touches neither `package.json` nor `package-lock.json`. `CompressionStream` is browser-native and available under the project's vitest config.

**Artifact identity.** `dist/` is byte-identical (`shasum`, all 6 files) to a fresh full-pipeline build of HEAD — `vite build` **plus** `scripts/prune_remote_code.mjs`. Worth noting for future verification: Vite computes the content hash *before* the prune runs, so a pruned and an unpruned bundle share the filename `index-B2GME7sR.js` while differing by 126 bytes. Comparing filenames says "identical" and is wrong.

**Live verification against real Firestore** (`tab-keeper-extension-dev`, the project both `.env` files point at):

- *Security rules, probed as a real anonymous client rather than via admin credentials, which would bypass them:* `list` → **403**; `get` on a random id → **404**. Same token both times, so the 403/404 split rules out a bad token as the explanation for the denial.
- *Create path*, control-first (document confirmed absent, 404) then the real pruned artifact in a cold Chrome profile: `writerVersion === 2`, `tabGroups` a plain array, no `tabGroupsZ`. Reproduced 4 further times, with a build of `main` as negative control writing the identical document minus `writerVersion`.
- *Merge path*, against a real account document that already held tombstones and a selection: read → validate → merge → write. Result carried `writerVersion: 2` with `deletedTabGroups`, `lastModified`, `selectedTabGroupId` and `tabGroups` all intact. This is the only live exercise of `5ce3060`; the create-path runs skip that branch entirely because `cloudCandidate` is `undefined` when no document exists.

**Attribution of an unrelated observation.** Cold start emits 9 `permission-denied` console messages before the first successful write. Measured 3 runs against each artifact: **9 per run on both `main` and this branch**, deterministic, zero variance. Pre-existing, neither caused nor worsened here. Filed as **KAN-70** with the mechanism (`isSignedIn` is written both by a `chrome.storage.sync` read and by `onAuthStateChanged`, and gates Firestore calls).

## What is not covered

- **The guard's refusal path is unit-test-only.** That a *malformed* cloud document is refused rather than overwritten is proven by `syncCloudValidation.test.ts`, not live.
- **No real cloud-document E2E.** The Playwright suite is signed-out — `e2e/fixtures/seed.ts` seeds localStorage only. An authenticated run needs new infrastructure and is a phase-2 prerequisite, not phase-1 work.
- **Mutation testing** (all 7 mutations observed going red, each with a marker grep proving it reached the file) was performed in the implementing session; it was not re-run today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
