### PR TITLE
Release 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,37 @@ Tab Keeper is an intuitive Chrome extension crafted to redefine the way users sa
 
 ## Changelog
 
-### v.1.4.1 (Latest)
+### v.1.5.0 (Latest)
+
+#### Features
+
+- Save just the current window as a session, instead of always saving every open window
+- Every button, list row and menu item can now be reached with Tab and used with Enter or Space
+- Screen readers now announce every control correctly, and in your own language rather than in English
+- Disabled controls are no longer focusable, and are announced as disabled instead of as ordinary buttons
+
+#### Fixes
+
+- Renaming a session no longer loses what you have typed when a sync or an undo arrives while you are editing
+- An undone rename no longer reappears on the next sync
+- Redo now works on macOS, where the Cmd+Shift+Z shortcut previously did nothing at all
+- Cmd+Z inside a text field now undoes your typing instead of the app's last action
+- Typing in the search box no longer clears the redo history or floods the undo history
+- Search results now report how many matches were found, instead of repeating the session's own window and tab counts
+- Sessions are now ordered and dated by the instant they were created, so their order no longer depends on the device's clock
+- The focus-mode confirmation no longer says your windows are "already saved" when there was nothing to save
+- Focus mode no longer saves popup windows that it cannot reopen later
+- A session too large to sync is now refused with an explanation, instead of leaving sync stuck for good
+- Selecting or searching a session no longer changes when that session was last modified, which could let an older copy win a sync
+- The message shown when a sync fails now appears in your own language
+- The area around the app now follows your chosen theme instead of staying grey
+- Icon spacing inside buttons now renders as intended
+
+#### Improvements
+
+- Selecting or searching a session no longer triggers a cloud sync
+
+### v.1.4.1
 
 #### Fixes
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Justine George",
   "description": "Efficiently save and synchronize tabs across devices without the need for personal logins.",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "1.4.1",
+  "version": "1.5.0",
   "name": "Tab Keeper - Chrome Tab Manager & Sync Tool",
   "description": "Efficiently save and synchronize tabs across devices without the need for personal logins.",
   "action": {


### PR DESCRIPTION
Nineteen commits since `v1.4.1`, and this batch has features — so a MINOR bump. 1.4.1 was a patch on the stated grounds that it carried "no features"; `d26c8bd` adds saving the current window as a session, and KAN-64/67/68 make the interface keyboard-operable for the first time.

## Version

Both files bumped `1.4.1` → `1.5.0`, edited surgically (one line each, no reformatting):

- `package.json` — the README badge reads it
- `public/manifest.json` — the release workflow reads it to name the artifact

`npm run bump-version` is not used. It runs `sync-versions`, which round-trips `manifest.json` through a JSON dump and reformats the permissions array, and it ends in a blanket `git add -A`.

## Changelog

Added to `README.md`. The wiki `Changelog.md` still needs the same text verbatim; that repo is not checked out locally, so it is not part of this PR.

24 of the 27 `pending-release` tickets get a line:

| Ticket | Changelog line |
|---|---|
| KAN-5 | Save just the current window as a session |
| KAN-67, 64, 68, 62, 63, 56 | Every button, list row and menu item is reachable with Tab and usable with Enter or Space |
| KAN-65 | Screen readers announce every control in the user's own language |
| KAN-66 | Disabled controls are no longer focusable, and announce as disabled |
| KAN-51 | Renaming a session no longer loses typed text when a sync or undo arrives mid-edit |
| KAN-55 | An undone rename no longer reappears on the next sync |
| KAN-54 | Redo works on macOS, where Cmd+Shift+Z did nothing |
| KAN-52 | Cmd+Z inside a text field undoes typing, not the app's last action |
| KAN-57 | Typing in search no longer clears redo history or floods undo history |
| KAN-60 | Search results report match counts instead of the session's own window and tab counts |
| KAN-25 | Sessions are ordered and dated by the instant they were created |
| KAN-42 | The focus-mode confirmation no longer claims windows are "already saved" when nothing was saved |
| KAN-50 | Focus mode no longer saves popup windows it cannot reopen |
| KAN-71 | A session too large to sync is refused with an explanation instead of wedging sync |
| KAN-58 | Selecting or searching no longer changes when a session was last modified |
| KAN-61 | The sync-failure message appears in the user's own language |
| KAN-49 | The area around the app follows the chosen theme |
| KAN-26 | Icon spacing inside buttons renders as intended |
| KAN-35 | Selecting or searching a session no longer triggers a cloud sync |

KAN-51 is in the changelog despite reading as lint work. Two of its three `react-hooks` findings were a user-facing defect: an effect re-seeded the rename drafts for the component's whole lifetime, so a sync or an undo landing mid-edit overwrote what the user was typing.

The standing "Dependent packages updated to latest versions" line is **not** carried forward. Every dependency change since `v1.4.1` is a devDependency — eslint 8→10, typescript-eslint, playwright, globals. No runtime dependency moved.

`KAN-71` was filed for the write-path size guard shipped in `2ca8922`, which had no ticket to cite.

## Deliberately omitted from the changelog

**KAN-24**, though its `pending-release` label clears with this release. Its own commit says no user was ever affected: `createAsyncThunk` has no registry, nothing in the codebase consumed the colliding string, and undo/redo keys off the distinct reducer names in `actionTypes.ts`. The cost was a DevTools display collision. Same reasoning as KAN-45 in 1.4.1.

Also omitted, as they never reach users: KAN-40 (Playwright golden path) and KAN-46 (ESLint 10 flat config).

## Verification

- `npm run build:e2e` emits `dist/manifest.json` with `"version": "1.5.0"`
- 505/505 unit tests across 60 files
- 27/27 Playwright E2E against the built artifact
- `tsc --noEmit` 0 errors; `typecheck:e2e` 0 errors; `eslint src e2e` 0 errors, 25 pre-existing warnings

KAN-6 phase 1 was also checked live against `tab-keeper-extension-dev`, driving the built extension through chrome-devtools:

- a valid gzip `tabGroupsZ` document is fetched, inflated and merged — proven with a marker string that exists only inside the compressed payload
- a corrupt `tabGroupsZ` document is refused: `updateTime` byte-identical, `tabGroupsZ` preserved, local state not written over it, header reports `sync_problem`
- the refusal holds across a subsequent user edit, because the debounce dispatches `syncStateWithFirestore` and the read gates the write
- the error state clears once the document is readable again

Tagging is deliberately not part of this PR — `v1.5.0` gets pushed after merge, which is what triggers the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
