### PR TITLE
Say why sync stopped when the cloud document cannot be read (KAN-72)

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -94,5 +94,6 @@
   "Maybe Later": "Vielleicht später",
   "Never Remind Again": "Nicht mehr erinnern",
   "Restored on this device, but syncing failed.": "Auf diesem Gerät wiederhergestellt, aber die Synchronisierung ist fehlgeschlagen.",
-  "Save changes": "Änderungen speichern"
+  "Save changes": "Änderungen speichern",
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Synchronisierung nicht verfügbar: Ihre Cloud-Daten konnten nicht gelesen werden. Die Sitzungen auf diesem Gerät sind sicher."
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -94,5 +94,6 @@
   "Never Remind Again": "Never Remind Again",
   "Sync unavailable: your saved account token could not be read.": "Sync unavailable: your saved account token could not be read.",
   "Restored on this device, but syncing failed.": "Restored on this device, but syncing failed.",
-  "Save changes": "Save changes"
+  "Save changes": "Save changes",
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Sync unavailable: your cloud data could not be read. Sessions on this device are safe."
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -94,5 +94,6 @@
   "Maybe Later": "Más tarde",
   "Never Remind Again": "No recordar más",
   "Restored on this device, but syncing failed.": "Restaurado en este dispositivo, pero falló la sincronización.",
-  "Save changes": "Guardar cambios"
+  "Save changes": "Guardar cambios",
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Sincronización no disponible: no se pudieron leer los datos de la nube. Las sesiones de este dispositivo están a salvo."
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -94,5 +94,6 @@
   "Maybe Later": "Peut-être plus tard",
   "Never Remind Again": "Ne plus rappeler",
   "Restored on this device, but syncing failed.": "Restauré sur cet appareil, mais la synchronisation a échoué.",
-  "Save changes": "Enregistrer les modifications"
+  "Save changes": "Enregistrer les modifications",
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Synchronisation indisponible : vos données cloud n'ont pas pu être lues. Les sessions sur cet appareil sont intactes."
 }

--- a/public/locales/hi/translation.json
+++ b/public/locales/hi/translation.json
@@ -94,5 +94,6 @@
   "Maybe Later": "बाद में",
   "Never Remind Again": "फिर से याद न करें",
   "Restored on this device, but syncing failed.": "इस डिवाइस पर पुनर्स्थापित किया गया, लेकिन सिंक विफल रहा।",
-  "Save changes": "परिवर्तन सहेजें"
+  "Save changes": "परिवर्तन सहेजें",
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "सिंक अनुपलब्ध: आपका क्लाउड डेटा पढ़ा नहीं जा सका। इस डिवाइस के सत्र सुरक्षित हैं।"
 }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -94,5 +94,6 @@
   "Maybe Later": "Più tardi",
   "Never Remind Again": "Non ricordare più",
   "Restored on this device, but syncing failed.": "Ripristinato su questo dispositivo, ma la sincronizzazione non è riuscita.",
-  "Save changes": "Salva modifiche"
+  "Save changes": "Salva modifiche",
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Sincronizzazione non disponibile: impossibile leggere i dati sul cloud. Le sessioni su questo dispositivo sono al sicuro."
 }

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -94,5 +94,6 @@
   "Maybe Later": "後で",
   "Never Remind Again": "再度お知らせしない",
   "Restored on this device, but syncing failed.": "このデバイスに復元しましたが、同期に失敗しました。",
-  "Save changes": "変更を保存"
+  "Save changes": "変更を保存",
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "同期を利用できません: クラウドのデータを読み取れませんでした。このデバイスのセッションは安全です。"
 }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -94,5 +94,6 @@
   "Maybe Later": "Mais tarde",
   "Never Remind Again": "Não lembrar mais",
   "Restored on this device, but syncing failed.": "Restaurado neste dispositivo, mas a sincronização falhou.",
-  "Save changes": "Salvar alterações"
+  "Save changes": "Salvar alterações",
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Sincronização indisponível: não foi possível ler os dados da nuvem. As sessões neste dispositivo estão seguras."
 }

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -94,5 +94,6 @@
   "Maybe Later": "Позже",
   "Never Remind Again": "Больше не напоминать",
   "Restored on this device, but syncing failed.": "Восстановлено на этом устройстве, но синхронизация не удалась.",
-  "Save changes": "Сохранить изменения"
+  "Save changes": "Сохранить изменения",
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Синхронизация недоступна: не удалось прочитать данные в облаке. Сессии на этом устройстве в сохранности."
 }

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -94,5 +94,6 @@
   "Maybe Later": "稍后再说",
   "Never Remind Again": "不再提醒",
   "Restored on this device, but syncing failed.": "已在此设备上恢复，但同步失败。",
-  "Save changes": "保存更改"
+  "Save changes": "保存更改",
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "无法同步：无法读取云端数据。此设备上的会话是安全的。"
 }

--- a/src/redux/slices/globalStateSlice.ts
+++ b/src/redux/slices/globalStateSlice.ts
@@ -131,6 +131,14 @@ export const syncStateWithFirestore = createAsyncThunk(
         'Unreadable Firestore document for this user; leaving it untouched.'
       );
       thunkAPI.dispatch(setSyncStatus('error'));
+      // The glyph alone says "something is wrong" without saying what, or
+      // whether the sessions on this device survived it (KAN-72).
+      thunkAPI.dispatch(
+        showToast({
+          toastText: TOAST_MESSAGES.UNREADABLE_CLOUD_DOCUMENT,
+          duration: 6000,
+        })
+      );
       return;
     }
     const tabDataFromCloud: TabMasterContainer | undefined = cloudCandidate;

--- a/src/tests/redux/syncCloudValidation.test.ts
+++ b/src/tests/redux/syncCloudValidation.test.ts
@@ -29,6 +29,7 @@ import {
 import { replaceState } from '../../redux/slices/tabContainerDataStateSlice';
 import { makeTestStore } from '../setup/makeStore';
 import { buildContainer, buildSession } from '../fixtures/sessionFixture';
+import { TOAST_MESSAGES } from '../../utils/constants/common';
 
 const localOnly = buildContainer([buildSession()]);
 
@@ -96,6 +97,20 @@ describe('an unreadable cloud document stops the sync without writing', () => {
     );
   });
 
+  // KAN-72. setSyncStatus('error') only repaints the header glyph, and the
+  // console.warn beside it reaches no user. The glyph alone cannot say whether
+  // the local sessions are at risk, which is the one thing a user needs to
+  // know here - and they are not at risk, because the guard keeps them.
+  it('tells the user why sync stopped, instead of only warning the console', async () => {
+    mocks.loadFromFirestore.mockResolvedValue(unreadable);
+    const { store } = makeTestStore();
+    store.dispatch(setUserId('u1'));
+    await store.dispatch(syncStateWithFirestore());
+    expect(store.getState().globalState.toastText).toBe(
+      TOAST_MESSAGES.UNREADABLE_CLOUD_DOCUMENT
+    );
+  });
+
   // POSITIVE CONTROL. Without this, all three assertions above pass just as
   // well against code that never writes or merges anything at all.
   it('control: a VALID cloud document is still merged and can still write', async () => {
@@ -111,5 +126,21 @@ describe('an unreadable cloud document stops the sync without writing', () => {
       .getState()
       .tabContainerDataState.tabGroups.map((g) => g.title);
     expect(titles).toContain('Cloud Only');
+  });
+
+  // CONTROL for the toast above. A readable document must not raise it, or the
+  // assertion would pass against code that shows the message unconditionally.
+  it('control: a VALID cloud document raises no unreadable-document toast', async () => {
+    const validCloud = buildContainer([
+      buildSession({ tabGroupId: 'cloud-only', title: 'Cloud Only' }),
+    ]);
+    validCloud.lastModified = 9999;
+    mocks.loadFromFirestore.mockResolvedValue(validCloud);
+    const { store } = makeTestStore();
+    store.dispatch(setUserId('u1'));
+    await store.dispatch(syncStateWithFirestore());
+    expect(store.getState().globalState.toastText).not.toBe(
+      TOAST_MESSAGES.UNREADABLE_CLOUD_DOCUMENT
+    );
   });
 });

--- a/src/utils/constants/common.ts
+++ b/src/utils/constants/common.ts
@@ -98,6 +98,17 @@ export const TOAST_MESSAGES = {
   DELETE_TAB_SUCCESS: 'Session tab deleted.',
   UNREADABLE_ACCOUNT_TOKEN:
     'Sync unavailable: your saved account token could not be read.',
+  // The refusal it reports is deliberate: an unparseable cloud document may be
+  // a NEWER FORMAT rather than corruption, so the sync stops instead of
+  // overwriting it. Without a toast the only signals are the header glyph and
+  // a console.warn, and the glyph cannot answer the question a user actually
+  // has - whether their sessions are at risk. They are not, so say so (KAN-72).
+  //
+  // No "try again" instruction, unlike the over-limit message: retrying is not
+  // the remedy and there may be no user-side remedy at all. A false
+  // instruction would be worse than none.
+  UNREADABLE_CLOUD_DOCUMENT:
+    'Sync unavailable: your cloud data could not be read. Sessions on this device are safe.',
   // Shown only when a merge actually brought something new to this device.
   // Divergence between devices used to be visible as a blocking prompt; this
   // replaces it with a notification, and stays silent when the merge is a


### PR DESCRIPTION
`syncStateWithFirestore` refuses an unparseable cloud document and reports it with `setSyncStatus('error')` plus a `console.warn`. The header glyph is the only thing a user sees, and it cannot answer the question they actually have — whether the sessions on this device survived. They did; nothing said so.

## The defect

`src/redux/slices/globalStateSlice.ts:126-135`:

    console.warn('Unreadable Firestore document for this user; leaving it untouched.');
    thunkAPI.dispatch(setSyncStatus('error'));

Justine hit this while reviewing a screenshot of the refusal, with full knowledge of the codebase, and asked "if no issues, then why sync is shown broken". A real user has strictly less information.

Rare today. Once KAN-6 phase 2 writes compressed documents, every install that has not updated hits this path on every sync and shows a permanently broken-looking icon.

## What changed

One dispatch beside the existing one, and a message phrased on `UNREADABLE_ACCOUNT_TOKEN` — the existing "Sync unavailable: …" text for the adjacent failure.

The refusal is unchanged. It is deliberate: an unparseable document may be a *newer format* rather than corruption, so overwriting it would destroy data we merely could not read.

The message carries no "try again" instruction, unlike the over-limit toast. Retrying is not the remedy and there may be no user-side remedy at all, so an instruction would be a false promise. It says the local sessions are safe, because that is the actual question.

Ten locales: `Toast.tsx:52` renders `t(toastText)`, and a missing key falls back to English silently — which is KAN-61, fixed in this same release for a different toast.

## Evidence

- `syncCloudValidation.test.ts`: 2 new tests, 505 → 507. Watched RED first (`expected '' to be undefined`), then green. The second is a control asserting a *valid* document raises no such toast.
- **Mutation 1** — delete the `showToast` dispatch → the new test fails.
- **Mutation 2** — delete the key from the `de` locale → `keyCoverage`'s "every locale defines exactly the keys en defines" fails, naming the file.
- **Live, on the built artifact**, language set to `de`, against a staged corrupt `tabGroupsZ` document in `tab-keeper-extension-dev`:

      Synchronisierung nicht verfügbar: Ihre Cloud-Daten konnten nicht
      gelesen werden. Die Sitzungen auf diesem Gerät sind sicher.

  Displayed for 6000ms (opened at page age 756ms, closed at 6756ms) beside the `sync_problem` glyph. A non-`en` locale is the only way to see this — in `en` the key and the value are the same string, so "returned the key" and "found the value" look identical.
- 507/507 tests, `tsc` 0 errors, `eslint` 0 errors (25 pre-existing warnings).

## Found while doing this, deliberately not fixed here

`SYNC_MERGED` ("Synced changes from another device.") and `IMPORT_SUCCESS` ("Restored tabs successfully!") have no `en` entry either, so both render English in all ten locales — the same defect as KAN-61. The other eight untranslated `TOAST_MESSAGES` values belong to the dead `SignIn`/`CreateAccount`/`ForgotPassword` components (KAN-69) and are unreachable.

A guard test asserting every reachable `TOAST_MESSAGES` value exists in `en` would have caught KAN-61 and both of the above. It cannot be added until those two are translated and the dead strings are resolved, so it is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
