### PR TITLE
Translate the last two reachable toasts, and guard the ones after them (KAN-73)

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -95,5 +95,7 @@
   "Never Remind Again": "Nicht mehr erinnern",
   "Restored on this device, but syncing failed.": "Auf diesem Gerät wiederhergestellt, aber die Synchronisierung ist fehlgeschlagen.",
   "Save changes": "Änderungen speichern",
-  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Synchronisierung nicht verfügbar: Ihre Cloud-Daten konnten nicht gelesen werden. Die Sitzungen auf diesem Gerät sind sicher."
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Synchronisierung nicht verfügbar: Ihre Cloud-Daten konnten nicht gelesen werden. Die Sitzungen auf diesem Gerät sind sicher.",
+  "Synced changes from another device.": "Änderungen von einem anderen Gerät synchronisiert.",
+  "Restored tabs successfully!": "Tabs erfolgreich wiederhergestellt!"
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -95,5 +95,7 @@
   "Sync unavailable: your saved account token could not be read.": "Sync unavailable: your saved account token could not be read.",
   "Restored on this device, but syncing failed.": "Restored on this device, but syncing failed.",
   "Save changes": "Save changes",
-  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Sync unavailable: your cloud data could not be read. Sessions on this device are safe."
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.",
+  "Synced changes from another device.": "Synced changes from another device.",
+  "Restored tabs successfully!": "Restored tabs successfully!"
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -95,5 +95,7 @@
   "Never Remind Again": "No recordar más",
   "Restored on this device, but syncing failed.": "Restaurado en este dispositivo, pero falló la sincronización.",
   "Save changes": "Guardar cambios",
-  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Sincronización no disponible: no se pudieron leer los datos de la nube. Las sesiones de este dispositivo están a salvo."
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Sincronización no disponible: no se pudieron leer los datos de la nube. Las sesiones de este dispositivo están a salvo.",
+  "Synced changes from another device.": "Cambios sincronizados desde otro dispositivo.",
+  "Restored tabs successfully!": "¡Pestañas restauradas correctamente!"
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -95,5 +95,7 @@
   "Never Remind Again": "Ne plus rappeler",
   "Restored on this device, but syncing failed.": "Restauré sur cet appareil, mais la synchronisation a échoué.",
   "Save changes": "Enregistrer les modifications",
-  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Synchronisation indisponible : vos données cloud n'ont pas pu être lues. Les sessions sur cet appareil sont intactes."
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Synchronisation indisponible : vos données cloud n'ont pas pu être lues. Les sessions sur cet appareil sont intactes.",
+  "Synced changes from another device.": "Modifications synchronisées depuis un autre appareil.",
+  "Restored tabs successfully!": "Onglets restaurés avec succès !"
 }

--- a/public/locales/hi/translation.json
+++ b/public/locales/hi/translation.json
@@ -95,5 +95,7 @@
   "Never Remind Again": "फिर से याद न करें",
   "Restored on this device, but syncing failed.": "इस डिवाइस पर पुनर्स्थापित किया गया, लेकिन सिंक विफल रहा।",
   "Save changes": "परिवर्तन सहेजें",
-  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "सिंक अनुपलब्ध: आपका क्लाउड डेटा पढ़ा नहीं जा सका। इस डिवाइस के सत्र सुरक्षित हैं।"
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "सिंक अनुपलब्ध: आपका क्लाउड डेटा पढ़ा नहीं जा सका। इस डिवाइस के सत्र सुरक्षित हैं।",
+  "Synced changes from another device.": "दूसरे डिवाइस से किए गए बदलाव सिंक कर दिए गए।",
+  "Restored tabs successfully!": "टैब सफलतापूर्वक पुनर्स्थापित किए गए!"
 }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -95,5 +95,7 @@
   "Never Remind Again": "Non ricordare più",
   "Restored on this device, but syncing failed.": "Ripristinato su questo dispositivo, ma la sincronizzazione non è riuscita.",
   "Save changes": "Salva modifiche",
-  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Sincronizzazione non disponibile: impossibile leggere i dati sul cloud. Le sessioni su questo dispositivo sono al sicuro."
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Sincronizzazione non disponibile: impossibile leggere i dati sul cloud. Le sessioni su questo dispositivo sono al sicuro.",
+  "Synced changes from another device.": "Modifiche sincronizzate da un altro dispositivo.",
+  "Restored tabs successfully!": "Tab ripristinati correttamente!"
 }

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -95,5 +95,7 @@
   "Never Remind Again": "再度お知らせしない",
   "Restored on this device, but syncing failed.": "このデバイスに復元しましたが、同期に失敗しました。",
   "Save changes": "変更を保存",
-  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "同期を利用できません: クラウドのデータを読み取れませんでした。このデバイスのセッションは安全です。"
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "同期を利用できません: クラウドのデータを読み取れませんでした。このデバイスのセッションは安全です。",
+  "Synced changes from another device.": "別のデバイスからの変更を同期しました。",
+  "Restored tabs successfully!": "タブを復元しました。"
 }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -95,5 +95,7 @@
   "Never Remind Again": "Não lembrar mais",
   "Restored on this device, but syncing failed.": "Restaurado neste dispositivo, mas a sincronização falhou.",
   "Save changes": "Salvar alterações",
-  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Sincronização indisponível: não foi possível ler os dados da nuvem. As sessões neste dispositivo estão seguras."
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Sincronização indisponível: não foi possível ler os dados da nuvem. As sessões neste dispositivo estão seguras.",
+  "Synced changes from another device.": "Alterações sincronizadas de outro dispositivo.",
+  "Restored tabs successfully!": "Abas restauradas com sucesso!"
 }

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -95,5 +95,7 @@
   "Never Remind Again": "Больше не напоминать",
   "Restored on this device, but syncing failed.": "Восстановлено на этом устройстве, но синхронизация не удалась.",
   "Save changes": "Сохранить изменения",
-  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Синхронизация недоступна: не удалось прочитать данные в облаке. Сессии на этом устройстве в сохранности."
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Синхронизация недоступна: не удалось прочитать данные в облаке. Сессии на этом устройстве в сохранности.",
+  "Synced changes from another device.": "Изменения с другого устройства синхронизированы.",
+  "Restored tabs successfully!": "Вкладки успешно восстановлены!"
 }

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -95,5 +95,7 @@
   "Never Remind Again": "不再提醒",
   "Restored on this device, but syncing failed.": "已在此设备上恢复，但同步失败。",
   "Save changes": "保存更改",
-  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "无法同步：无法读取云端数据。此设备上的会话是安全的。"
+  "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "无法同步：无法读取云端数据。此设备上的会话是安全的。",
+  "Synced changes from another device.": "已同步来自其他设备的更改。",
+  "Restored tabs successfully!": "标签页已成功恢复！"
 }

--- a/src/tests/locales/toastCoverage.test.ts
+++ b/src/tests/locales/toastCoverage.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test, vi } from 'vitest';
+
+// Inlined rather than imported: a vi.hoisted block runs before the module graph
+// is evaluated, and common.ts -- the module under test here -- reads
+// window.screen at load to size a new window. Keep in step with
+// src/tests/setup/domStub.ts.
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+import en from '../../../public/locales/en/translation.json';
+import { TOAST_MESSAGES } from '../../utils/constants/common';
+
+// Toast text is invisible to keyCoverage.test.ts. Toast.tsx renders
+// `t(toastText)` -- a computed key -- and that file's scan only matches literal
+// t('...') calls, as its own comment says. Its other test compares the ten
+// locale files against each other, so it only ever sees DRIFT: when a string is
+// missing from `en` too there is no drift and nothing fails.
+//
+// That blind spot is exactly KAN-61 (the sync-failure toast shipped English in
+// nine locales) and then KAN-73 (SYNC_MERGED and IMPORT_SUCCESS shipped English
+// in all ten). Both were found by hand. This is the test that sees them.
+//
+// Same import.meta.glob route as keyCoverage, and for the same reason: this
+// project's tsconfig has no "node" types, so node:fs would fail tsc even though
+// vitest resolves it at runtime.
+const sources = import.meta.glob('/src/**/*.{ts,tsx}', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
+
+// Reachability is DERIVED, not listed. A constant counts as reachable if live
+// source mentions `TOAST_MESSAGES.NAME` anywhere, so a newly added toast is
+// covered the moment it is used -- nobody has to remember to register it here.
+const USAGE_PATTERN = /\bTOAST_MESSAGES\.([A-Z0-9_]+)/g;
+
+// The only exclusions, and they are files rather than message names on purpose:
+// naming messages would need updating whenever one is added, while naming the
+// dead files needs updating exactly once, when KAN-69 deletes them.
+//
+// These three components have no importers and do not reach the bundle
+// (`handleCreateAccount` occurs 0 times in dist). Their eight strings DO still
+// ship, because TOAST_MESSAGES is one object literal that live code imports and
+// tree-shaking does not drop object properties -- but nothing can display them,
+// so translating them would be dead weight in ten files.
+const DEAD_COMPONENTS = [
+  '/src/components/settings/rightpane/Account/SignIn.tsx',
+  '/src/components/settings/rightpane/Account/CreateAccount.tsx',
+  '/src/components/settings/rightpane/Account/ForgotPassword.tsx',
+];
+
+function reachableConstantNames(): Set<string> {
+  const names = new Set<string>();
+
+  for (const [file, source] of Object.entries(sources)) {
+    if (file.includes('/src/tests/')) continue;
+    if (file.endsWith('/utils/constants/common.ts')) continue; // the definition
+    if (DEAD_COMPONENTS.some((dead) => file.endsWith(dead))) continue;
+
+    for (const [, name] of source.matchAll(USAGE_PATTERN)) names.add(name);
+  }
+
+  return names;
+}
+
+describe('toast translation coverage', () => {
+  test('every reachable toast message has an en translation', () => {
+    const missing: string[] = [];
+
+    for (const name of reachableConstantNames()) {
+      const text = (TOAST_MESSAGES as Record<string, string>)[name];
+      // A name that resolves to nothing is a typo at the usage site, which is
+      // its own bug: `t(undefined)` renders nothing at all.
+      if (text === undefined) {
+        missing.push(`${name}  (no such TOAST_MESSAGES entry)`);
+        continue;
+      }
+      if (!(text in en)) missing.push(`${name}  ->  "${text}"`);
+    }
+
+    expect(missing).toEqual([]);
+  });
+
+  // CONTROL. Without it the test above passes just as well against a broken
+  // scan that finds no usages at all -- which is precisely how keyCoverage
+  // misses these, so it is not a hypothetical failure mode here.
+  test('control: the scan actually finds toast usages, including known ones', () => {
+    const reached = reachableConstantNames();
+
+    expect(reached.size).toBeGreaterThan(5);
+    expect(reached).toContain('SYNC_MERGED');
+    expect(reached).toContain('UNREADABLE_CLOUD_DOCUMENT');
+  });
+
+  // CONTROL for the exclusion. If the dead-file filter ever stops matching --
+  // a moved file, a renamed directory -- the test above starts demanding
+  // translations for eight strings no user can reach, and the honest fix then
+  // is to update DEAD_COMPONENTS rather than to translate them.
+  test('control: the dead Account components are excluded from the scan', () => {
+    const reached = reachableConstantNames();
+
+    expect(reached).not.toContain('LOGIN_FAIL');
+    expect(reached).not.toContain('ACCOUNT_CREATION_SUCCESS');
+  });
+});


### PR DESCRIPTION
`SYNC_MERGED` and `IMPORT_SUCCESS` had no `en` entry, so i18next fell back to returning the key and both rendered English in all ten locales. Same defect as KAN-61, which fixed it for one toast in 1.5.0; these two were missed because nothing looks for them.

## Nothing could look for them

`Toast.tsx:52` renders `t(toastText)` — a **computed** key. `keyCoverage.test.ts` scans for literal `t('...')` calls and says so itself: *"What this cannot see is a genuinely computed key ... This test is a floor on coverage, not a complete census."*

Its other test compares the ten locale files against each other, so it only ever sees drift **between** locales. When a string is missing from `en` too there is no drift and nothing fails. That is the hole KAN-61 and KAN-73 both fell through.

## The guard

`toastCoverage.test.ts` scans **usage sites** instead of locale files: any `TOAST_MESSAGES.NAME` mentioned in live source must have an `en` entry. A newly added toast is covered the moment it is used — nothing to register, nothing to remember.

Reachability is derived, and the exclusions are **files, not message names**. Eight values are consumed only by `SignIn` / `CreateAccount` / `ForgotPassword`, which have no importers and do not reach the bundle. Excluding message names would need an edit whenever a toast is added; excluding the three dead files needs one edit ever, when KAN-69 deletes them.

**A correction to KAN-69's phrasing, worth recording:** the *components* are tree-shaken, but their **strings still ship**. `TOAST_MESSAGES` is one object literal imported by live code, and tree-shaking does not drop object properties — `"Please enter a valid email address."` is present in `dist` while `handleCreateAccount` occurs 0 times. That is why a blanket "every value is translated" assertion cannot pass until those components are deleted.

## Evidence

- `toastCoverage.test.ts` written first and watched **RED**, listing exactly `IMPORT_SUCCESS` and `SYNC_MERGED` — no more, no less. 507 → **510 tests**, 60 → 61 files.
- **Mutation** — delete `SYNC_MERGED` from `en` → the new test fails naming it (and `keyCoverage` fails on the resulting drift).
- **Mutation** — break the usage scan → the anti-vacuity control fails. That is not a hypothetical failure mode here; it is precisely how `keyCoverage` misses these.
- **Live, on the built artifact**, language `de`, against a staged cloud document holding a session this device had never seen. A `MutationObserver` installed via `initScript` — before the page's own scripts — recorded **only**:

      Änderungen von einem anderen Gerät synchronisiert.

  and never the English string, while the merged session appeared in the list.
- 510/510 tests, `tsc` 0 errors, `eslint` 0 errors (25 pre-existing warnings).

**Measurement note:** polling after the reload is not good enough. `SYNC_MERGED` lasts 3000ms and the CDP round-trip is ~5600ms, so a poll starting after `navigate_page` returns always misses it and reads as a false negative — it did, twice, before I switched to `initScript`.

## Not verified live

`IMPORT_SUCCESS` was **not** driven in the browser: reaching it needs the file-restore flow with a stubbed file picker. It shares the mechanism proven above (`t(toastText)` plus a locale entry), and its presence is now guarded by `toastCoverage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
