### PR TITLE
Wait for Firebase auth before calling Firestore (KAN-70)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,9 @@ function App() {
   const isSignedIn = useSelector(
     (state: RootState) => state.globalState.isSignedIn
   );
+  const isFirebaseAuthed = useSelector(
+    (state: RootState) => state.globalState.isFirebaseAuthed
+  );
   const userId = useSelector((state: RootState) => state.globalState.userId);
   const isAutoSync = useSelector(
     (state: RootState) => state.settingsDataState.isAutoSync
@@ -167,7 +170,12 @@ function App() {
   }, []);
 
   useEffect(() => {
-    if (isSignedIn && userId && isAutoSync) {
+    // isFirebaseAuthed is what makes this wait for the sign-in round trip.
+    // Without it the chrome.storage.sync read alone opened this gate, and the
+    // first sync of every cold start was denied by the security rules before
+    // request.auth existed (KAN-70). The local-storage branch below runs in the
+    // meantime, so there is nothing to show for the wait.
+    if (isSignedIn && isFirebaseAuthed && userId && isAutoSync) {
       dispatch(syncStateWithFirestore());
     } else {
       // load from local storage
@@ -193,7 +201,11 @@ function App() {
         }
       }
     }
-  }, [isSignedIn, userId]);
+    // isFirebaseAuthed is load-bearing in this array, not decoration: it is the
+    // flag that flips late, and re-running on it is what makes the sync happen
+    // at all once auth lands. Recovery used to depend on isSignedIn flapping
+    // false -> true, which was accidental (KAN-70).
+  }, [isSignedIn, isFirebaseAuthed, userId]);
 
   const containerStyle = css`
     background-color: ${COLORS.PRIMARY_COLOR};

--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -10,7 +10,10 @@ import { getAuth, onAuthStateChanged, signInAnonymously } from 'firebase/auth';
 
 import { AppDispatch } from '../redux/store';
 import { decompressFromBytes } from '../utils/functions/compression';
-import { setLoggedOut, setSignedIn } from '../redux/slices/globalStateSlice';
+import {
+  setFirebaseAuthed,
+  setFirebaseUnauthed,
+} from '../redux/slices/globalStateSlice';
 // https://firebase.google.com/docs/web/setup#available-libraries
 
 // Firebase configuration
@@ -31,14 +34,19 @@ const db = getFirestore(app);
 
 export { auth, db };
 
+// Writes ONLY the Firebase auth flag. It used to write isSignedIn, which the
+// chrome.storage.sync token read also writes - so a local lookup and a network
+// round trip fed one boolean, and whichever resolved first decided whether
+// Firestore calls were authorised. The token read always wins that race, so
+// every cold start issued requests the rules then denied (KAN-70).
 export const observeAuthState = (dispatch: AppDispatch) => {
   onAuthStateChanged(auth, (user) => {
     if (user) {
-      // User is signed in
-      dispatch(setSignedIn());
+      dispatch(setFirebaseAuthed());
     } else {
-      // User is signed out, anonymous sign them back in
-      dispatch(setLoggedOut());
+      // Not authenticated yet - or no longer. Sign in anonymously; this
+      // callback fires again with a user once it lands.
+      dispatch(setFirebaseUnauthed());
       signInUserAnonymously();
     }
   });

--- a/src/redux/middleware/customMiddleware.ts
+++ b/src/redux/middleware/customMiddleware.ts
@@ -113,10 +113,15 @@ export const customMiddleware: Middleware = (store) => {
     const nextState = store.getState();
 
     // After processing the action, check if it was setIsDirty and the flag is true
+    // isFirebaseAuthed as well as isSignedIn: the first means a document id
+    // exists, the second means the rules will accept a request. An edit made
+    // inside the first second of a cold start satisfies only the first, and
+    // syncing on it produces denied writes (KAN-70).
     if (
       action.type === setIsDirty.type &&
       nextState.globalState.isDirty &&
       nextState.globalState.isSignedIn &&
+      nextState.globalState.isFirebaseAuthed &&
       nextState.settingsDataState.isAutoSync
     ) {
       debouncedSync();

--- a/src/redux/slices/globalStateSlice.ts
+++ b/src/redux/slices/globalStateSlice.ts
@@ -21,7 +21,21 @@ import { TOAST_MESSAGES } from '../../utils/constants/common';
 
 export interface Global {
   hasSyncedBefore: boolean;
+  // "a usable document id exists in chrome.storage.sync". A LOCAL read: no
+  // network, no authentication. This app has no accounts - sync identity is a
+  // client uuid - so "signed in" genuinely means "has a sync identity", and it
+  // is what the settings pane renders LoggedIn/NotLoggedIn from.
+  //
+  // It is NOT permission to call Firestore. See isFirebaseAuthed (KAN-70).
   isSignedIn: boolean;
+  // "Firebase anonymous auth has landed", i.e. request.auth is non-null and the
+  // security rules will accept a request. Written ONLY by onAuthStateChanged.
+  //
+  // Separate from isSignedIn because the two resolve at different times: the
+  // chrome.storage.sync read returns in milliseconds, the sign-in is a network
+  // round trip. Gating on isSignedIn alone opened the gate ~500ms early and
+  // every request in that window was denied by the rules.
+  isFirebaseAuthed: boolean;
   userId: string | null;
   isDirty: boolean;
   isSettingsPage: boolean;
@@ -49,6 +63,7 @@ export interface FocusRequest {
 export const initialState: Global = {
   hasSyncedBefore: false,
   isSignedIn: false,
+  isFirebaseAuthed: false,
   userId: null,
   isDirty: false,
   isSettingsPage: false,
@@ -339,6 +354,16 @@ export const globalStateSlice = createSlice({
       state.isSignedIn = true;
     },
 
+    // Dispatched only by observeAuthState. Deliberately does not touch
+    // isSignedIn: conflating the two is the defect these exist to separate.
+    setFirebaseAuthed: (state) => {
+      state.isFirebaseAuthed = true;
+    },
+
+    setFirebaseUnauthed: (state) => {
+      state.isFirebaseAuthed = false;
+    },
+
     setHasSyncedBefore: (state) => {
       state.hasSyncedBefore = true;
     },
@@ -405,6 +430,8 @@ export const {
   setIsDirtyWithoutSync,
   setIsNotDirty,
   setSignedIn,
+  setFirebaseAuthed,
+  setFirebaseUnauthed,
   setHasSyncedBefore,
   setLoggedOut,
   setSyncStatus,

--- a/src/tests/redux/authGatesSync.test.ts
+++ b/src/tests/redux/authGatesSync.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, afterEach, describe, expect, test, vi } from 'vitest';
+
+// common.ts reads window.screen at module load, and this is a node test.
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+import { makeTestStore } from '../setup/makeStore';
+import {
+  setFirebaseAuthed,
+  setSignedIn,
+  setUserId,
+  setIsDirty,
+} from '../../redux/slices/globalStateSlice';
+import { DEBOUNCE_TIME_WINDOW } from '../../utils/constants/common';
+
+const SYNC_PENDING_ACTION = 'global/syncStateWithFirestore/pending';
+
+// KAN-70. `isSignedIn` is written by a chrome.storage.sync read -- a local
+// lookup that means "a usable document id exists" and involves no network.
+// Firebase anonymous auth is a round trip that lands hundreds of milliseconds
+// later. Gating Firestore calls on `isSignedIn` alone therefore opens the gate
+// while `request.auth` is still null, and the security rule correctly denies
+// every request that goes through it: measured at 1 denied BatchGetDocuments +
+// 2 denied Commits, 9 console messages, on every cold start.
+//
+// Both flags are booleans, so no compiler could catch the substitution. Only a
+// test that holds one true and the other false can.
+//
+// It self-heals today, but by accident: onAuthStateChanged fires first with
+// user === null, so `isSignedIn` flaps false -> true when auth lands and the
+// effect re-runs. Nothing retries on purpose. These tests exist so the fix
+// cannot be silently undone by a refactor that removes the flap.
+describe('Firestore is not touched before Firebase auth lands (KAN-70)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // A store in the exact state a cold start produces: the token has been read
+  // from chrome.storage.sync, so there is a document id, but the anonymous
+  // sign-in round trip has not come back yet.
+  const tokenReadButAuthPending = () => {
+    const made = makeTestStore();
+    made.store.dispatch(setSignedIn());
+    made.store.dispatch(setUserId('u1'));
+    return made;
+  };
+
+  test('a dirty change does NOT schedule a sync while auth is unresolved', () => {
+    const { store, seen } = tokenReadButAuthPending();
+
+    store.dispatch(setIsDirty());
+    vi.advanceTimersByTime(DEBOUNCE_TIME_WINDOW + 1);
+
+    expect(seen).not.toContain(SYNC_PENDING_ACTION);
+  });
+
+  // THE CONTROL, and the one that makes the assertion above mean something.
+  // Without it the test passes just as well against a store that never syncs
+  // at all -- signed out, auto-sync off, or a middleware that lost its branch.
+  test('control: the same change DOES schedule a sync once auth has landed', () => {
+    const { store, seen } = tokenReadButAuthPending();
+
+    store.dispatch(setFirebaseAuthed());
+    store.dispatch(setIsDirty());
+    vi.advanceTimersByTime(DEBOUNCE_TIME_WINDOW + 1);
+
+    expect(seen).toContain(SYNC_PENDING_ACTION);
+  });
+
+  // The two flags must stay independent. If a future edit makes one imply the
+  // other -- the mistake this ticket is about, in the opposite direction --
+  // this fails while both tests above still pass.
+  test('auth landing alone does not imply a document id exists', () => {
+    const { store } = makeTestStore();
+
+    store.dispatch(setFirebaseAuthed());
+
+    expect(store.getState().globalState.isFirebaseAuthed).toBe(true);
+    expect(store.getState().globalState.isSignedIn).toBe(false);
+  });
+
+  test('a document id alone does not imply auth has landed', () => {
+    const { store } = makeTestStore();
+
+    store.dispatch(setSignedIn());
+
+    expect(store.getState().globalState.isSignedIn).toBe(true);
+    expect(store.getState().globalState.isFirebaseAuthed).toBe(false);
+  });
+});

--- a/src/tests/redux/selectionDoesNotSync.test.ts
+++ b/src/tests/redux/selectionDoesNotSync.test.ts
@@ -20,7 +20,10 @@ import {
   updateTabGroupTitle,
 } from '../../redux/slices/tabContainerDataStateSlice';
 import { IS_DIRTY_ACTION, SET_ACTION } from '../../utils/constants/actionTypes';
-import { setSignedIn } from '../../redux/slices/globalStateSlice';
+import {
+  setFirebaseAuthed,
+  setSignedIn,
+} from '../../redux/slices/globalStateSlice';
 import { DEBOUNCE_TIME_WINDOW } from '../../utils/constants/common';
 
 const SYNC_PENDING_ACTION = 'global/syncStateWithFirestore/pending';
@@ -149,6 +152,9 @@ describe('selection does not reach Firestore when signed in (KAN-35)', () => {
   const signedInStore = () => {
     const { store, seen } = seededStore();
     store.dispatch(setSignedIn());
+    // Both flags: a document id alone no longer authorises a Firestore call,
+    // because it does not mean the security rules will accept one (KAN-70).
+    store.dispatch(setFirebaseAuthed());
     seen.length = 0;
     return { store, seen };
   };

--- a/src/tests/redux/syncScheduling.test.ts
+++ b/src/tests/redux/syncScheduling.test.ts
@@ -21,7 +21,11 @@ vi.mock('../../utils/functions/external', () => ({
   displayToast: vi.fn(),
 }));
 
-import { setSignedIn, setUserId } from '../../redux/slices/globalStateSlice';
+import {
+  setFirebaseAuthed,
+  setSignedIn,
+  setUserId,
+} from '../../redux/slices/globalStateSlice';
 import {
   saveToTabContainerInternal,
   replaceState,
@@ -96,6 +100,8 @@ describe('a sync is scheduled by user edits, not by the merge persisting', () =>
   it('schedules a sync when the user changes data', async () => {
     const { store } = makeTestStore();
     store.dispatch(setSignedIn());
+    // KAN-70: the gate needs auth as well as a document id.
+    store.dispatch(setFirebaseAuthed());
     store.dispatch(setUserId('u1'));
 
     store.dispatch(saveToTabContainerInternal(group('a', 1000)));
@@ -124,6 +130,8 @@ describe('a sync is scheduled by user edits, not by the merge persisting', () =>
 
     const { store } = makeTestStore();
     store.dispatch(setSignedIn());
+    // KAN-70: the gate needs auth as well as a document id.
+    store.dispatch(setFirebaseAuthed());
     store.dispatch(setUserId('u1'));
     store.dispatch(replaceState(local));
 


### PR DESCRIPTION
`isSignedIn` was written by two sources that mean different things:

- `App.tsx` set it from a **`chrome.storage.sync` read** — a local lookup meaning *"a usable document id exists"*. No network, no authentication.
- `firebase.ts` set it from **`onAuthStateChanged`** — actual authentication.

`App.tsx:170` and `customMiddleware:119` then used that single boolean to authorise network calls. The local read always wins the race, so the gate opened while `request.auth` was still `null`, and the security rules correctly denied everything that went through it. Both sources write a `boolean`, so no compiler could see the substitution.

## Split, not timed or retried

The defect is the shared field, not the timing. `isFirebaseAuthed` is new, written **only** by `onAuthStateChanged`, and both gates now require it alongside `isSignedIn`.

**`isSignedIn` keeps its name and its meaning.** This app has no accounts — sync identity is a client uuid — so "signed in" genuinely means "has a sync identity", which is also what the settings pane renders `LoggedIn`/`NotLoggedIn` from. What was wrong was the *gate* reading it as "is authenticated".

`isFirebaseAuthed` is in the App effect's dependency array deliberately: it is the flag that flips late, so re-running on it is what makes the sync happen at all once auth lands. Recovery previously depended on `isSignedIn` **flapping** false → true, because `onAuthStateChanged` fires once with `user === null` before sign-in completes. That rescue was accidental and untested — a refactor removing the flap would have left sync silently never running.

A behaviour improvement falls out: `isSignedIn` no longer flaps, so the settings pane stops flashing "Cloud Sync Inactive" on open.

## Evidence

- `authGatesSync.test.ts` — 4 new tests, watched **RED** first (`setFirebaseAuthed` did not exist). Includes the positive control — the same dirty change *does* schedule a sync once auth has landed — without which the negative passes against a store that never syncs at all. 510 → **514 tests**.
- **Mutation** — drop `isFirebaseAuthed` from the middleware gate → the negative test fails while its control stays green.
- **Three existing tests went red on the first run** (`selectionDoesNotSync`, `syncScheduling`) because they dispatch `setSignedIn()` to open the gate. That is the gate proving itself; both now dispatch `setFirebaseAuthed()` too.
- **Live, cold profile, 3 runs per artifact**, document deleted before every run, both artifacts marker-verified (`isFirebaseAuthed` appears 3× in the fix bundle, 0× in main's):

  | artifact | denials/run | write completed | fields |
  |---|---|---|---|
  | main | 9, 9, 9 | 1715–2140ms | 4, correct |
  | fix | **0, 0, 0** | 1647–1780ms | 4, correct |

  The `wroteAt` and `fields` columns are the control that matters: a change that simply stopped syncing would also show zero denials. The document is still written, with the same four fields, marginally faster because no failed attempts precede it.
- 514/514 tests, `tsc` 0 errors, `eslint` 0 errors (25 pre-existing warnings).

## Scope

`globalStateSlice`'s `saveToFirestoreIfDirty.fulfilled` case also reads `isSignedIn`, and is left alone — it chooses a status label for display, it does not issue a request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
