### PR TITLE
Offer tab group support to users who have tab groups (KAN-74)

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -99,5 +99,11 @@
   "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Synchronisierung nicht verfügbar: Ihre Cloud-Daten konnten nicht gelesen werden. Die Sitzungen auf diesem Gerät sind sicher.",
   "Synced changes from another device.": "Änderungen von einem anderen Gerät synchronisiert.",
   "Restored tabs successfully!": "Tabs erfolgreich wiederhergestellt!",
-  "Unnamed group": "Unbenannte Gruppe"
+  "Unnamed group": "Unbenannte Gruppe",
+  "TabGroupsPromptTitle": "Ihre Tab-Gruppen speichern",
+  "TabGroupsPromptBodyOne": "Ohne Berechtigung kann Tab Keeper den Namen und die Farbe Ihrer Tab-Gruppe nicht speichern.",
+  "TabGroupsPromptBodyOther": "Ohne Berechtigung kann Tab Keeper die Namen und Farben Ihrer {{count}} Tab-Gruppen nicht speichern.",
+  "TabGroupsPromptConfirm": "Tab-Gruppen-Unterstützung aktivieren",
+  "TabGroupsPromptDismiss": "Jetzt nicht",
+  "TabGroupsPromptNever": "Nicht mehr fragen"
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -99,5 +99,11 @@
   "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.",
   "Synced changes from another device.": "Synced changes from another device.",
   "Restored tabs successfully!": "Restored tabs successfully!",
-  "Unnamed group": "Unnamed group"
+  "Unnamed group": "Unnamed group",
+  "TabGroupsPromptTitle": "Save your tab groups",
+  "TabGroupsPromptBodyOne": "Tab Keeper can't save the name and colour of your tab group without permission.",
+  "TabGroupsPromptBodyOther": "Tab Keeper can't save the names and colours of your {{count}} tab groups without permission.",
+  "TabGroupsPromptConfirm": "Enable tab group support",
+  "TabGroupsPromptDismiss": "Not now",
+  "TabGroupsPromptNever": "Don't ask again"
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -99,5 +99,11 @@
   "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Sincronización no disponible: no se pudieron leer los datos de la nube. Las sesiones de este dispositivo están a salvo.",
   "Synced changes from another device.": "Cambios sincronizados desde otro dispositivo.",
   "Restored tabs successfully!": "¡Pestañas restauradas correctamente!",
-  "Unnamed group": "Grupo sin nombre"
+  "Unnamed group": "Grupo sin nombre",
+  "TabGroupsPromptTitle": "Guarda tus grupos de pestañas",
+  "TabGroupsPromptBodyOne": "Sin permiso, Tab Keeper no puede guardar el nombre y el color de tu grupo de pestañas.",
+  "TabGroupsPromptBodyOther": "Sin permiso, Tab Keeper no puede guardar los nombres y colores de tus {{count}} grupos de pestañas.",
+  "TabGroupsPromptConfirm": "Activar la compatibilidad con grupos de pestañas",
+  "TabGroupsPromptDismiss": "Ahora no",
+  "TabGroupsPromptNever": "No volver a preguntar"
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -99,5 +99,11 @@
   "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Synchronisation indisponible : vos données cloud n'ont pas pu être lues. Les sessions sur cet appareil sont intactes.",
   "Synced changes from another device.": "Modifications synchronisées depuis un autre appareil.",
   "Restored tabs successfully!": "Onglets restaurés avec succès !",
-  "Unnamed group": "Groupe sans nom"
+  "Unnamed group": "Groupe sans nom",
+  "TabGroupsPromptTitle": "Enregistrer vos groupes d'onglets",
+  "TabGroupsPromptBodyOne": "Sans autorisation, Tab Keeper ne peut pas enregistrer le nom et la couleur de votre groupe d'onglets.",
+  "TabGroupsPromptBodyOther": "Sans autorisation, Tab Keeper ne peut pas enregistrer les noms et les couleurs de vos {{count}} groupes d'onglets.",
+  "TabGroupsPromptConfirm": "Activer la prise en charge des groupes d'onglets",
+  "TabGroupsPromptDismiss": "Pas maintenant",
+  "TabGroupsPromptNever": "Ne plus demander"
 }

--- a/public/locales/hi/translation.json
+++ b/public/locales/hi/translation.json
@@ -99,5 +99,11 @@
   "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "सिंक अनुपलब्ध: आपका क्लाउड डेटा पढ़ा नहीं जा सका। इस डिवाइस के सत्र सुरक्षित हैं।",
   "Synced changes from another device.": "दूसरे डिवाइस से किए गए बदलाव सिंक कर दिए गए।",
   "Restored tabs successfully!": "टैब सफलतापूर्वक पुनर्स्थापित किए गए!",
-  "Unnamed group": "बिना नाम का समूह"
+  "Unnamed group": "बिना नाम का समूह",
+  "TabGroupsPromptTitle": "अपने टैब समूह सहेजें",
+  "TabGroupsPromptBodyOne": "अनुमति के बिना Tab Keeper आपके टैब समूह का नाम और रंग नहीं सहेज सकता।",
+  "TabGroupsPromptBodyOther": "अनुमति के बिना Tab Keeper आपके {{count}} टैब समूहों के नाम और रंग नहीं सहेज सकता।",
+  "TabGroupsPromptConfirm": "टैब समूह समर्थन चालू करें",
+  "TabGroupsPromptDismiss": "अभी नहीं",
+  "TabGroupsPromptNever": "फिर से न पूछें"
 }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -99,5 +99,11 @@
   "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Sincronizzazione non disponibile: impossibile leggere i dati sul cloud. Le sessioni su questo dispositivo sono al sicuro.",
   "Synced changes from another device.": "Modifiche sincronizzate da un altro dispositivo.",
   "Restored tabs successfully!": "Tab ripristinati correttamente!",
-  "Unnamed group": "Gruppo senza nome"
+  "Unnamed group": "Gruppo senza nome",
+  "TabGroupsPromptTitle": "Salva i tuoi gruppi di schede",
+  "TabGroupsPromptBodyOne": "Senza autorizzazione, Tab Keeper non può salvare il nome e il colore del tuo gruppo di schede.",
+  "TabGroupsPromptBodyOther": "Senza autorizzazione, Tab Keeper non può salvare i nomi e i colori dei tuoi {{count}} gruppi di schede.",
+  "TabGroupsPromptConfirm": "Attiva il supporto ai gruppi di schede",
+  "TabGroupsPromptDismiss": "Non ora",
+  "TabGroupsPromptNever": "Non chiedere più"
 }

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -99,5 +99,11 @@
   "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "同期を利用できません: クラウドのデータを読み取れませんでした。このデバイスのセッションは安全です。",
   "Synced changes from another device.": "別のデバイスからの変更を同期しました。",
   "Restored tabs successfully!": "タブを復元しました。",
-  "Unnamed group": "名前のないグループ"
+  "Unnamed group": "名前のないグループ",
+  "TabGroupsPromptTitle": "タブグループを保存",
+  "TabGroupsPromptBodyOne": "権限がないと、Tab Keeper はタブグループの名前と色を保存できません。",
+  "TabGroupsPromptBodyOther": "権限がないと、Tab Keeper は {{count}} 個のタブグループの名前と色を保存できません。",
+  "TabGroupsPromptConfirm": "タブグループのサポートを有効にする",
+  "TabGroupsPromptDismiss": "後で",
+  "TabGroupsPromptNever": "今後表示しない"
 }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -99,5 +99,11 @@
   "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Sincronização indisponível: não foi possível ler os dados da nuvem. As sessões neste dispositivo estão seguras.",
   "Synced changes from another device.": "Alterações sincronizadas de outro dispositivo.",
   "Restored tabs successfully!": "Abas restauradas com sucesso!",
-  "Unnamed group": "Grupo sem nome"
+  "Unnamed group": "Grupo sem nome",
+  "TabGroupsPromptTitle": "Salve seus grupos de guias",
+  "TabGroupsPromptBodyOne": "Sem permissão, o Tab Keeper não pode salvar o nome e a cor do seu grupo de guias.",
+  "TabGroupsPromptBodyOther": "Sem permissão, o Tab Keeper não pode salvar os nomes e as cores dos seus {{count}} grupos de guias.",
+  "TabGroupsPromptConfirm": "Ativar o suporte a grupos de guias",
+  "TabGroupsPromptDismiss": "Agora não",
+  "TabGroupsPromptNever": "Não perguntar novamente"
 }

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -99,5 +99,11 @@
   "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "Синхронизация недоступна: не удалось прочитать данные в облаке. Сессии на этом устройстве в сохранности.",
   "Synced changes from another device.": "Изменения с другого устройства синхронизированы.",
   "Restored tabs successfully!": "Вкладки успешно восстановлены!",
-  "Unnamed group": "Группа без имени"
+  "Unnamed group": "Группа без имени",
+  "TabGroupsPromptTitle": "Сохраняйте свои группы вкладок",
+  "TabGroupsPromptBodyOne": "Без разрешения Tab Keeper не может сохранить название и цвет вашей группы вкладок.",
+  "TabGroupsPromptBodyOther": "Без разрешения Tab Keeper не может сохранить названия и цвета ваших групп вкладок ({{count}}).",
+  "TabGroupsPromptConfirm": "Включить поддержку групп вкладок",
+  "TabGroupsPromptDismiss": "Не сейчас",
+  "TabGroupsPromptNever": "Больше не спрашивать"
 }

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -99,5 +99,11 @@
   "Sync unavailable: your cloud data could not be read. Sessions on this device are safe.": "无法同步：无法读取云端数据。此设备上的会话是安全的。",
   "Synced changes from another device.": "已同步来自其他设备的更改。",
   "Restored tabs successfully!": "标签页已成功恢复！",
-  "Unnamed group": "未命名的群组"
+  "Unnamed group": "未命名的群组",
+  "TabGroupsPromptTitle": "保存您的标签组",
+  "TabGroupsPromptBodyOne": "没有权限，Tab Keeper 无法保存标签组的名称和颜色。",
+  "TabGroupsPromptBodyOther": "没有权限，Tab Keeper 无法保存这 {{count}} 个标签组的名称和颜色。",
+  "TabGroupsPromptConfirm": "启用标签组支持",
+  "TabGroupsPromptDismiss": "暂不",
+  "TabGroupsPromptNever": "不再询问"
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { useDocumentTheme } from './hooks/useDocumentTheme';
 import { replaceState } from './redux/slices/tabContainerDataStateSlice';
 import {
   openRateAndReviewModal,
+  openTabGroupsPrompt,
   removeUserId,
   setHasTabGroupsPermission,
   setLoggedOut,
@@ -27,6 +28,7 @@ import {
   hasTabGroupsPermission,
   observeTabGroupsPermission,
 } from './utils/functions/permissions';
+import { shouldOfferTabGroups } from './utils/functions/tabGroupsOffer';
 
 import './App.css';
 import {
@@ -125,7 +127,14 @@ function App() {
   }
 
   // ask user to rate and review the extension
-  function askUserToRateAndReview() {
+  //
+  // Returns whether it opened the modal. KAN-74 needs that answer to keep two
+  // modals off the screen at once, and it cannot read it back out of Redux:
+  // this function is synchronous while the tab-groups check below is async, so
+  // by the time that one resolves it would be reading a store it has no
+  // guarantee of having seen settle. Handing the decision over as a value
+  // makes the coordination explicit instead of an accident of dispatch order.
+  function askUserToRateAndReview(): boolean {
     // load from localstorage to check if user has already rated and reviewed
     const {
       extensionInstalledTime = '',
@@ -136,13 +145,13 @@ function App() {
 
     // if user has already rated and reviewed, then don't ask again
     if (isUserRatedAndReviewed || isNeverAskAgainToRate) {
-      return;
+      return false;
     }
 
     // if user is first time user, then wait till he/she uses the extension for a day
     if (!isValidDate(extensionInstalledTime)) {
       dispatch(setExtensionInstalledTime());
-      return;
+      return false;
     }
     const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
     const currentTimeInMs = new Date().getTime();
@@ -150,7 +159,7 @@ function App() {
       extensionInstalledTime
     ).getTime();
     if (currentTimeInMs - extensionInstalledTimeInMs < ONE_DAY_IN_MS) {
-      return;
+      return false;
     }
 
     // if user has already been asked to rate and review, then wait for 3 days to ask again
@@ -160,17 +169,32 @@ function App() {
       ).getTime();
       const THREE_DAYS_IN_MS = 3 * ONE_DAY_IN_MS;
       if (currentTimeInMs - lastReviewRequestTimeInMs < THREE_DAYS_IN_MS) {
-        return;
+        return false;
       }
     }
 
     // It's to ask the user to rate and review!
     dispatch(openRateAndReviewModal());
+    return true;
+  }
+
+  // KAN-74. Offer the optional "tabGroups" permission to a user who has tab
+  // groups open right now. shouldOfferTabGroups owns every condition; this
+  // only turns its answer into a dispatch.
+  //
+  // "Never from autosave" is satisfied by construction rather than by a check:
+  // autosave runs in the service worker, and App only mounts when the user
+  // opens the popup.
+  async function offerTabGroupsPermission(
+    isRateAndReviewModalShowing: boolean
+  ) {
+    const openGroups = await shouldOfferTabGroups(isRateAndReviewModalShowing);
+    if (openGroups !== null) dispatch(openTabGroupsPrompt(openGroups));
   }
 
   useEffect(() => {
     getUserTokenFromChromeStorageSync();
-    askUserToRateAndReview();
+    void offerTabGroupsPermission(askUserToRateAndReview());
     observeAuthState(dispatch);
 
     void hasTabGroupsPermission().then((granted) =>

--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -16,6 +16,7 @@ import RightPaneSettings from './settings/rightpane/RightPaneSettings';
 import { closeToast } from '../redux/slices/globalStateSlice';
 import { RateAndReviewModal } from './modals/RateAndReviewModal';
 import { FocusConfirmModal } from './modals/FocusConfirmModal';
+import { TabGroupsPermissionModal } from './modals/TabGroupsPermissionModal';
 
 // KAN-52. The undo/redo shortcuts are registered on `window`, so they also see
 // keystrokes aimed at a text field. When they do, the browser's own undo stack
@@ -59,6 +60,10 @@ export default function MainContainer() {
 
   const focusRequest = useSelector(
     (state: RootState) => state.globalState.focusRequest
+  );
+
+  const tabGroupsPromptCount = useSelector(
+    (state: RootState) => state.globalState.tabGroupsPromptCount
   );
 
   // Keyboard shortcut listener for undo/redo
@@ -163,6 +168,7 @@ export default function MainContainer() {
       )}
       {isToastOpen && <Toast />}
       {isRateAndReviewModalOpen && <RateAndReviewModal />}
+      {tabGroupsPromptCount !== null && <TabGroupsPermissionModal />}
       {focusRequest && <FocusConfirmModal />}
     </div>
   );

--- a/src/components/modals/TabGroupsPermissionModal.tsx
+++ b/src/components/modals/TabGroupsPermissionModal.tsx
@@ -1,0 +1,212 @@
+import { useDispatch, useSelector } from 'react-redux';
+
+import { css } from '@emotion/react';
+
+import Button from '../common/Button';
+import { useFontFamily } from '../../hooks/useFontFamily';
+import { useThemeColors } from '../../hooks/useThemeColors';
+import { AppDispatch, RootState } from '../../redux/store';
+import { closeTabGroupsPrompt } from '../../redux/slices/globalStateSlice';
+import { useTranslation } from 'react-i18next';
+import {
+  setNeverAskAgainForTabGroups,
+  setTabGroupsPromptAnsweredOnce,
+  SettingsData,
+} from '../../redux/slices/settingsDataStateSlice';
+import { requestTabGroupsPermission } from '../../utils/functions/permissions';
+import {
+  asPartialSettings,
+  loadFromLocalStorage,
+} from '../../utils/functions/local';
+
+interface TabGroupsPermissionModalProps {
+  style?: string;
+}
+
+// KAN-74. Offers the optional "tabGroups" permission to a user who has tab
+// groups open right now. App.tsx decides WHETHER to open this; everything here
+// is about what happens once it is open.
+export const TabGroupsPermissionModal: React.FC<
+  TabGroupsPermissionModalProps
+> = ({ style }) => {
+  const COLORS = useThemeColors();
+  const FONT_FAMILY = useFontFamily();
+  const { t } = useTranslation();
+  const dispatch: AppDispatch = useDispatch();
+
+  const tabGroupsPromptCount = useSelector(
+    (state: RootState) => state.globalState.tabGroupsPromptCount
+  );
+
+  // Below the hooks, never above them: an early return placed at the top of
+  // this component would change the number of hooks React sees between the
+  // closed and open renders, which is the one thing hook ordering forbids.
+  if (tabGroupsPromptCount === null) return null;
+
+  // Read straight from localStorage rather than from the settings slice, the
+  // same way RateAndReviewModal does. Both modals can render before the
+  // settings state has been rehydrated, and the stored value is the one that
+  // decides whether the permanent opt-out has been earned.
+  const { isTabGroupsPromptAnsweredOnce = false } =
+    asPartialSettings<SettingsData>(loadFromLocalStorage('settingsData'));
+
+  // Both paths below record that the offer has been ANSWERED once, which is
+  // what reveals the permanent opt-out on the next showing.
+  //
+  // Answered, not "dismissed": measured on a real popup, a user who clicked
+  // the CTA and then pressed Deny on Chrome's own prompt had given the
+  // strongest refusal available and still got no escape hatch, because only
+  // "Not now" used to set this. Enable-then-deny, repeated, was an unbounded
+  // loop with no opt-out ever appearing -- the exact dead end the escape hatch
+  // exists to prevent.
+  //
+  // Setting it on the CTA path costs nothing when the user ALLOWS: the offer
+  // is then gated off by hasTabGroupsPermission() and never renders again, so
+  // the revealed link is never seen.
+  const rememberAnswered = () => {
+    if (!isTabGroupsPromptAnsweredOnce) {
+      dispatch(setTabGroupsPromptAnsweredOnce());
+    }
+  };
+
+  const handleEnable = () => {
+    // Deliberately NOT awaited, and deliberately followed by an unconditional
+    // close. chrome.permissions.request() destroys this popup on a coin flip
+    // and its promise may never settle, so there is no "then" to close in and
+    // nothing here may depend on the answer. The outcome is read from
+    // contains() on the next popup mount -- see permissions.ts.
+    //
+    // rememberAnswered() runs FIRST for that reason: the request can tear this
+    // popup down synchronously, and a write queued after it may never happen.
+    rememberAnswered();
+    requestTabGroupsPermission();
+    dispatch(closeTabGroupsPrompt());
+  };
+
+  const handleNotNow = () => {
+    // The offer still fires on every open until the permanent opt-out is
+    // taken. This only unlocks that opt-out.
+    rememberAnswered();
+    dispatch(closeTabGroupsPrompt());
+  };
+
+  const handleNeverAskAgain = () => {
+    dispatch(setNeverAskAgainForTabGroups());
+    dispatch(closeTabGroupsPrompt());
+  };
+
+  // Paired keys picked by a ternary, not i18next's `_one`/`_other` suffixes:
+  // that is how FocusConfirmModal does plurals and this repo has no plural
+  // suffixes anywhere. Note the ru value keeps the count parenthetical,
+  // because Russian declines the noun on the number.
+  const bodyKey =
+    tabGroupsPromptCount === 1
+      ? 'TabGroupsPromptBodyOne'
+      : 'TabGroupsPromptBodyOther';
+
+  // The two dismissals are real <button>s, not NormalLabels with onClick.
+  //
+  // NormalLabel renders a bare `<div onClick>`: no role, no tab stop. Measured
+  // in a live popup, "Not now" appeared in the accessibility tree as
+  // StaticText, i.e. a control no keyboard user can reach -- the exact defect
+  // class KAN-66/67/68 went through this codebase to remove. RateAndReviewModal
+  // still dismisses that way and should be fixed too, but that is its own
+  // change; this one is not going to add a fourth instance.
+  //
+  // NormalLabel is also `white-space: nowrap`, which ran the body sentence off
+  // both edges of the 500px card. That is why the body below is a <p>.
+  const dismissStyle = css`
+    background: none;
+    border: none;
+    padding: 0;
+    font-family: ${FONT_FAMILY};
+    font-size: 0.9rem;
+    color: ${COLORS.TEXT_COLOR};
+    cursor: pointer;
+    &:hover {
+      text-decoration: underline;
+    }
+  `;
+
+  return (
+    <div
+      css={css`
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.8);
+        z-index: 999;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        ${style}
+      `}
+    >
+      <div
+        css={css`
+          background-color: ${COLORS.PRIMARY_COLOR};
+          color: ${COLORS.LABEL_L1_COLOR};
+          border: 1px solid ${COLORS.BORDER_COLOR};
+          width: 500px;
+          padding: 20px;
+          align-items: center;
+          border-radius: 0px;
+          display: flex;
+          flex-direction: column;
+          padding-bottom: 25px;
+          gap: 20px;
+        `}
+      >
+        <h2
+          css={css`
+            font-weight: 500;
+            font-family: ${FONT_FAMILY};
+            font-size: 1.3rem;
+            margin: 10px;
+          `}
+        >
+          {t('TabGroupsPromptTitle')}
+        </h2>
+        <p
+          css={css`
+            font-family: ${FONT_FAMILY};
+            font-size: 0.9rem;
+            color: ${COLORS.TEXT_COLOR};
+            text-align: center;
+            margin: 0 0 10px 0;
+          `}
+        >
+          {t(bodyKey, { count: tabGroupsPromptCount })}
+        </p>
+        {/* No fixed width on the CTA: the label is a full phrase ("Enable tab
+            group support"), and several locales render it far longer still --
+            fr is "Activer la prise en charge des groupes d'onglets". The 217px
+            this started with would have clipped most of them. */}
+        <Button
+          text={t('TabGroupsPromptConfirm')}
+          onClick={handleEnable}
+          ariaLabel={t('TabGroupsPromptConfirm')}
+          iconType="check_circle"
+          style="max-width: 100%; margin-bottom: 10px; cursor: pointer;"
+        />
+        <button type="button" css={dismissStyle} onClick={handleNotNow}>
+          {t('TabGroupsPromptDismiss')}
+        </button>
+        {/* Earned, not offered: the permanent opt-out appears only after the
+            user has already said "not now" once. Same escalation as
+            RateAndReviewModal's "Never Remind Again". */}
+        {isTabGroupsPromptAnsweredOnce && (
+          <button
+            type="button"
+            css={dismissStyle}
+            onClick={handleNeverAskAgain}
+          >
+            {t('TabGroupsPromptNever')}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/redux/slices/globalStateSlice.ts
+++ b/src/redux/slices/globalStateSlice.ts
@@ -45,6 +45,16 @@ export interface Global {
   isToastOpen: boolean;
   toastText: string;
   isRateAndReviewModalOpen: boolean;
+  // KAN-74. How many live tab groups the "turn on tab group support?" offer is
+  // about, or null when the offer is not showing. One field rather than an
+  // open flag beside a count, so an open prompt without a count is
+  // unrepresentable -- the same shape, and for the same reason, as
+  // focusRequest below.
+  //
+  // Session-only, like every other flag here: whether the offer is SHOWING is
+  // a fact about this popup, while whether it may be shown AGAIN is persisted
+  // in settingsData.
+  tabGroupsPromptCount: number | null;
   focusRequest: FocusRequest | null;
   // "the tabGroups permission is granted right now". Mirrors
   // chrome.permissions.contains(), re-read on every popup mount and updated by
@@ -78,6 +88,7 @@ export const initialState: Global = {
   isToastOpen: false,
   toastText: '',
   isRateAndReviewModalOpen: false,
+  tabGroupsPromptCount: null,
   focusRequest: null,
   hasTabGroupsPermission: false,
 };
@@ -297,6 +308,14 @@ export const globalStateSlice = createSlice({
       state.isRateAndReviewModalOpen = false;
     },
 
+    openTabGroupsPrompt: (state, action: PayloadAction<number>) => {
+      state.tabGroupsPromptCount = action.payload;
+    },
+
+    closeTabGroupsPrompt: (state) => {
+      state.tabGroupsPromptCount = null;
+    },
+
     openFocusModal: (state, action: PayloadAction<FocusRequest>) => {
       state.focusRequest = action.payload;
     },
@@ -427,6 +446,8 @@ export const globalStateSlice = createSlice({
 export const {
   openRateAndReviewModal,
   closeRateAndReviewModal,
+  openTabGroupsPrompt,
+  closeTabGroupsPrompt,
   openFocusModal,
   closeFocusModal,
   openSearchPanel,

--- a/src/redux/slices/settingsDataStateSlice.ts
+++ b/src/redux/slices/settingsDataStateSlice.ts
@@ -37,6 +37,16 @@ export interface SettingsData {
   isUserRatedAndReviewed: boolean;
   isNeverAskAgainToRate: boolean;
   lastReviewRequestTime: number | '';
+  // KAN-74. The tab-groups permission offer. Two flags and no timestamp: the
+  // offer fires on every popup open that finds groups open, so there is
+  // nothing to schedule -- only an escalating opt-out to remember.
+  //
+  // Neither flag mirrors whether the permission is GRANTED. That stays
+  // hasTabGroupsPermission()'s job, so a user who grants and later revokes
+  // from chrome://extensions -- the most explicit "no" available -- cannot be
+  // re-armed into being asked again by a stale boolean.
+  isTabGroupsPromptAnsweredOnce: boolean;
+  isNeverAskAgainForTabGroups: boolean;
 }
 
 // Retrieve settings from localStorage
@@ -54,6 +64,8 @@ const defaultSettings: SettingsData = {
   isUserRatedAndReviewed: false,
   isNeverAskAgainToRate: false,
   lastReviewRequestTime: '',
+  isTabGroupsPromptAnsweredOnce: false,
+  isNeverAskAgainForTabGroups: false,
 };
 
 export const initialState: SettingsData = {
@@ -128,6 +140,20 @@ export const settingsDataStateSlice = createSlice({
       saveToLocalStorage('settingsData', state);
     },
 
+    setTabGroupsPromptAnsweredOnce: (state) => {
+      state.isTabGroupsPromptAnsweredOnce = true;
+
+      // Save updated state to localStorage
+      saveToLocalStorage('settingsData', state);
+    },
+
+    setNeverAskAgainForTabGroups: (state) => {
+      state.isNeverAskAgainForTabGroups = true;
+
+      // Save updated state to localStorage
+      saveToLocalStorage('settingsData', state);
+    },
+
     replaceState: (state, action: PayloadAction<typeof state>) => {
       // Save updated state to localStorage
       saveToLocalStorage('settingsData', state);
@@ -147,6 +173,8 @@ export const {
   setSkippedUserReviewOnce,
   setExtensionInstalledTime,
   updateLastReviewRequestTime,
+  setTabGroupsPromptAnsweredOnce,
+  setNeverAskAgainForTabGroups,
 } = settingsDataStateSlice.actions;
 
 export default settingsDataStateSlice.reducer;

--- a/src/tests/components/TabGroupsPermissionModal.test.tsx
+++ b/src/tests/components/TabGroupsPermissionModal.test.tsx
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { TabGroupsPermissionModal } from '../../components/modals/TabGroupsPermissionModal';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import { openTabGroupsPrompt } from '../../redux/slices/globalStateSlice';
+import { SettingsData } from '../../redux/slices/settingsDataStateSlice';
+import {
+  asPartialSettings,
+  loadFromLocalStorage,
+} from '../../utils/functions/local';
+
+// The modal reads its escalation flag straight out of localStorage (as
+// RateAndReviewModal does), so these tests write it there rather than into the
+// store. Cleared each time so one test's dismissal cannot reveal the permanent
+// opt-out in the next.
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+const storedSettings = () =>
+  asPartialSettings<SettingsData>(loadFromLocalStorage('settingsData'));
+
+const seedSettings = (settings: Partial<SettingsData>) =>
+  localStorage.setItem('settingsData', JSON.stringify(settings));
+
+// The prompt is opened by App.tsx in production. Here it is opened directly,
+// synchronously, before first render -- see renderWithProviders' note on why
+// seedStore must not defer.
+const openWith =
+  (count: number) => (store: { dispatch: (a: unknown) => void }) =>
+    store.dispatch(openTabGroupsPrompt(count));
+
+describe('TabGroupsPermissionModal', () => {
+  test('renders nothing when no prompt is open', async () => {
+    await renderWithProviders(<TabGroupsPermissionModal />);
+
+    expect(screen.queryByText('Save your tab groups')).toBeNull();
+  });
+
+  test('renders the offer when a prompt is open', async () => {
+    await renderWithProviders(<TabGroupsPermissionModal />, {
+      seedStore: openWith(2),
+    });
+
+    expect(screen.getByText('Save your tab groups')).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'Enable tab group support' })
+    ).toBeTruthy();
+    expect(screen.getByText('Not now')).toBeTruthy();
+  });
+
+  test('one group reads as singular, with no count in the sentence', async () => {
+    await renderWithProviders(<TabGroupsPermissionModal />, {
+      seedStore: openWith(1),
+    });
+
+    expect(
+      screen.getByText(
+        "Tab Keeper can't save the name and colour of your tab group without permission."
+      )
+    ).toBeTruthy();
+  });
+
+  // Paired with the singular test above: together they prove the ternary picks
+  // a key rather than always landing on one of them.
+  test('several groups read as plural and name the count', async () => {
+    await renderWithProviders(<TabGroupsPermissionModal />, {
+      seedStore: openWith(3),
+    });
+
+    expect(
+      screen.getByText(
+        "Tab Keeper can't save the names and colours of your 3 tab groups without permission."
+      )
+    ).toBeTruthy();
+  });
+});
+
+describe('TabGroupsPermissionModal escalation', () => {
+  // The escape hatch is EARNED, not offered. A user seeing this for the first
+  // time gets two choices; only one who has already declined once gets the
+  // permanent opt-out.
+  test('the permanent opt-out is absent on a first showing', async () => {
+    await renderWithProviders(<TabGroupsPermissionModal />, {
+      seedStore: openWith(2),
+    });
+
+    expect(screen.queryByText("Don't ask again")).toBeNull();
+  });
+
+  test('the permanent opt-out appears once the user has declined before', async () => {
+    seedSettings({ isTabGroupsPromptAnsweredOnce: true });
+
+    await renderWithProviders(<TabGroupsPermissionModal />, {
+      seedStore: openWith(2),
+    });
+
+    expect(screen.getByText("Don't ask again")).toBeTruthy();
+  });
+
+  // Measured in a live popup before this was fixed: rendered as a NormalLabel
+  // (a bare `<div onClick>`), "Not now" reached the accessibility tree as
+  // StaticText -- a control a keyboard user cannot reach at all. getByRole is
+  // the assertion that says so; getByText passes either way, which is why the
+  // clicks below are deliberately left on getByText and this test carries the
+  // role check on its own.
+  test('both dismissals are real buttons, reachable by keyboard', async () => {
+    seedSettings({ isTabGroupsPromptAnsweredOnce: true });
+
+    await renderWithProviders(<TabGroupsPermissionModal />, {
+      seedStore: openWith(2),
+    });
+
+    expect(screen.getByRole('button', { name: 'Not now' })).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: "Don't ask again" })
+    ).toBeTruthy();
+  });
+
+  test('"Not now" records the dismissal and closes, without opting out for good', async () => {
+    await renderWithProviders(<TabGroupsPermissionModal />, {
+      seedStore: openWith(2),
+    });
+
+    await userEvent.click(screen.getByText('Not now'));
+
+    expect(storedSettings().isTabGroupsPromptAnsweredOnce).toBe(true);
+    // The whole point of "later means later": declining once must NOT set the
+    // flag that stops the offer permanently.
+    expect(storedSettings().isNeverAskAgainForTabGroups ?? false).toBe(false);
+  });
+
+  test('"Don\'t ask again" opts out for good', async () => {
+    seedSettings({ isTabGroupsPromptAnsweredOnce: true });
+
+    const { store } = await renderWithProviders(<TabGroupsPermissionModal />, {
+      seedStore: openWith(2),
+    });
+
+    await userEvent.click(screen.getByText("Don't ask again"));
+
+    expect(storedSettings().isNeverAskAgainForTabGroups).toBe(true);
+    expect(store.getState().globalState.tabGroupsPromptCount).toBeNull();
+  });
+});
+
+describe('TabGroupsPermissionModal permission request', () => {
+  test('the CTA asks Chrome for the permission', async () => {
+    await renderWithProviders(<TabGroupsPermissionModal />, {
+      seedStore: openWith(2),
+    });
+
+    expect(
+      await chrome.permissions.contains({ permissions: ['tabGroups'] })
+    ).toBe(false);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Enable tab group support' })
+    );
+
+    expect(
+      await chrome.permissions.contains({ permissions: ['tabGroups'] })
+    ).toBe(true);
+  });
+
+  // The hard constraint from KAN-11, measured against a real popup:
+  // chrome.permissions.request() may never settle, and may destroy the popup
+  // outright. Nothing in this handler may wait on it. requestNeverSettles
+  // models exactly that -- if the close were moved into a .then/await on the
+  // request, this test would hang the modal open forever.
+  test('closes even when the permission request never settles', async () => {
+    const { store } = await renderWithProviders(<TabGroupsPermissionModal />, {
+      seed: { requestNeverSettles: true },
+      seedStore: openWith(2),
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Enable tab group support' })
+    );
+
+    expect(store.getState().globalState.tabGroupsPromptCount).toBeNull();
+  });
+
+  // Control for the test above: with a request that DOES settle the modal also
+  // closes, so the assertion there is about not waiting, not about closing.
+  test('closes when the permission request settles normally', async () => {
+    const { store } = await renderWithProviders(<TabGroupsPermissionModal />, {
+      seedStore: openWith(2),
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Enable tab group support' })
+    );
+
+    expect(store.getState().globalState.tabGroupsPromptCount).toBeNull();
+  });
+
+  // Nothing may write a "granted" boolean into settings. The grant lives in
+  // chrome.permissions and is re-read on the next mount; a persisted mirror
+  // would disagree with reality the moment the user revoked it. Note this
+  // asserts on the OPT-OUT flag only: the answered flag below is deliberately
+  // set here, and is not a grant mirror -- it records that the offer was put
+  // to the user, which is true whatever they then told Chrome.
+  test('turning it on persists no grant flag of its own', async () => {
+    await renderWithProviders(<TabGroupsPermissionModal />, {
+      seedStore: openWith(2),
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Enable tab group support' })
+    );
+
+    expect(storedSettings().isNeverAskAgainForTabGroups ?? false).toBe(false);
+  });
+
+  // The deny dead end, found by pressing Deny on a real Chrome prompt.
+  //
+  // The CTA is the ONLY route to a native denial, and a denial is invisible to
+  // this popup (permissions.request() may never settle, and may destroy the
+  // popup outright). So if clicking the CTA recorded nothing, a user who
+  // answered Enable -> Deny every time would never unlock "Don't ask again":
+  // an unbounded prompt with no escape hatch. Taking the CTA has to count as
+  // having been asked.
+  test('the CTA unlocks the opt-out, so an Enable-then-Deny user is not trapped', async () => {
+    await renderWithProviders(<TabGroupsPermissionModal />, {
+      seedStore: openWith(2),
+    });
+
+    expect(screen.queryByText("Don't ask again")).toBeNull();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Enable tab group support' })
+    );
+
+    // Chrome's answer never reaches us, so the flag is what the NEXT popup
+    // reads to decide whether the escape hatch has been earned.
+    expect(storedSettings().isTabGroupsPromptAnsweredOnce).toBe(true);
+  });
+
+  // Control for the test above: the flag alone is not enough to show the
+  // opt-out -- it has to actually reach the render on the next showing.
+  test('a user who answered once sees the opt-out on the next showing', async () => {
+    seedSettings({ isTabGroupsPromptAnsweredOnce: true });
+
+    await renderWithProviders(<TabGroupsPermissionModal />, {
+      seedStore: openWith(2),
+    });
+
+    expect(
+      screen.getByRole('button', { name: "Don't ask again" })
+    ).toBeTruthy();
+  });
+});

--- a/src/tests/components/modalCoordination.test.tsx
+++ b/src/tests/components/modalCoordination.test.tsx
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { waitFor } from '@testing-library/react';
+
+// Firebase is the only reason App cannot just be mounted: observeAuthState
+// opens a real onAuthStateChanged subscription against a live auth object.
+// Nothing in this file is about auth, so it is stubbed to a no-op. App then
+// takes its localStorage branch, because isFirebaseAuthed never flips.
+vi.mock('../../config/firebase', () => ({
+  observeAuthState: () => {},
+  signInUserAnonymously: () => {},
+}));
+
+import App from '../../App';
+import { renderWithProviders } from '../setup/renderWithProviders';
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+const DAY = 24 * 60 * 60 * 1000;
+
+// Two tab groups open, permission ungranted -- everything the tab-groups offer
+// needs. Held constant across both tests below so the ONLY difference is
+// whether the rate modal also wants the screen.
+const twoGroupsUngranted = {
+  tabs: [{ groupId: 11 }, { groupId: 12 }, { groupId: -1 }],
+};
+
+// KAN-74. Both modals are position:fixed at z-index 999 and both are opened
+// from App's mount effect, so if they ever opened together they would stack
+// with no defined winner. They cannot, and this is why: askUserToRateAndReview
+// runs synchronously and hands its answer to the tab-groups check as a value.
+//
+// That handoff is the thing under test. The decision itself is covered in
+// tabGroupsOffer.test.ts; what could still break is App passing the wrong
+// argument -- a hardcoded `false` would satisfy every other test in the suite.
+describe('modal coordination on popup open', () => {
+  test('the rate request wins, and the tab-groups offer stands down', async () => {
+    // Installed two days ago, never rated, never asked -> the rate modal fires.
+    localStorage.setItem(
+      'settingsData',
+      JSON.stringify({ extensionInstalledTime: Date.now() - 2 * DAY })
+    );
+
+    const { store } = await renderWithProviders(<App />, {
+      seed: twoGroupsUngranted,
+    });
+
+    await waitFor(() =>
+      expect(store.getState().globalState.isRateAndReviewModalOpen).toBe(true)
+    );
+
+    // The offer's own conditions are all met; only the rate modal suppresses it.
+    expect(store.getState().globalState.tabGroupsPromptCount).toBeNull();
+  });
+
+  // The control. Same seed, same install age -- only the rate modal is taken
+  // out of the running. Without this, the test above passes just as well
+  // against an App that never opens the tab-groups offer at all.
+  test('with the rate request silenced, the tab-groups offer opens', async () => {
+    localStorage.setItem(
+      'settingsData',
+      JSON.stringify({
+        extensionInstalledTime: Date.now() - 2 * DAY,
+        isNeverAskAgainToRate: true,
+      })
+    );
+
+    const { store } = await renderWithProviders(<App />, {
+      seed: twoGroupsUngranted,
+    });
+
+    await waitFor(() =>
+      expect(store.getState().globalState.tabGroupsPromptCount).toBe(2)
+    );
+
+    expect(store.getState().globalState.isRateAndReviewModalOpen).toBe(false);
+  });
+
+  // A brand-new user: the rate path writes extensionInstalledTime and returns
+  // without opening anything, so the tab-groups offer is free to fire on the
+  // very first open. Verified against a real fresh install too.
+  test('a first-run user gets the tab-groups offer, not the rate request', async () => {
+    const { store } = await renderWithProviders(<App />, {
+      seed: twoGroupsUngranted,
+    });
+
+    await waitFor(() =>
+      expect(store.getState().globalState.tabGroupsPromptCount).toBe(2)
+    );
+
+    expect(store.getState().globalState.isRateAndReviewModalOpen).toBe(false);
+  });
+});

--- a/src/tests/setup/chrome.fake.ts
+++ b/src/tests/setup/chrome.fake.ts
@@ -100,6 +100,27 @@ export function setupChromeFake(seed: ChromeSeed = {}): ChromeFakeHandle {
     tabs.push(makeTab(tab, tab.windowId ?? DEFAULT_WINDOW_ID));
   }
 
+  // Whether `currentWindow` in a tabs.query can be honoured at all.
+  //
+  // Honouring it needs a seed that places every tab in a window it actually
+  // declared. Several seeds do not: they declare `windows: [{id: 7, ...}]` for
+  // the capture path AND a separate top-level `tabs: [{active: true}]` for the
+  // name pre-fill, and that second tab falls to DEFAULT_WINDOW_ID. Filtering
+  // those on currentWindow would erase the active tab and break the seed's
+  // own intent, so such seeds keep the historical "currentWindow means any
+  // window" behaviour.
+  //
+  // Inferred from the seed rather than set by a flag, because the inference is
+  // exactly the precondition -- a seed that IS window-consistent can only
+  // benefit from the higher fidelity, and one that is not could only be broken
+  // by it. Snapshotted here rather than recomputed per query so that a later
+  // tabs.create() cannot silently flip the semantics mid-test.
+  const declaredWindowIds = new Set(windows.map((win) => win.id));
+  const currentWindowId = windows[0]?.id;
+  const seedPlacesEveryTabInADeclaredWindow =
+    windows.length > 0 &&
+    tabs.every((tab) => declaredWindowIds.has(tab.windowId));
+
   // Chrome omits `tabs` entirely unless populate was asked for, so the two
   // cases are deliberately different shapes rather than one with an empty
   // array -- a test that forgets populate should see what production sees.
@@ -186,13 +207,17 @@ export function setupChromeFake(seed: ChromeSeed = {}): ChromeFakeHandle {
     },
 
     tabs: {
-      // `active` and `windowId` are honoured. `currentWindow` and
-      // `lastFocusedWindow` are deliberately NOT: production passes them
-      // (UserInputContainer.tsx:28, TabGroupDetailsContainer.tsx:56) but
-      // honouring them would require every seed to place its tabs in a real
-      // window, which today's seeds do not. Treating them as "any window"
-      // keeps single-window tests honest; a multi-window test that depends on
-      // the distinction must not use this fake until that is fixed.
+      // `active` and `windowId` are always honoured. `currentWindow` is
+      // honoured only for window-consistent seeds (see
+      // `seedPlacesEveryTabInADeclaredWindow` above); `lastFocusedWindow` is
+      // still deliberately NOT honoured at all.
+      //
+      // Widened for KAN-74. countOpenTabGroups() must count across ALL
+      // windows, and while `currentWindow` was ignored outright the fake
+      // answered query({}) and query({currentWindow:true}) identically -- so
+      // the multi-window test asserting all-windows behaviour passed against a
+      // deliberately broken implementation that asked for the current window
+      // only. The mutation survived; this is what kills it.
       query: (
         queryInfo: chrome.tabs.QueryInfo,
         cb?: (result: chrome.tabs.Tab[]) => void
@@ -202,7 +227,12 @@ export function setupChromeFake(seed: ChromeSeed = {}): ChromeFakeHandle {
             (queryInfo.active === undefined ||
               tab.active === queryInfo.active) &&
             (queryInfo.windowId === undefined ||
-              tab.windowId === queryInfo.windowId)
+              tab.windowId === queryInfo.windowId) &&
+            (queryInfo.currentWindow === undefined ||
+              !seedPlacesEveryTabInADeclaredWindow ||
+              (queryInfo.currentWindow
+                ? tab.windowId === currentWindowId
+                : tab.windowId !== currentWindowId))
         );
         return settle(matched, cb);
       },

--- a/src/tests/utils/functions/liveTabGroups.test.ts
+++ b/src/tests/utils/functions/liveTabGroups.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from 'vitest';
+
+import {
+  setupChromeFake,
+  type ChromeFakeHandle,
+} from '../../setup/chrome.fake';
+import { countOpenTabGroups } from '../../../utils/functions/liveTabGroups';
+
+let handle: ChromeFakeHandle;
+afterEach(() => handle?.restore());
+
+describe('countOpenTabGroups', () => {
+  // The premise of KAN-74. Every test below seeds no grantedPermissions, so
+  // the whole file is really one long assertion that counting works while
+  // ungranted -- but this one says it out loud, because if it ever stops being
+  // true the feature has no trigger and the rest of these tests would look
+  // like they were merely testing arithmetic.
+  test('counts groups on a profile that has NOT granted tabGroups', async () => {
+    handle = setupChromeFake({
+      tabs: [{ groupId: 42 }, { groupId: -1 }],
+    });
+
+    expect(
+      await chrome.permissions.contains({ permissions: ['tabGroups'] })
+    ).toBe(false);
+    expect(await countOpenTabGroups()).toBe(1);
+  });
+
+  test('zero when nothing is grouped', async () => {
+    handle = setupChromeFake({ tabs: [{ groupId: -1 }, { groupId: -1 }] });
+    expect(await countOpenTabGroups()).toBe(0);
+  });
+
+  test('zero when there are no tabs at all', async () => {
+    handle = setupChromeFake();
+    expect(await countOpenTabGroups()).toBe(0);
+  });
+
+  // Distinct, not total. Two tabs in one group is one group to offer to save.
+  test('two tabs sharing a group count as one group', async () => {
+    handle = setupChromeFake({ tabs: [{ groupId: 7 }, { groupId: 7 }] });
+    expect(await countOpenTabGroups()).toBe(1);
+  });
+
+  // The ticket's "all windows, not just the current one": the ask is about the
+  // feature in general. A per-window query would return 1 here.
+  test('counts groups across separate windows', async () => {
+    handle = setupChromeFake({
+      windows: [{ id: 1 }, { id: 2 }],
+      tabs: [
+        { groupId: 7, windowId: 1 },
+        { groupId: 9, windowId: 2 },
+      ],
+    });
+    expect(await countOpenTabGroups()).toBe(2);
+  });
+
+  // Paired positive control for the exclusion below: the SAME seed, minus the
+  // ungrouped tab, must still count 1. Without this, a countOpenTabGroups that
+  // always returned 0 would satisfy the exclusion test.
+  test('a lone grouped tab counts 1 (control for the exclusion below)', async () => {
+    handle = setupChromeFake({ tabs: [{ groupId: 7 }] });
+    expect(await countOpenTabGroups()).toBe(1);
+  });
+
+  test('ungrouped tabs (-1) are excluded, not counted as a group', async () => {
+    handle = setupChromeFake({
+      tabs: [{ groupId: 7 }, { groupId: -1 }, { groupId: -1 }],
+    });
+    expect(await countOpenTabGroups()).toBe(1);
+  });
+
+  // A tab whose groupId Chrome omitted entirely. Distinct from -1 and must not
+  // become a group of its own: `undefined` is not a group id.
+  test('a tab with no groupId at all is excluded', async () => {
+    handle = setupChromeFake({ tabs: [{ groupId: undefined }] });
+    expect(await countOpenTabGroups()).toBe(0);
+  });
+
+  // Worst path. The count only decides whether to show an offer, so a failed
+  // query must degrade to "do not offer" rather than reject into the mount
+  // effect that calls it.
+  test('zero, not a throw, when chrome.tabs.query rejects', async () => {
+    handle = setupChromeFake();
+    const tabs = chrome.tabs as unknown as { query: () => Promise<unknown> };
+    tabs.query = () => Promise.reject(new Error('no tabs permission'));
+
+    await expect(countOpenTabGroups()).resolves.toBe(0);
+  });
+
+  test('zero, not a throw, when the tabs API is missing entirely', async () => {
+    handle = setupChromeFake();
+    delete (globalThis as { chrome?: { tabs?: unknown } }).chrome!.tabs;
+
+    await expect(countOpenTabGroups()).resolves.toBe(0);
+  });
+});

--- a/src/tests/utils/functions/tabGroupsOffer.test.ts
+++ b/src/tests/utils/functions/tabGroupsOffer.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import {
+  setupChromeFake,
+  type ChromeFakeHandle,
+} from '../../setup/chrome.fake';
+import { shouldOfferTabGroups } from '../../../utils/functions/tabGroupsOffer';
+import { SettingsData } from '../../../redux/slices/settingsDataStateSlice';
+
+let handle: ChromeFakeHandle;
+beforeEach(() => localStorage.clear());
+afterEach(() => {
+  handle?.restore();
+  localStorage.clear();
+});
+
+const seedSettings = (settings: Partial<SettingsData>) =>
+  localStorage.setItem('settingsData', JSON.stringify(settings));
+
+// A profile with two tab groups open and no permission granted -- the state
+// the whole feature exists to catch. Every suppression test below starts from
+// exactly this seed and changes one thing, so a test that stops offering
+// really is being suppressed by the thing it names.
+const twoGroupsUngranted = {
+  tabs: [{ groupId: 11 }, { groupId: 12 }, { groupId: -1 }],
+};
+
+describe('shouldOfferTabGroups', () => {
+  test('offers, with the group count, when everything lines up', async () => {
+    handle = setupChromeFake(twoGroupsUngranted);
+
+    expect(await shouldOfferTabGroups(false)).toBe(2);
+  });
+
+  test('stays quiet when no tab groups are open', async () => {
+    handle = setupChromeFake({ tabs: [{ groupId: -1 }] });
+
+    expect(await shouldOfferTabGroups(false)).toBeNull();
+  });
+
+  // Nothing to offer: they already have it.
+  test('stays quiet when the permission is already granted', async () => {
+    handle = setupChromeFake({
+      ...twoGroupsUngranted,
+      grantedPermissions: ['tabGroups'],
+    });
+
+    expect(await shouldOfferTabGroups(false)).toBeNull();
+  });
+
+  test('stays quiet once the user has opted out for good', async () => {
+    handle = setupChromeFake(twoGroupsUngranted);
+    seedSettings({ isNeverAskAgainForTabGroups: true });
+
+    expect(await shouldOfferTabGroups(false)).toBeNull();
+  });
+
+  test('stays quiet while the rate-and-review modal is showing', async () => {
+    handle = setupChromeFake(twoGroupsUngranted);
+
+    expect(await shouldOfferTabGroups(true)).toBeNull();
+  });
+
+  // "Not now" means later, and later means the very next open. A single
+  // dismissal must suppress nothing -- only the permanent opt-out does.
+  test('still offers after the user has dismissed it once', async () => {
+    handle = setupChromeFake(twoGroupsUngranted);
+    seedSettings({ isTabGroupsPromptAnsweredOnce: true });
+
+    expect(await shouldOfferTabGroups(false)).toBe(2);
+  });
+
+  // A revoked permission is the most explicit "no" a user can give, and it
+  // must not re-arm the offer past an opt-out that is already recorded. This
+  // is the pairing that a stored "we asked already" mirror would get wrong.
+  test('an opted-out user who revokes the permission is still not re-asked', async () => {
+    handle = setupChromeFake({
+      ...twoGroupsUngranted,
+      grantedPermissions: ['tabGroups'],
+    });
+    seedSettings({ isNeverAskAgainForTabGroups: true });
+
+    await chrome.permissions.remove({ permissions: ['tabGroups'] });
+    expect(
+      await chrome.permissions.contains({ permissions: ['tabGroups'] })
+    ).toBe(false);
+
+    expect(await shouldOfferTabGroups(false)).toBeNull();
+  });
+
+  // The control for the test above: the same revocation, without the opt-out,
+  // DOES offer again. Without this, that test passes against a function that
+  // never offers anything.
+  test('a user who has not opted out is offered again after revoking', async () => {
+    handle = setupChromeFake({
+      ...twoGroupsUngranted,
+      grantedPermissions: ['tabGroups'],
+    });
+
+    expect(await shouldOfferTabGroups(false)).toBeNull();
+
+    await chrome.permissions.remove({ permissions: ['tabGroups'] });
+
+    expect(await shouldOfferTabGroups(false)).toBe(2);
+  });
+
+  test('unreadable settings in localStorage do not suppress the offer', async () => {
+    handle = setupChromeFake(twoGroupsUngranted);
+    localStorage.setItem('settingsData', 'not json');
+
+    expect(await shouldOfferTabGroups(false)).toBe(2);
+  });
+});

--- a/src/utils/functions/liveTabGroups.ts
+++ b/src/utils/functions/liveTabGroups.ts
@@ -1,0 +1,60 @@
+// Reading Chrome's LIVE tab groups -- the ones open in the browser right now.
+//
+// Distinct from tabGroups.ts, which is about groups already SAVED into a
+// session and keyed by the uuid minted at capture. Nothing here touches stored
+// data; nothing there touches the browser.
+//
+// This module exists because of one measured fact: `Tab.groupId` is NOT
+// privileged. It arrives on every tab from `chrome.tabs.query` whether or not
+// the optional "tabGroups" permission has been granted. Only a group's title
+// and colour need the grant. So membership can be COUNTED without permission,
+// which is what lets KAN-74 offer the feature to the users who would actually
+// benefit rather than to everyone.
+//
+// Measured 2026-09-04 by revoking the permission mid-session and re-querying:
+// contains({tabGroups}) returned false while chrome.tabs.query still reported
+// groupId 801893355 on the grouped tabs.
+
+// Chrome's own name for this value is chrome.tabGroups.TAB_GROUP_ID_NONE, and
+// it is deliberately NOT used here: `chrome.tabGroups` is undefined while the
+// permission is ungranted, so reading the constant off it would throw in
+// exactly the case this module is built for. The numeric value is stable
+// platform API.
+const UNGROUPED = -1;
+
+// How many distinct tab groups are open across ALL windows.
+//
+// Distinct, not total: two tabs in one group is one group. All windows, not
+// the current one: the offer this feeds is about the feature in general, not
+// about a particular window the user happens to be looking at.
+//
+// Returns 0 rather than throwing on any failure. The only caller uses this to
+// decide whether to show an offer, and "could not tell" and "none" lead to the
+// same correct behaviour there -- stay quiet. Rejecting instead would put an
+// unhandled rejection in App's mount effect.
+export async function countOpenTabGroups(): Promise<number> {
+  let tabs: chrome.tabs.Tab[];
+  try {
+    // The try is the ONLY gate, deliberately. The sibling modules open with a
+    // `typeof chrome === 'undefined' || !chrome.x` guard, and one here would
+    // be unreachable decoration: a missing `chrome` or `chrome.tabs` throws on
+    // this very line and lands in the catch below with the same result. It was
+    // written, mutation-tested, found to be un-killable, and removed rather
+    // than left as a line no test can hold to account.
+    tabs = await chrome.tabs.query({});
+  } catch {
+    return 0;
+  }
+
+  const groupIds = new Set<number>();
+  for (const tab of tabs) {
+    // `undefined` is not a group id. Chrome types groupId as required, but a
+    // tab that arrives without one must not become a group of its own -- the
+    // Set would otherwise take `undefined` as a distinct key.
+    if (tab.groupId === undefined) continue;
+    if (tab.groupId === UNGROUPED) continue;
+    groupIds.add(tab.groupId);
+  }
+
+  return groupIds.size;
+}

--- a/src/utils/functions/tabGroupsOffer.ts
+++ b/src/utils/functions/tabGroupsOffer.ts
@@ -1,0 +1,43 @@
+import { hasTabGroupsPermission } from './permissions';
+import { countOpenTabGroups } from './liveTabGroups';
+import { asPartialSettings, loadFromLocalStorage } from './local';
+import { SettingsData } from '../../redux/slices/settingsDataStateSlice';
+
+// KAN-74. Should the popup offer to turn on tab group support, and for how
+// many groups?
+//
+// Returns the number of live tab groups to offer for, or null to stay quiet.
+// A number rather than a boolean because the offer's copy names the count, and
+// splitting "whether" from "how many" would let the two disagree.
+//
+// Lives outside App.tsx because it is a decision, not a rendering concern:
+// here it can be tested against a chrome fake and a seeded localStorage
+// without mounting the whole app (and its Firebase auth subscription) to find
+// out whether a modal would open.
+//
+// The offer fires on EVERY popup open that passes these checks. There is no
+// interval and no cap by design -- the escalating opt-out inside the modal is
+// what bounds it. Note that nothing here consults a stored "granted" flag:
+// hasTabGroupsPermission() is the only source of truth, so a user who granted
+// and later revoked cannot be re-armed by a stale boolean.
+export async function shouldOfferTabGroups(
+  isRateAndReviewModalShowing: boolean
+): Promise<number | null> {
+  // One modal at a time. The rate request loses nothing by winning here: it is
+  // interval-gated and rare, while this offer returns on the very next open.
+  if (isRateAndReviewModalShowing) return null;
+
+  const { isNeverAskAgainForTabGroups = false } =
+    asPartialSettings<SettingsData>(loadFromLocalStorage('settingsData'));
+  if (isNeverAskAgainForTabGroups) return null;
+
+  if (await hasTabGroupsPermission()) return null;
+
+  // Last, because it is the only check that costs a chrome round trip. It
+  // works WITHOUT the permission -- the premise of the whole feature, see
+  // liveTabGroups.ts.
+  const openGroups = await countOpenTabGroups();
+  if (openGroups === 0) return null;
+
+  return openGroups;
+}


### PR DESCRIPTION
KAN-11 ships tab groups behind an optional permission whose only switch is buried in Settings → Data Management. Nothing tells anyone it exists.

The cost lands hardest on **new** users: they save a window with groups, the groups vanish, and nothing indicates a toggle would have kept them.

When the popup opens and the user has tab groups open **right now**, offer to turn it on.

> **Save your tab groups**
> Tab Keeper can't save the names and colours of your 2 tab groups without permission.
> **[ ✓ Enable tab group support ]** · Not now

## Detection works without the permission, which is what makes this buildable

`Tab.groupId` is **not** privileged. Only a group's title and colour need the grant; membership is free.

Measured by revoking mid-session and re-querying: `contains({tabGroups})` returned `false` while `chrome.tabs.query` still reported `groupId: 801893355` on the grouped tabs. Re-confirmed in this branch's own browser run — two real groups created, `hasTabGroupsPermission: false`, both ids visible.

`countOpenTabGroups()` counts distinct non-`(-1)` `groupId`s across **all** windows, and returns `0` on any failure — "could not tell" and "none" lead to the same correct behaviour, and rejecting would put an unhandled rejection in App's mount effect.

It deliberately does **not** read `chrome.tabGroups.TAB_GROUP_ID_NONE`. That namespace is `undefined` while ungranted — precisely the case this module exists for — so the constant is a local `-1`.

## It fires on every qualifying open, and the escape hatch is what bounds it

No interval, no cap. The escalation is the limit: one answer reveals **"Don't ask again"**, and only that stops it for good.

Without that hatch this would be a dismiss trap — a user who keeps tab groups open and doesn't want the permission would see a full-scrim modal on every open forever, with closing their tab groups as the only remedy.

**The CTA counts as an answer, not just "Not now".** Found by pressing Deny on a real Chrome prompt: a native denial is the strongest refusal available and still left the flag unset, so an Enable-then-Deny user never unlocked the opt-out — an unbounded prompt with no exit, which is exactly what the hatch exists to prevent. The flag is therefore `isTabGroupsPromptAnsweredOnce`, not `…DismissedOnce`; the old name would have been a lie.

`rememberAnswered()` runs **before** `requestTabGroupsPermission()`, because the request can destroy the popup synchronously and a write queued after it may never land. Verified: the popup was destroyed by the prompt and the flag still persisted.

## Nothing mirrors the grant

`hasTabGroupsPermission()` stays the only source of truth. A stored "we already asked" boolean would let a revoke from `chrome://extensions` — the most explicit "no" a user can give — be undone by stale state.

Verified: revoke, reopen, the offer returns. And the inverse, with the opt-out flag *absent*, the grant alone suppresses it.

`chrome.permissions.request()` is never awaited, per KAN-11's measured behaviour. Pinned by a test using the fake's `requestNeverSettles`, with a settling control beside it so the assertion is about *not waiting* rather than about closing.

## Two modals, one screen

`RateAndReviewModal` and this one both open from `App.tsx`'s mount effect, and both are `position: fixed; z-index: 999` — so if both opened they would stack by DOM order with no defined winner.

Coordination is a value handoff:

```ts
void offerTabGroupsPermission(askUserToRateAndReview());
```

`askUserToRateAndReview()` becomes `boolean`. It has to be a value: that check is synchronous while this one is async, so the async side could not otherwise observe the sync dispatch reliably. **The rate request wins** — it is interval-gated and rare, while this returns on the very next open.

`shouldOfferTabGroups()` lives outside `App.tsx` so the decision can be tested against a chrome fake and a seeded localStorage without mounting the app and its Firebase subscription.

## Two defects found by running it, invisible to jsdom

`NormalLabel` is `white-space: nowrap`, so the body sentence ran off **both edges** of the 500px card. Visible only in a screenshot. The body is a `<p>` now.

`NormalLabel` is also a bare `<div onClick>`. The live accessibility tree showed `StaticText "Not now"` — a control no keyboard user can reach, the exact defect class KAN-66/67/68 went through this codebase to remove:

```
before   uid=1_53 button     "Turn on"
         uid=1_54 StaticText "Not now"      ← clickable, unreachable
after    uid=2_53 button     "Enable tab group support"
         uid=2_54 button     "Not now"
```

Both dismissals are real `<button>`s, pinned by a `getByRole` test that fails against the old markup. `RateAndReviewModal` has the same defect; filed as **KAN-75** rather than fixed here, to keep this reviewable.

## Evidence

- **610 unit tests** across 71 files, up from 573/67. `tsc` 0, `typecheck:e2e` 0, `eslint src e2e` 0 errors / 25 warnings — the pre-branch baseline exactly. Playwright **28/28**, including `golden-path.spec.ts:180`, the KAN-11 ungranted-path test.
- **19 mutations applied, all killed.** Reverting the `-1` exclusion, the distinct-group `Set`, the all-windows query, the `try/catch`, each of the four suppression conditions, the escalation gate, the non-awaited request, the plural ternary, the null render guard, the keyboard-reachable markup, the answered-on-CTA fix, and the App handoff each fails its own named test on its own assertion.
- **Two mutations initially survived, and each led to a real fix rather than a weakened assertion.**
  - A `currentWindow` query the fake could not distinguish. The fake's own comment warned that a multi-window test depending on that distinction "must not use this fake until that is fixed" — this was that test, passing against a deliberately broken implementation. Widened in its own commit, scoped to window-consistent seeds; unscoped it fails 11 existing tests.
  - A redundant `typeof chrome === 'undefined'` guard that the surrounding `try/catch` already subsumed. Deleted rather than kept as a line no test can hold to account.
- **The App-level handoff is tested.** `modalCoordination.test.tsx` mounts the real `App` with Firebase stubbed and asserts that a winning surface suppresses the others. Hardcoding the handoff to `false` — which every other test in the suite passes against — is caught here.

### Live browser verification

On the built artifact, with the change confirmed present in the bundle first, including a **fresh install** and both **Allow** and **Deny**.

| step | result |
|---|---|
| fresh install, 0 sessions, 2 groups open | offer shown on the very first open, no opt-out link |
| "Not now" → reopen | offer returns, now with "Don't ask again" |
| "Don't ask again" → reopen | suppressed |
| control: clear only that flag | offer returns — so the flag caused it |
| Allow | granted; `chrome.tabGroups` live with real titles and colours |
| reopen after Allow | suppressed with the opt-out flag **absent** — the grant alone |
| revoke → reopen | offer returns; no stored granted mirror |
| **Deny** | ungranted, offer returns, no crash, no unhandled rejection |
| CTA with the request unsettled | modal already closed — it does not await |

The fresh install also confirmed the optional permission does **not** survive uninstall/reinstall, and settled the design question empirically: with zero sessions the right pane renders nothing and the left pane shows only "Empty", so the inline session-pane banner originally proposed would have been invisible to exactly the user it was meant for.

Also measured, and worth recording: after a **programmatic** `permissions.remove()`, a later `request()` re-granted with **no prompt** — Chrome kept the earlier consent. Whether a `chrome://extensions` UI revoke behaves the same is untested and not claimed.

## i18n

Six keys across all ten locales (101 → 107), enforced by `keyCoverage.test.ts`. Plurals use the paired `…One`/`…Other` keys picked by a ternary, matching `FocusConfirmModal`; this repo uses no i18next plural suffixes. The `ru` value keeps the count parenthetical because Russian declines the noun on the number, which is the same technique `FocusConfirmBodyOther` already uses.

The CTA has no fixed width: `fr` renders it as "Activer la prise en charge des groupes d'onglets", which the initial 217px would have clipped.

## Scope

Editing groups inside a saved session, and promoting `tabGroups` from optional to required, are both out.

Higher adoption is what would eventually make that promotion possible without disabling the install base — a user who already granted it optionally has already accepted the warning, so an update promoting it should present nothing new. **That is untested** and needs confirming on a real Web Store update before anyone bets on it.

## Base branch

Targets `feat/kan-11-chrome-tab-groups`, not `main` — #173 is still open. Rebase onto `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
