### PR TITLE
Defer the icon cursor to its clickable ancestor (KAN-76)

### DIFF
--- a/e2e/cursor-affordance.spec.ts
+++ b/e2e/cursor-affordance.spec.ts
@@ -1,0 +1,218 @@
+import type { BrowserContext, Locator, Page } from '@playwright/test';
+
+import { test, expect } from './fixtures/extension';
+import { buildContainer, buildSession, seedSessions } from './fixtures/seed';
+
+// KAN-76. Every assertion here reads the cursor from the element that is
+// really under the pointer, via elementFromPoint, rather than from the control
+// the test names.
+//
+// That is the whole defect. Icon painted `cursor: default` on itself whenever
+// it did not own its own onClick, and an Icon that does not own its onClick is
+// usually sitting inside something that does -- a Button or a ClickableRow,
+// both of which render a real <button> carrying `cursor: pointer`. The child
+// won, so the button advertised a pointer it never showed.
+//
+// A child overriding its parent is invisible to `toHaveCSS` on the button
+// (which reports the button's own declaration, still `pointer`, still passing)
+// and invisible to jsdom, which does not resolve inheritance for `cursor` at
+// all. Sampling the hit target is the only probe that can see it.
+
+const RESEARCH = buildSession({
+  tabGroupId: 'session-research',
+  title: 'Research',
+});
+
+async function openPopup(
+  context: BrowserContext,
+  extensionId: string
+): Promise<Page> {
+  await seedSessions(context, buildContainer([RESEARCH]));
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/index.html`);
+  return page;
+}
+
+/** The cursor the browser would actually paint at a viewport point. */
+async function cursorAt(page: Page, x: number, y: number): Promise<string> {
+  return page.evaluate(
+    ([px, py]) => {
+      const el = document.elementFromPoint(px, py);
+      return el === null
+        ? '<nothing under the pointer>'
+        : getComputedStyle(el).cursor;
+    },
+    [x, y]
+  );
+}
+
+async function cursorAtCentreOf(page: Page, target: Locator): Promise<string> {
+  const box = await target.boundingBox();
+  if (box === null) throw new Error('the target has no layout box');
+  return cursorAt(page, box.x + box.width / 2, box.y + box.height / 2);
+}
+
+// Material Symbols renders its glyph as ligature TEXT, so the icon inside a
+// control is the span whose text content is the glyph name.
+function glyphOf(control: Locator): Locator {
+  return control.locator('span.material-symbols-outlined').first();
+}
+
+// Probes the glyph specifically, not the control's centre. On an icon-only
+// button the two coincide, but on an icon+text button the centre lands on the
+// text -- which was never broken -- so a centre probe would pass against the
+// defect. "Backup App Data to File" below is the case that proves this matters.
+async function cursorOverIconOf(page: Page, control: Locator): Promise<string> {
+  return cursorAtCentreOf(page, glyphOf(control));
+}
+
+async function openSettingsCategory(page: Page, name: string): Promise<void> {
+  await page.getByRole('button', { name: 'Settings' }).click();
+  await expect(page.getByText('Themes')).toBeVisible();
+  await page.getByRole('button', { name, exact: true }).click();
+}
+
+test.describe('clickable controls show a pointer over their icon (KAN-76)', () => {
+  // CONTROL, positive. An Icon that owns its own onClick was never affected,
+  // and reads `pointer` today. If this fails, the probe is broken rather than
+  // the app: it is the proof that cursorOverIconOf can observe a pointer at
+  // all, without which every assertion below is unfalsifiable.
+  test('CONTROL: an Icon that owns its onClick already shows a pointer', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+
+    const settings = page.getByRole('button', { name: 'Settings' });
+    expect(await cursorOverIconOf(page, settings)).toBe('pointer');
+  });
+
+  // CONTROL, negative. The other half: proof that the probe can return
+  // something OTHER than `pointer`, so a `pointer` result elsewhere is a
+  // measurement and not a constant.
+  //
+  // It is also the regression this fix must not cause. Undo is genuinely
+  // unavailable on a freshly opened popup -- there is no history to undo --
+  // and a control that is unavailable must not advertise a click. Deferring to
+  // the ancestor is only correct if it keeps saying "not clickable" here,
+  // where the ancestor is a plain layout div.
+  test('CONTROL: a disabled Icon does not show a pointer', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+
+    const undo = page.getByRole('button', { name: 'Undo' });
+    // Asserted, not assumed. If Undo were enabled at this moment the cursor
+    // assertion below would be testing the wrong state and would pass for the
+    // wrong reason.
+    await expect(undo).toHaveAttribute('aria-disabled', 'true');
+
+    expect(await cursorOverIconOf(page, undo)).not.toBe('pointer');
+
+    // The value this actually resolves to is `auto`, not the `default` it was
+    // before, because the ancestor here is a plain layout div. The two paint
+    // the same arrow only because the glyph is not selectable -- `auto` over
+    // selectable text is an I-beam. That premise is the reason the change is
+    // safe, so it is asserted rather than reasoned about.
+    await expect(glyphOf(undo)).toHaveCSS('user-select', 'none');
+  });
+
+  // Pattern 1: Button always passes `disable={true}` to its inner Icon, so
+  // every one of the icon-bearing buttons in the app was affected. These two
+  // are the worst case -- `padding: 0` means the icon fills the button, so
+  // there was no live pixel anywhere on the control.
+  //
+  // These are the RENDERED names, not the i18n keys the call sites pass.
+  // `en` re-maps some of its own keys, and this pair is one of them:
+  // UserInputContainer passes `t('Save every open window as a session')`,
+  // which en/translation.json:11 maps to "Save all open windows as a session".
+  // Written from the key, this locator matches nothing and the test fails as
+  // "element(s) not found" -- which looks like a broken control rather than a
+  // broken locator. src/tests/locales/verbSplit.test.ts guards the mapping
+  // itself; this comment is here so the next person does not re-derive it from
+  // a confusing failure.
+  for (const name of [
+    'Save current window as a session',
+    'Save all open windows as a session',
+  ]) {
+    test(`"${name}" shows a pointer over its icon`, async ({
+      context,
+      extensionId,
+    }) => {
+      const page = await openPopup(context, extensionId);
+      const button = page.getByRole('button', { name });
+
+      // The button's own declaration was never the problem, and stating that
+      // here is what makes the failure legible: the two lines disagreeing is
+      // precisely the bug.
+      await expect(button).toHaveCSS('cursor', 'pointer');
+      expect(await cursorOverIconOf(page, button)).toBe('pointer');
+    });
+  }
+
+  // Pattern 2: a bare <Icon> with no onClick at all, inside a ClickableRow.
+  // Unrelated to `disable`, same single line of CSS. This is the one the
+  // ticket's first scope missed.
+  test('the settings back row shows a pointer over its icon', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+    await page.getByRole('button', { name: 'Settings' }).click();
+    await expect(page.getByText('Themes')).toBeVisible();
+
+    const back = page.getByRole('button', { name: 'Go back' });
+    await expect(back).toHaveCSS('cursor', 'pointer');
+    expect(await cursorOverIconOf(page, back)).toBe('pointer');
+  });
+
+  // The icon+text geometry, which is where the defect was most obviously
+  // wrong to a user: the cursor changed as the pointer crossed a single
+  // button. The text half is asserted alongside the icon half precisely
+  // because the text half always passed -- it is what the icon half should
+  // have matched all along, and probing only the centre would have found
+  // nothing to report.
+  test('an icon+text button shows a pointer over BOTH halves', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+    await openSettingsCategory(page, 'Data Management');
+
+    const button = page.getByRole('button', {
+      name: 'Backup App Data to File',
+    });
+    const label = button.getByText('Backup App Data to File');
+
+    expect(await cursorAtCentreOf(page, label)).toBe('pointer');
+    expect(await cursorOverIconOf(page, button)).toBe('pointer');
+  });
+
+  // The other half of the fix, which the ticket asked to be verified rather
+  // than assumed: an icon that is genuinely decorative, in a container nobody
+  // can click, must NOT start advertising a click.
+  //
+  // `cloud_done` sits in a plain layout div in Account/LoggedIn. Deferring to
+  // the ancestor is only the right answer if the ancestor's answer is right
+  // here too -- if this ever reads `pointer`, `inherit` is reaching a
+  // clickable ancestor that this icon has no business inheriting from.
+  test('a decorative icon in a non-clickable container shows no pointer', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+    await openSettingsCategory(page, 'Sync & Privacy');
+
+    // Which of the two Account panes renders is asserted, not assumed: the
+    // fixture context is signed IN, so this is LoggedIn/`cloud_done`, and the
+    // sibling NotLoggedIn/`cloud_off` is unreachable here. Without this line a
+    // wrong glyph name would surface as an unexplained locator timeout.
+    await expect(page.getByText('Cloud Sync Active')).toBeVisible();
+    const decorative = page
+      .locator('span.material-symbols-outlined')
+      .filter({ hasText: /^cloud_done$/ });
+
+    expect(await cursorAtCentreOf(page, decorative)).not.toBe('pointer');
+  });
+});

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -118,13 +118,32 @@ const Icon: React.FC<IconProps> = ({
   // edited the tab order (KAN-68).
   const isActionable = Boolean(onClick) && !disable;
 
+  // The non-actionable branch below is `inherit`, not `default`, and the
+  // distinction is KAN-76. `isActionable` answers "does this icon handle its
+  // own click?" -- a fact about this element. The cursor asks "is the thing
+  // under the pointer clickable?" -- a fact about the whole subtree, which an
+  // icon cannot see. An icon without its own onClick is usually sitting inside
+  // something that does have one: Button passes `disable` to its inner Icon at
+  // every one of its call sites, and a bare Icon inside a ClickableRow has no
+  // onClick by design. Both render a real <button> carrying `cursor: pointer`,
+  // and `default` here painted over it from the inside.
+  //
+  // `inherit` is the icon declining to answer a question it cannot answer.
+  // Inside a button it resolves to pointer; for a disabled Undo/Redo sitting
+  // in a plain layout div it resolves to the div's `auto`, which paints the
+  // same arrow `default` did -- the container sets `user-select: none`, so
+  // `auto` never becomes an I-beam here.
+  //
+  // Since `cursor` is an inherited property, this is equivalent to dropping
+  // the declaration entirely. It is spelled out so the next person to read
+  // this line sees a decision rather than an omission to fill in.
   const containerStyle = css`
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
     padding: 4px;
-    cursor: ${isActionable ? 'pointer' : 'default'};
+    cursor: ${isActionable ? 'pointer' : 'inherit'};
     user-select: none;
     transition: background-color 0.2s;
     background-color: ${backgroundColor};


### PR DESCRIPTION
Several clickable controls showed the default arrow on hover instead of the hand: the search submit button, both save-session buttons, the three About-page buttons, and the back rows. `Button` and `ClickableRow` both already set `cursor: pointer`. The pointer was being painted over from the inside, by the icon.

```
cursor: ${isActionable ? 'pointer' : 'default'};   →   'inherit'
```

`isActionable` answers *"does this icon handle its own click?"* — a fact about this element. The cursor asks *"is the thing under the pointer clickable?"* — a fact about the whole subtree, which an icon cannot see. An icon that does not handle its own click is usually sitting inside something that does, and there it asserted `default` over its own clickable ancestor.

`inherit` is the icon declining to answer a question it cannot answer.

## Two ways in, one line out

An `Icon` becomes non-actionable for two unrelated reasons, and both were affected:

1. `disable={true}` — `Button` passes this to its inner Icon at every call site (`Button.tsx:89`), so this reaches all 11 `iconType=` sites, including the modal KAN-74 just shipped.
2. **No** `onClick` at all — a bare `<Icon>` inside a `ClickableRow`. The back rows and the window/tab rows.

Both reduce to the one line, which is why the fix is in `Icon` and not in `Button`.

The worst case is the two save buttons: `padding: 0` lets the icon fill the button, so there was no live pixel anywhere on the control. On icon+text buttons the cursor changed as the pointer crossed a single button.

## The measurement is the point

A child overriding its parent is invisible to `toHaveCSS` on the button — the button's own declaration was always `pointer`, and still passes — and invisible to jsdom, which does not resolve inheritance for `cursor` at all. A jsdom assertion here would be green against the broken code.

Every assertion samples the element actually under the pointer, via `elementFromPoint`, at the **glyph** rather than the control's centre. On an icon-only button the two coincide; on an icon+text button the centre lands on the text, which was never broken, so a centre probe would have found nothing to report.

## Two claims on the ticket did not survive being checked

**Disabled Undo resolves to `auto`, not `default`.** The ticket predicted `inherit` would leave it "`default`, unchanged". Undo's ancestor is a plain layout div that sets no cursor, so `inherit` walks to the root. It paints the same arrow, but only because the glyph is not selectable — `auto` over selectable text is an I-beam. That premise was an inference, so it is now an assertion:

```ts
await expect(glyphOf(undo)).toHaveCSS('user-select', 'none');
```

A test written to the ticket's prediction would have failed against the correct fix.

**`inherit` does not beat deleting the rule.** The ticket argued it did. `cursor` is an inherited property, so `cursor: inherit` and no declaration compute identically — which is also why the existing `NON_INTERACTIVE_ICON_STYLE` (`cursor: unset`) already behaved this way and is unaffected. The reason to keep the line is legibility, not behaviour: it leaves a decision where the wrong answer used to be.

## The half that had to stay true

An icon that is genuinely decorative, in a container nobody can click, must not start advertising a click. Checked rather than assumed, per the ticket:

| call site | ancestor | before | after |
| --- | --- | --- | --- |
| `Account/LoggedIn.tsx:38` `cloud_done` | plain div | `default` | non-pointer ✓ |
| `MenuContainer.tsx:72` disabled Undo | plain div | `default` | non-pointer ✓ |
| `WindowEntryContainer.tsx:273` favicon | `ClickableRow` | `default` | `pointer` ✓ |
| `HeroContainerRightSettings.tsx:28` | plain div | `unset` | unchanged |

`MenuContainerSettings.tsx:43`'s `cursor: pointer` is on the sibling `NormalLabel`, not the Icon — which is exactly why that control measured `default` at the icon and `pointer` at the text. A local workaround of the symptom, now redundant, left alone.

## Evidence

`e2e/cursor-affordance.spec.ts`, 7 specs, against the built artifact in real Chrome. Playwright **35/35**, up from 28/28.

Both controls are load-bearing. The positive one (an Icon that owns its `onClick`) proves the probe can observe `pointer` at all; the negative one (disabled Undo) proves it can return something else, so a `pointer` result elsewhere is a measurement rather than a constant.

**Two mutations, each killing a different half:**

| mutation | result |
| --- | --- |
| revert `inherit` → `default` | **4 failed, 3 passed** — the four defect specs go red; both controls and the decorative-icon spec stay green |
| unconditional `cursor: pointer` | **2 failed, 5 passed** — kills the disabled-Undo control and the decorative-icon spec |

The second is the one that matters for review: the obvious shortcut fix cannot pass this suite.

Each mutation was confirmed present in `dist/` before its result was believed — a failed build silently retests the old bundle.

Gates: **610 unit tests** across 71 files, `tsc --noEmit` 0, `typecheck:e2e` 0, `eslint src e2e` 0 errors / 25 warnings — the pre-branch baseline exactly. Prettier clean.

## Not claimed

No manual hover in a dev Chrome profile. The automated probe is the ticket's own prescribed reproduction and is mutation-tested, which is stronger evidence than an eyeball, but it is not the same thing as watching the cursor change.

`e2e/README.md` fails `prettier --check` on clean `main` as well. Pre-existing, untouched here.

## Scope

Affordance and polish, not compliance. `Icon.tsx:148` sets `aria-hidden` whenever there is no `onClick`, so the icon and its `aria-disabled` never reach the accessibility tree — these render as plain enabled buttons with correct names. `cursor: pointer` is not a WCAG success criterion. Stated so nobody re-files it as an accessibility defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
