### PR TITLE
Make the rate prompt's dismissals real buttons (KAN-75)

### DIFF
--- a/e2e/a11y-controls.spec.ts
+++ b/e2e/a11y-controls.spec.ts
@@ -1,7 +1,12 @@
 import type { BrowserContext, Page } from '@playwright/test';
 
 import { test, expect } from './fixtures/extension';
-import { buildContainer, buildSession, seedSessions } from './fixtures/seed';
+import {
+  buildContainer,
+  buildSession,
+  seedSessions,
+  seedSettings,
+} from './fixtures/seed';
 
 // These specs assert on ROLE plus accessible name, never on the raw
 // `[aria-label=...]` attribute. That distinction is the whole point of
@@ -35,6 +40,27 @@ async function openPopup(
   const page = await context.newPage();
   await page.goto(`chrome-extension://${extensionId}/index.html`);
   return page;
+}
+
+const RATE_PROMPT_BODY = 'Please consider helping me out with a good review!';
+
+// The rate-and-review prompt is gated entirely on localStorage (App.tsx:137):
+// installed more than a day ago, never rated, never opted out, and not asked
+// in the last three days. Seeding those opens it on the first render.
+//
+// `extensionInstalledTime` is a NUMBER of milliseconds, not a date string --
+// see seedSettings, where getting that wrong fails silently as a modal that
+// never appears.
+async function openRatePrompt(
+  context: BrowserContext,
+  extensionId: string
+): Promise<Page> {
+  await seedSettings(context, {
+    extensionInstalledTime: Date.now() - 2 * 24 * 60 * 60 * 1000,
+    // Reveals the second dismissal, which is earned rather than offered.
+    isSkippedUserReviewOnce: true,
+  });
+  return openPopup(context, extensionId);
 }
 
 test.describe('accessible controls', () => {
@@ -340,6 +366,75 @@ test.describe('controls are reachable by keyboard', () => {
     await page.getByRole('button', { name: 'Delete', exact: true }).focus();
 
     await expect(actions).toHaveCSS('opacity', '1');
+  });
+
+  // KAN-75. RateAndReviewModal rendered both dismissals as a NormalLabel with
+  // an onClick -- a bare `<div onClick>`, so neither took a tab stop nor
+  // reached the accessibility tree as a control. The modal has no Escape
+  // handler and no close affordance, so a keyboard-only user could reach the
+  // CTA and then had no way at all to decline it.
+  //
+  // These run in a real browser rather than only in jsdom because the tab-order
+  // walk is the assertion that actually matters. A role query proves the markup
+  // is a button; only walking from <body> proves a keyboard user can arrive at
+  // it -- `locator.focus()` succeeds on a tabindex=-1 element, per tabOrderNames
+  // above.
+  test('the rate prompt dismissals are reachable by Tab (KAN-75)', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openRatePrompt(context, extensionId);
+    await expect(page.getByText(RATE_PROMPT_BODY)).toBeVisible();
+
+    const names = await tabOrderNames(page, 30);
+
+    expect(names).toContain('Maybe Later');
+    expect(names).toContain('Never Remind Again');
+  });
+
+  test('the rate prompt dismissals are buttons with accessible names (KAN-75)', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openRatePrompt(context, extensionId);
+    await expect(page.getByText(RATE_PROMPT_BODY)).toBeVisible();
+
+    await expect(page.getByRole('button', { name: 'Maybe Later' })).toHaveCount(
+      1
+    );
+    await expect(
+      page.getByRole('button', { name: 'Never Remind Again' })
+    ).toHaveCount(1);
+  });
+
+  // The body sentence used to carry its own onClick, opening the Web Store --
+  // an invisible click target, equally unreachable, duplicating the CTA right
+  // beneath it. It is body copy now.
+  //
+  // Asserted by CLICKING it, not by querying its role. A role query cannot see
+  // this defect at all: a `<div onClick>` is not a button and a `<p>` is not a
+  // button either, so `getByRole` returns zero against both the broken and the
+  // fixed markup. Written that way this test passed against the defect --
+  // confirmed by running it against the reverted component.
+  //
+  // The observable difference is that the old handler called cleanUp(), which
+  // closes the modal. So: click the sentence, and the modal must still be
+  // there.
+  test('the rate prompt body is not a click target (KAN-75)', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openRatePrompt(context, extensionId);
+    await expect(page.getByText(RATE_PROMPT_BODY)).toBeVisible();
+
+    await page.getByText(RATE_PROMPT_BODY).click();
+
+    await expect(page.getByText(RATE_PROMPT_BODY)).toBeVisible();
+    // The positive control for that assertion: the CTA beside it DOES close
+    // the modal, so "still visible" above is a property of the body copy
+    // rather than of a modal that cannot be dismissed at all.
+    await page.getByRole('button', { name: 'Rate this extension' }).click();
+    await expect(page.getByText(RATE_PROMPT_BODY)).toBeHidden();
   });
 
   // KAN-67. `focusableButton` had no default, so `tabIndex={onClick &&

--- a/e2e/fixtures/seed.ts
+++ b/e2e/fixtures/seed.ts
@@ -14,23 +14,47 @@ export {
 // Sessions live in localStorage under `tabContainerData`; only the device id
 // lives in chrome.storage.sync. For a signed-out run this is the whole seeding
 // surface.
-//
-// addInitScript, not page.evaluate: the popup reads localStorage during its
-// first render, so anything written after navigation is already too late. This
-// must therefore be called BEFORE context.newPage().
 export async function seedSessions(
   context: BrowserContext,
   container: TabMasterContainer = buildContainer()
 ): Promise<void> {
+  await seedLocalStorage(context, 'tabContainerData', container);
+}
+
+/**
+ * Seeds `settingsData`, which is what gates the rate-and-review prompt.
+ *
+ * Note `extensionInstalledTime` must be a NUMBER of milliseconds, not a date
+ * string: `isValidDate` (`local.ts:12`) only accepts `typeof param ===
+ * 'number'`, so a plausible-looking ISO string is treated as "never
+ * installed", and App silently stamps a fresh install time and declines to
+ * prompt. A spec seeded that way never opens the modal and reads as a missing
+ * control rather than a bad fixture.
+ */
+export async function seedSettings(
+  context: BrowserContext,
+  settings: Record<string, unknown>
+): Promise<void> {
+  await seedLocalStorage(context, 'settingsData', settings);
+}
+
+// addInitScript, not page.evaluate: the popup reads localStorage during its
+// first render, so anything written after navigation is already too late. This
+// must therefore be called BEFORE context.newPage().
+async function seedLocalStorage(
+  context: BrowserContext,
+  key: string,
+  value: unknown
+): Promise<void> {
   await context.addInitScript(
-    ([key, value]: [string, string]) => {
+    ([k, v]: [string, string]) => {
       try {
-        window.localStorage.setItem(key, value);
+        window.localStorage.setItem(k, v);
       } catch {
         // A profile with storage blocked would throw here. The assertions that
         // follow fail with a clearer message than this could produce.
       }
     },
-    ['tabContainerData', JSON.stringify(container)] as [string, string]
+    [key, JSON.stringify(value)] as [string, string]
   );
 }

--- a/src/components/modals/RateAndReviewModal.tsx
+++ b/src/components/modals/RateAndReviewModal.tsx
@@ -2,7 +2,6 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { css } from '@emotion/react';
 
-import { NormalLabel } from '../common/Label';
 import { useFontFamily } from '../../hooks/useFontFamily';
 import { useThemeColors } from '../../hooks/useThemeColors';
 import { AppDispatch, RootState } from '../../redux/store';
@@ -74,6 +73,31 @@ export const RateAndReviewModal: React.FC<RateAndReviewModalProps> = ({
     cleanUp();
   };
 
+  // KAN-75. Both dismissals are real <button>s, not NormalLabels with onClick.
+  //
+  // NormalLabel renders a bare `<div onClick>`: no role, no tab stop. Measured
+  // in a live popup on the equivalent KAN-74 modal, the dismissal reached the
+  // accessibility tree as StaticText -- a control no keyboard user can reach.
+  // Since this modal has no Escape handler and no close affordance, that left
+  // a keyboard-only user who could reach the CTA with no way to decline it.
+  //
+  // Kept in sync with TabGroupsPermissionModal's identical block by hand. Two
+  // copies rather than a shared component: there are exactly two, and the
+  // abstraction would have to carry the modal's whole visual language to earn
+  // its name.
+  const dismissStyle = css`
+    background: none;
+    border: none;
+    padding: 0;
+    font-family: ${FONT_FAMILY};
+    font-size: 0.9rem;
+    color: ${COLORS.TEXT_COLOR};
+    cursor: pointer;
+    &:hover {
+      text-decoration: underline;
+    }
+  `;
+
   return (
     <div
       css={css`
@@ -115,34 +139,48 @@ export const RateAndReviewModal: React.FC<RateAndReviewModalProps> = ({
         >
           {t('RequestUserReviewHeader')}
         </h2>
-        <NormalLabel
-          value={t(`RequestUserReviewText`)}
-          size="0.9rem"
-          color={COLORS.TEXT_COLOR}
-          onClick={handleRateExtension}
-          style={`cursor: pointer; margin-bottom: 10px;`}
-        />
+        {/* Body copy, not a control. This carried its own
+            `onClick={handleRateExtension}` -- an invisible click target that
+            opened the Web Store, duplicating the CTA directly beneath it and
+            just as unreachable by keyboard. A sentence is not a button, so the
+            handler is gone rather than promoted; the CTA below is the only way
+            to the review page.
+
+            A <p> also escapes NormalLabel's `white-space: nowrap;
+            overflow: hidden`, which silently clips any body copy too long for
+            the 500px card. Nothing clips today -- pt is the longest at 56
+            characters -- but that is a property of the current copy, not of
+            the markup. */}
+        <p
+          css={css`
+            font-family: ${FONT_FAMILY};
+            font-size: 0.9rem;
+            color: ${COLORS.TEXT_COLOR};
+            text-align: center;
+            margin: 0 0 10px 0;
+          `}
+        >
+          {t(`RequestUserReviewText`)}
+        </p>
         <Button
           text={t(`Rate this app`)}
           onClick={handleRateExtension}
           iconType="thumb_up"
           style="width: 217px; margin-bottom: 10px; cursor: pointer;"
         />
-        <NormalLabel
-          value={t(`Maybe Later`)}
-          size="0.9rem"
-          color={COLORS.TEXT_COLOR}
-          onClick={handleRemindLater}
-          style={`cursor: pointer;`}
-        />
+        <button type="button" css={dismissStyle} onClick={handleRemindLater}>
+          {t(`Maybe Later`)}
+        </button>
+        {/* Earned, not offered: the permanent opt-out appears only after the
+            user has already skipped once. */}
         {isSkippedUserReviewOnce && (
-          <NormalLabel
-            value={t(`Never Remind Again`)}
-            size="0.9rem"
-            color={COLORS.TEXT_COLOR}
+          <button
+            type="button"
+            css={dismissStyle}
             onClick={handleNeverAskAgain}
-            style={`cursor: pointer;`}
-          />
+          >
+            {t(`Never Remind Again`)}
+          </button>
         )}
       </div>
     </div>

--- a/src/tests/components/RateAndReviewModal.test.tsx
+++ b/src/tests/components/RateAndReviewModal.test.tsx
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { RateAndReviewModal } from '../../components/modals/RateAndReviewModal';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import { openRateAndReviewModal } from '../../redux/slices/globalStateSlice';
+import { SettingsData } from '../../redux/slices/settingsDataStateSlice';
+import {
+  asPartialSettings,
+  loadFromLocalStorage,
+} from '../../utils/functions/local';
+
+// KAN-75. The modal read its escalation flag straight out of localStorage, so
+// these tests write it there rather than into the store. Cleared each time so
+// one test's dismissal cannot reveal the permanent opt-out in the next.
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+const storedSettings = () =>
+  asPartialSettings<SettingsData>(loadFromLocalStorage('settingsData'));
+
+const seedSettings = (settings: Partial<SettingsData>) =>
+  localStorage.setItem('settingsData', JSON.stringify(settings));
+
+// Opened directly and synchronously before first render -- see
+// renderWithProviders' note on why seedStore must not defer.
+const openModal = (store: { dispatch: (a: unknown) => void }) =>
+  store.dispatch(openRateAndReviewModal());
+
+// handleRateExtension reads `tabs[0].index` from a currentWindow query, so
+// there has to be an active tab or it throws before reaching tabs.create.
+const ACTIVE_TAB = { tabs: [{ active: true, index: 3 }] };
+
+const BODY_TEXT = 'Please consider helping me out with a good review!';
+
+// The RENDERED label, not the i18n key the component passes. `en` re-maps some
+// of its own keys and this is one of them: the call site passes
+// t('Rate this app'), which en/translation.json:89 maps to "Rate this
+// extension". Written from the key, every query below misses and the CONTROL
+// fails -- which reads as a broken harness rather than a broken locator.
+const CTA_TEXT = 'Rate this extension';
+
+describe('RateAndReviewModal', () => {
+  // The control for every role assertion below. The CTA is a real Button and
+  // was never affected, so it is the proof that getByRole can find
+  // a button in this harness at all -- without it, a passing role query
+  // elsewhere would be indistinguishable from a query that never ran.
+  test('CONTROL: the primary CTA is already a real button', async () => {
+    await renderWithProviders(<RateAndReviewModal />, { seedStore: openModal });
+
+    expect(screen.getByRole('button', { name: CTA_TEXT })).toBeTruthy();
+  });
+
+  // Measured in a live popup on the equivalent KAN-74 modal before it was
+  // fixed: rendered as a NormalLabel (a bare `<div onClick>`), the dismissal
+  // reached the accessibility tree as StaticText -- a control no keyboard user
+  // can reach. getByRole is the assertion that says so; getByText passes
+  // against the broken markup either way, which is why the behaviour tests
+  // below deliberately keep using getByText and these two carry the role
+  // check on their own.
+  test('"Maybe Later" is a real button, reachable by keyboard', async () => {
+    await renderWithProviders(<RateAndReviewModal />, { seedStore: openModal });
+
+    expect(screen.getByRole('button', { name: 'Maybe Later' })).toBeTruthy();
+  });
+
+  test('"Never Remind Again" is a real button, reachable by keyboard', async () => {
+    // Earned, not offered: the permanent opt-out renders only after the user
+    // has already skipped once.
+    seedSettings({ isSkippedUserReviewOnce: true });
+
+    await renderWithProviders(<RateAndReviewModal />, { seedStore: openModal });
+
+    expect(
+      screen.getByRole('button', { name: 'Never Remind Again' })
+    ).toBeTruthy();
+  });
+
+  // The third control the ticket did not mention. The body sentence carried
+  // `onClick={handleRateExtension}` -- an invisible click target that opened
+  // the Web Store, duplicating the CTA directly beneath it and equally
+  // unreachable by keyboard.
+  //
+  // Asserted behaviourally rather than by role, because a role query cannot
+  // tell the two states apart: a `<div onClick>` is not a button before the
+  // fix, and a `<p>` is not a button after it, so getByRole is null either way
+  // and would pass against the defect.
+  test('the body sentence is not a click target', async () => {
+    const { chrome } = await renderWithProviders(<RateAndReviewModal />, {
+      seed: ACTIVE_TAB,
+      seedStore: openModal,
+    });
+
+    await userEvent.click(screen.getByText(BODY_TEXT));
+
+    expect(chrome.createdTabs).toEqual([]);
+    // Still open: clicking body copy must not dismiss the modal either.
+    expect(screen.getByText(BODY_TEXT)).toBeTruthy();
+  });
+
+  // The positive control for the assertion above. Without it, an empty
+  // createdTabs proves only that nothing in this harness can ever open a tab.
+  test('CONTROL: the CTA does open the review page', async () => {
+    const { chrome } = await renderWithProviders(<RateAndReviewModal />, {
+      seed: ACTIVE_TAB,
+      seedStore: openModal,
+    });
+
+    await userEvent.click(screen.getByText(CTA_TEXT));
+
+    expect(chrome.createdTabs).toHaveLength(1);
+    expect(chrome.createdTabs[0].url).toContain('/reviews');
+    // Opened next to the active tab, not appended to the end.
+    expect(chrome.createdTabs[0].index).toBe(4);
+  });
+
+  // Swapping a div for a button must not change what the controls DO. These
+  // drive the dismissals by text, so they pass against both markups and pin
+  // the behaviour rather than the role.
+  test('"Maybe Later" records the skip and closes', async () => {
+    await renderWithProviders(<RateAndReviewModal />, { seedStore: openModal });
+
+    await userEvent.click(screen.getByText('Maybe Later'));
+
+    expect(storedSettings().isSkippedUserReviewOnce).toBe(true);
+    expect(screen.queryByText(BODY_TEXT)).toBeNull();
+  });
+
+  test('"Never Remind Again" opts out for good and closes', async () => {
+    seedSettings({ isSkippedUserReviewOnce: true });
+
+    await renderWithProviders(<RateAndReviewModal />, { seedStore: openModal });
+
+    await userEvent.click(screen.getByText('Never Remind Again'));
+
+    expect(storedSettings().isNeverAskAgainToRate).toBe(true);
+    expect(screen.queryByText(BODY_TEXT)).toBeNull();
+  });
+});


### PR DESCRIPTION
`RateAndReviewModal` rendered "Maybe Later" and "Never Remind Again" as a `NormalLabel` with an `onClick`. `NormalLabel` returns a bare `<div onClick>` — no `role`, no `tabIndex` — so both were out of the tab order and reached the accessibility tree as StaticText.

The modal has no Escape handler and no close affordance. A keyboard-only user could reach "Rate this extension" and then had no way at all to decline it.

Both are `<button type="button">` now, styled by the same block `TabGroupsPermissionModal` already uses.

## A third control the ticket did not mention

The body sentence carried its own `onClick={handleRateExtension}` — an invisible click target that opened the Web Store, duplicating the CTA directly beneath it and just as unreachable by keyboard.

A sentence is not a button, so the handler is gone rather than promoted; the CTA below is the only way to the review page. The copy is a `<p>`, which also escapes `NormalLabel`'s `white-space: nowrap; overflow: hidden`. Nothing clips today — `pt` is the longest at 56 characters against a 460px content box — but that is a property of the current copy, not of the markup.

## Tested at two depths, because neither alone is sufficient

The **component** tests pin behaviour and are the only ones that catch the body `onClick`, by asserting the chrome fake recorded no created tab. The **e2e** tests walk the real tab order from `<body>`, which is the only thing that proves reachability — `locator.focus()` succeeds on a `tabindex="-1"` element, so a test that focuses a control directly proves nothing.

Both controls are load-bearing in each layer. The CTA was never affected, so it proves `getByRole` can find a button here at all; without it a passing role query elsewhere is indistinguishable from one that never ran.

## Evidence

**7 component specs**, 617 unit tests across 72 files, up from 610/71.

**3 e2e specs**, Playwright **31/31**, up from 28/28. Driving the prompt needed a `seedSettings` fixture: the gate is entirely localStorage (`App.tsx:137`), and `extensionInstalledTime` must be a **number** of milliseconds — `isValidDate` (`local.ts:12`) only accepts `typeof param === 'number'`, so a plausible ISO string is read as "never installed" and the modal silently never opens. That is documented on the fixture, because it fails as a missing control rather than a bad seed.

**Reverting the component** fails all 3 e2e specs and 3 of the 7 component specs, leaving both controls green.

**Three targeted mutations**, each failing exactly one component spec and no others:

| mutation | kills |
| --- | --- |
| "Maybe Later" back to a `div onClick` | that spec only |
| "Never Remind Again" back to a `div onClick` | that spec only |
| body `onClick` restored | the body spec only |

### One test did not earn its place on the first attempt

The e2e body assertion was originally a role query, and it **passed against the reverted component** — confirmed by running it there. A role query cannot see this defect at all: a `<div onClick>` is not a button, and a `<p>` is not a button either, so the count is zero either way.

It clicks the sentence now and asserts the modal is still open, with the CTA's own click as the positive control — the old handler called `cleanUp()`, so the observable difference is whether the modal survives the click. That version is killed by the revert.

Gates: `tsc --noEmit` 0, `typecheck:e2e` 0, `eslint src e2e` 0 errors / 25 warnings — the pre-branch baseline exactly. Prettier clean.

## Checked, not assumed

`FocusConfirmModal` is flagged on the ticket as needing the same check. It is already clean — `<p>` for its body and real `<button type="button">` for both actions.

One other instance of the pattern exists and is **not** fixed here: `HeroContainerRight.tsx:207` renders the session title as a `NormalLabel` with an `onClick` that starts a rename. Filed separately rather than folded in, because it is materially less severe — "Rename session" is a properly labelled control in the same row and has been keyboard-reachable since KAN-68, so there is a working alternate path. This modal had none.

## Scope

Pre-existing and shipped, not a regression from KAN-74. No Escape handler is added here; the modal is dismissible by keyboard now via its own controls, and a focus trap plus Escape is a broader change across all three modals than this ticket calls for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
