### PR TITLE
Make the session title a real rename control (KAN-77)

### DIFF
--- a/e2e/a11y-controls.spec.ts
+++ b/e2e/a11y-controls.spec.ts
@@ -250,6 +250,22 @@ async function tabOrderNames(page: Page, steps: number): Promise<string[]> {
   return names;
 }
 
+/**
+ * The value of the focused element when it is a text input, or null when the
+ * focus is anywhere else.
+ *
+ * Reads the focused element rather than querying for an input because the home
+ * screen already renders one (the current-window title box), so a bare
+ * `getByRole('textbox')` cannot tell "the rename editor opened" from "an input
+ * exists somewhere on the page".
+ */
+async function focusedInputValue(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const el = document.activeElement;
+    return el instanceof HTMLInputElement ? el.value : null;
+  });
+}
+
 test.describe('controls are reachable by keyboard', () => {
   // KAN-64. Four list rows were `tabIndex={0}` divs with an onClick and no
   // role: they took a tab stop, were exposed as `generic` -- where ARIA
@@ -435,6 +451,156 @@ test.describe('controls are reachable by keyboard', () => {
     // rather than of a modal that cannot be dismissed at all.
     await page.getByRole('button', { name: 'Rate this extension' }).click();
     await expect(page.getByText(RATE_PROMPT_BODY)).toBeHidden();
+  });
+
+  // KAN-77. The last NormalLabel-with-onClick in the codebase: the selected
+  // session's title in the right pane started a rename on click, from a bare
+  // `<div onClick>` with no role and no tab stop.
+  //
+  // Severity was Low rather than KAN-75's, because the "Rename session" icon in
+  // the same row is a labelled control that KAN-68 made keyboard-reachable --
+  // so a keyboard user could always rename, just not by the route a mouse user
+  // takes. The two tests below therefore assert the SHORTCUT now exists; the
+  // icon's own reachability is not what changed.
+  //
+  // Every name here is matched with `exact: true`. Playwright's `name` matches
+  // a SUBSTRING, so "Rename session" would also match this new button, and
+  // "Research" would match it too -- which is precisely the hazard the fixture
+  // comment at the top of this file exists to keep in view.
+  test('the session title is a button that names its action and its target (KAN-77)', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+    await selectSession(page);
+    await expect(
+      page.getByRole('button', { name: 'Morning reading' })
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole('button', {
+        name: 'Rename session: Research',
+        exact: true,
+      })
+    ).toHaveCount(1);
+  });
+
+  test('the session title is reachable by Tab (KAN-77)', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+    await selectSession(page);
+    await expect(
+      page.getByRole('button', { name: 'Morning reading' })
+    ).toBeVisible();
+
+    const names = await tabOrderNames(page, 20);
+
+    expect(names).toContain('Rename session: Research');
+    // The positive control for that assertion: the pencil in the same row was
+    // already reachable, so a walk that found neither would mean the walk
+    // stopped short rather than that the title is unreachable.
+    expect(names).toContain('Rename session');
+  });
+
+  // The outcome the ticket is actually about: a keyboard user renaming by the
+  // same route a mouse user takes. Both keys are asserted because that is what
+  // this file does for every promoted control -- and because Space is the one a
+  // hand-rolled `div role="button"` forgets. ClickableRow renders a real
+  // <button>, so both come from the platform; these tests are what would notice
+  // if it ever stopped doing that.
+  for (const key of ['Enter', 'Space'] as const) {
+    test(`the session title starts a rename with ${key} (KAN-77)`, async ({
+      context,
+      extensionId,
+    }) => {
+      const page = await openPopup(context, extensionId);
+      await selectSession(page);
+      await expect(
+        page.getByRole('button', { name: 'Morning reading' })
+      ).toBeVisible();
+
+      await page
+        .getByRole('button', { name: 'Rename session: Research', exact: true })
+        .focus();
+      // The control: the editor is not open yet, so the assertion below is
+      // about the key press rather than about an input that was already there.
+      // `getByRole('textbox')` would be the wrong probe -- the home screen
+      // already has one -- so this reads the focused element instead, which
+      // also happens to be the stronger claim.
+      expect(await focusedInputValue(page)).toBeNull();
+
+      await page.keyboard.press(key);
+
+      // The editor opens AND takes focus, so the user can type immediately.
+      // Polled rather than read once: the input is mounted by a React state
+      // update that the key press does not wait for.
+      await expect.poll(() => focusedInputValue(page)).toBe('Research');
+    });
+  }
+
+  // Promoting the title to a <button> is a layout change as well as an a11y
+  // one, and this is the part that silently breaks.
+  //
+  // The bare label truncated because a flex item's `min-width: auto` collapses
+  // to zero when its overflow is not `visible`, and NormalLabel sets
+  // `overflow: hidden`. A <button> has `overflow: visible`, so wrapping the
+  // label in one restores `min-width: auto`, the item refuses to shrink below
+  // its content, and a long title runs out under the action block instead of
+  // ellipsing. `min-width: 0` on the ClickableRow is what prevents that.
+  //
+  // Measured rather than eyeballed. Both numbers are assertions, not controls:
+  // deleting `min-width: 0` and rebuilding fails this on `clippedBy`, because
+  // the button grows to its full content width and the ellipsis never engages.
+  //
+  // There is deliberately no control here, and it is safe to go without one:
+  // if the fixture title were ever short enough to fit, `clippedBy` would be 0
+  // and this test would fail loudly rather than pass vacuously.
+  test('a long session title still truncates inside the pane (KAN-77)', async ({
+    context,
+    extensionId,
+  }) => {
+    const LONG_TITLE =
+      'A session title long enough to overflow the right pane by a wide margin';
+    await seedSessions(
+      context,
+      buildContainer([
+        buildSession({ tabGroupId: 'session-long', title: LONG_TITLE }),
+      ])
+    );
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/index.html`);
+
+    await page
+      .getByRole('button', { name: LONG_TITLE, exact: true })
+      .click({ position: { x: 20, y: 20 } });
+    await expect(
+      page.getByRole('button', { name: `Rename session: ${LONG_TITLE}` })
+    ).toHaveCount(1);
+
+    const metrics = await page.evaluate(() => {
+      const button = document.querySelector<HTMLElement>(
+        'button[aria-label^="Rename session: "]'
+      );
+      const parent = button?.parentElement;
+      const span = button?.querySelector('span');
+      if (!button || !parent || !span) return null;
+      return {
+        // > 0 means the text is being clipped, i.e. the title really is longer
+        // than the space it has.
+        clippedBy: span.scrollWidth - span.clientWidth,
+        // > 0 means the button has burst out of the row it sits in.
+        overflowsParentBy: Math.round(
+          button.getBoundingClientRect().right -
+            parent.getBoundingClientRect().right
+        ),
+      };
+    });
+
+    expect(metrics).not.toBeNull();
+    expect(metrics!.clippedBy).toBeGreaterThan(0);
+    expect(metrics!.overflowsParentBy).toBeLessThanOrEqual(0);
   });
 
   // KAN-67. `focusableButton` had no default, so `tabIndex={onClick &&

--- a/src/components/home/rightpane/HeroContainerRight.tsx
+++ b/src/components/home/rightpane/HeroContainerRight.tsx
@@ -6,6 +6,7 @@ import { css } from '@emotion/react';
 
 import Icon from '../../common/Icon';
 import Button from '../../common/Button';
+import ClickableRow from '../../common/ClickableRow';
 import { NormalLabel } from '../../common/Label';
 import { useFontFamily } from '../../../hooks/useFontFamily';
 import { useThemeColors } from '../../../hooks/useThemeColors';
@@ -162,6 +163,18 @@ export default function HeroContainerRight() {
     ${isSearchPanel && 'visibility: hidden;'}
   `;
 
+  // Shared by both non-editing branches so the search-mode label and the
+  // rename button cannot drift apart visually.
+  const titleLabel = (
+    <NormalLabel
+      tooltipText={title}
+      value={title}
+      size="1.125rem"
+      color={COLORS.TEXT_COLOR}
+      style="height: 32px; padding-left: 8px; margin-right: 8px; max-width: 100%;"
+    />
+  );
+
   return (
     <div
       css={containerStyle}
@@ -203,15 +216,34 @@ export default function HeroContainerRight() {
                 }
               `}
             />
+          ) : isSearchPanel ? (
+            // Read-only while searching: the action block and the whole bottom
+            // row are `visibility: hidden` here, so exposing the title as a
+            // button would advertise the one action still on offer in a pane
+            // where nothing else can be done.
+            //
+            // This branch, not handleTabGroupTitleClick's own `!isSearchPanel`
+            // check, is what makes that true now -- the handler is never wired
+            // here at all, so that check no longer has a reachable call site.
+            titleLabel
           ) : (
-            <NormalLabel
-              tooltipText={title}
-              value={title}
-              size="1.125rem"
-              color={COLORS.TEXT_COLOR}
-              style="height: 32px; padding-left: 8px; margin-right: 8px;"
+            // KAN-77. Click-to-rename used to be an onClick on the NormalLabel,
+            // which renders a bare `<div onClick>` -- no role, no tab stop. The
+            // accessible name has to CONTAIN the visible title rather than
+            // replace it (WCAG 2.5.3): a bare "Rename session" would leave a
+            // voice-control user saying "click Research" with nothing to hit.
+            // Same `action + ': ' + target` shape as WindowEntryContainer:269.
+            <ClickableRow
+              ariaLabel={t('Rename session') + ': ' + title}
               onClick={handleTabGroupTitleClick}
-            />
+              // min-width: 0 is load-bearing. A <button> has `overflow:
+              // visible`, so its `min-width: auto` does NOT collapse to zero
+              // the way the bare label's did, and without this the title stops
+              // truncating and runs under the action block.
+              style="display: flex; align-items: center; min-width: 0;"
+            >
+              {titleLabel}
+            </ClickableRow>
           )}
           <div
             css={css`

--- a/src/tests/components/HeroContainerRight.test.tsx
+++ b/src/tests/components/HeroContainerRight.test.tsx
@@ -1,8 +1,12 @@
 import { describe, expect, test } from 'vitest';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import HeroContainerRight from '../../components/home/rightpane/HeroContainerRight';
-import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  renderWithProviders,
+  RenderWithProvidersResult,
+} from '../setup/renderWithProviders';
 import { getPrettyDate } from '../../utils/functions/local';
 import {
   openSearchPanel,
@@ -123,5 +127,105 @@ describe('HeroContainerRight', () => {
     store.dispatch(selectTabContainer('group-1'));
 
     expect(await screen.findByText('Research')).toBeTruthy();
+  });
+
+  // KAN-77. The title carried an onClick on a NormalLabel -- a bare
+  // `<div onClick>` (Label.tsx:50), so click-to-rename existed for a mouse and
+  // did not exist for a keyboard: no tab stop, and announced as static text
+  // rather than as a control.
+  //
+  // The tab-order half of this lives in e2e/a11y-controls.spec.ts, because
+  // `locator.focus()` succeeds on a tabindex=-1 element and jsdom has no tab
+  // order to walk at all. What jsdom CAN settle is the role and the accessible
+  // name, and that is what these assert.
+  describe('the session title as a rename control (KAN-77)', () => {
+    type Store = RenderWithProvidersResult['store'];
+
+    const renderSelected = (seed: (store: Store) => void = () => {}) =>
+      renderWithProviders(<HeroContainerRight />, {
+        seedStore: (store) => {
+          store.dispatch(saveToTabContainerInternal(buildSession()));
+          store.dispatch(selectTabContainer('group-1'));
+          seed(store);
+        },
+      });
+
+    // The control for every role assertion below. The rename Icon owns its own
+    // onClick and so already renders role="button" -- it is the proof that
+    // getByRole can find a control in this harness at all. Without it, a
+    // passing role query below could not be told apart from one that never ran,
+    // and the search-mode negative below would prove nothing.
+    test('CONTROL: the rename icon is already a named button', async () => {
+      await renderSelected();
+
+      expect(
+        await screen.findByRole('button', { name: 'Rename session' })
+      ).toBeTruthy();
+    });
+
+    // The accessible name has to CONTAIN the visible title, not replace it.
+    // A bare "Rename session" here would be a fresh WCAG 2.5.3 failure: the
+    // visible label is the title, and a voice-control user saying "click
+    // Research" would find nothing. Hence the same `action + ': ' + target`
+    // shape WindowEntryContainer.tsx:269 already uses.
+    test('the title is a button whose name says both the action and the session', async () => {
+      await renderSelected();
+
+      expect(
+        await screen.findByRole('button', { name: 'Rename session: Research' })
+      ).toBeTruthy();
+    });
+
+    // Swapping a div for a button must not change what the control DOES.
+    // Driven by text so it passes against both markups, pinning the behaviour
+    // rather than the role: this is the affordance the alternative fix
+    // (deleting the onClick) would have removed.
+    test('clicking the title still starts a rename', async () => {
+      await renderSelected();
+
+      await userEvent.click(await screen.findByText('Research'));
+
+      expect(screen.getByDisplayValue('Research')).toBeTruthy();
+    });
+
+    // In search mode the pane is read-only: the whole action block and the
+    // bottom row are `visibility: hidden`, and handleTabGroupTitleClick already
+    // declined to open the editor. A button that does nothing is worse than no
+    // button, so the title must not be exposed as one here.
+    //
+    // A role query alone cannot see this -- `<div onClick>` and `<div>` are
+    // both non-buttons, so this assertion is green against the pre-fix
+    // component too. It is only meaningful because the test above proves the
+    // same query DOES find a button in the non-search render.
+    test('the title is not a control while the search panel is open', async () => {
+      await renderSelected((store) => {
+        store.dispatch(openSearchPanel());
+        store.dispatch(setSearchInputText('Research'));
+      });
+
+      expect(await screen.findByText('Research')).toBeTruthy();
+      expect(
+        screen.queryByRole('button', { name: /Rename session/ })
+      ).toBeNull();
+    });
+
+    // The behavioural half of the test above, and the one that would survive
+    // someone re-attaching an onClick to the search-mode label: that change is
+    // invisible to a role query, because a `<div onClick>` is not a button.
+    //
+    // Note what protects this. handleTabGroupTitleClick still guards on
+    // `!isSearchPanel`, but that guard is now unreachable -- the search branch
+    // never wires the handler at all -- and deleting it fails nothing. The
+    // render branch is the real protection; this test is what pins it.
+    test('clicking the title does not start a rename while searching', async () => {
+      await renderSelected((store) => {
+        store.dispatch(openSearchPanel());
+        store.dispatch(setSearchInputText('Research'));
+      });
+
+      await userEvent.click(await screen.findByText('Research'));
+
+      expect(screen.queryByDisplayValue('Research')).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
`HeroContainerRight.tsx:207` rendered the selected session's title as a `NormalLabel` carrying an `onClick`. `NormalLabel` returns a bare `<div onClick>` (`Label.tsx:50`) — no `role`, no `tabIndex` — so click-to-rename existed for a mouse and did not exist for a keyboard, and the title reached the accessibility tree as static text rather than as a control.

This is the last instance of that construction in the codebase; KAN-75 fixed the other three.

## Why this one was promoted rather than deleted

KAN-75 deleted its body-copy `onClick` because that handler duplicated a CTA sitting directly beneath it, so nothing was lost. Here there is no equivalent affordance, and clicking a title to rename it is the gesture users expect — deleting it would have removed a real interaction to fix a gap that already had a working alternate path.

The ticket's argument against promoting was a second tab stop for the same action. That does not apply: `HeroContainerRight` is the single selected-session detail pane, not a per-row control, so it costs **one** extra tab stop in the whole popup rather than one per session.

It is a `ClickableRow` now — the real `<button>` KAN-62 built for exactly this shape, which brings the role, the tab order, Enter, Space and the focus ring from the platform.

## The accessible name is the part most easily got wrong

`Rename session: <title>`, composed as `t('Rename session') + ': ' + title` — the same `action + ': ' + target` form `WindowEntryContainer.tsx:269` already uses. No new i18n key; `Rename session` exists in all ten locales.

A bare `aria-label="Rename session"` would have been a **fresh** WCAG 2.5.3 (Label in Name) failure. The visible label is the title, and an accessible name that replaces it leaves a voice-control user saying "click Research" with nothing to hit.

## Search mode keeps the plain label

The action block and the whole bottom row are `visibility: hidden` while searching, so a button there would advertise the only action still on offer in a pane where nothing else can be done.

That render branch, rather than `handleTabGroupTitleClick`'s own `!isSearchPanel` check, is what makes this true now. The handler is not wired in that branch at all, so deleting the check fails nothing — verified. The check is left in place as belt-and-braces, but the comment says which one is load-bearing.

## `min-width: 0` is not cosmetic

A flex item's `min-width: auto` collapses to zero only when its overflow is not `visible`, which is why the bare label truncated: `NormalLabel` sets `overflow: hidden`. A `<button>` has `overflow: visible`, so wrapping the label in one restores the automatic minimum size, the item refuses to shrink below its content, and a long title stops ellipsing and runs out under the action block.

## Evidence

**5 component specs**, 622 unit tests across 72 files, up from 617/72.

**5 e2e specs**, Playwright **43/43**, up from 38/38.

**Reverting the component** fails all 5 e2e specs and 1 of the 5 component specs, leaving the controls green. The tab-order failure is the informative one — it printed `["Open","Switch","Delete","Rename session",…]`, so the walk reached the pencil in the same row and the title genuinely was not in the tab order.

**Two targeted mutations**, each failing exactly one spec:

| mutation | kills |
| --- | --- |
| delete `min-width: 0` | the truncation spec only |
| force the `isSearchPanel` branch off | the search-mode spec only |

Browser-verified end to end: Tab lands on the title with a visible focus ring, Enter opens the rename input already focused, and a long title ellipses inside the pane. Driven with real `Tab` presses rather than `locator.focus()`, because Chrome only paints `:focus-visible` for keyboard-driven focus — a programmatic `focus()` showed no ring at all and would have read as a missing focus indicator.

Gates: `tsc --noEmit` 0, `typecheck:e2e` 0, `eslint src e2e` 0 errors / 25 warnings — the pre-branch baseline exactly. Prettier clean on all three changed files.

### Two probes of mine proved nothing and were replaced

Both would have "confirmed" a mutation reached the built artifact while being insensitive to it. `grep "Rename session: "` never matches, because that string is composed at runtime from `t(...) + ': ' + title`. `grep "align-items:center;min-width:0"` never matches either, because the `style` prop survives minification verbatim, spaces included — the discriminating form is `align-items: center; min-width: 0;` going 1 → 2.

What actually established it each time was the spec going red against the rebuilt bundle, with the bundle hash and size as corroboration.

## Scope

Pre-existing and shipped. Not a regression from KAN-75 or KAN-76. The "Rename session" icon is untouched — it was already a labelled, keyboard-reachable control, and this adds the shortcut beside it rather than replacing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
