### PR TITLE
Give both offer modals one layout, and stop sizing buttons to English (KAN-78)

### DIFF
--- a/e2e/i18n-layout.spec.ts
+++ b/e2e/i18n-layout.spec.ts
@@ -1,0 +1,228 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import type { BrowserContext, Locator, Page, Worker } from '@playwright/test';
+
+import { test, expect } from './fixtures/extension';
+import { buildContainer, seedSessions, seedSettings } from './fixtures/seed';
+
+// Does the UI still fit once it is translated?
+//
+// English is the shortest label in this app for almost every control, so a
+// card sized to the English copy looks fine right up until it ships. This spec
+// renders the tab-groups offer in the widest locale and asserts the CTA label
+// still fits on ONE LINE.
+//
+// One line, specifically -- and that is the whole lesson of this file. A label
+// too long for its button here does not clip and does not overflow: it WRAPS.
+// Measured against a card deliberately shrunk to 300px, `scrollWidth ===
+// clientWidth` (nothing clipped), the button's own height stays 56px, and
+// `document.scrollWidth` never exceeds the viewport. An earlier version of
+// this spec asserted exactly those three things and passed against the broken
+// layout. Only the line count moves: the label's text goes from one line box
+// to two.
+//
+// Counted with a Range over the text rather than `span.getClientRects()`,
+// which returns a single box regardless -- the label is `display: block`, so
+// its own rect covers both lines. A Range over its contents reports one rect
+// per line box, which is the real question being asked.
+//
+// The expected strings are READ FROM THE LOCALE FILES rather than hardcoded,
+// so rewording the copy never touches this spec -- it fails only when the
+// LAYOUT breaks. That is deliberate: the component tests already pin the
+// wording, and duplicating it here would mean two files to edit for every copy
+// change and a spec that goes red for a reason it does not care about.
+//
+// Locale choice is not arbitrary. Measured 2026-09-04 across all ten:
+//   es 404px, fr 397px, de 338px, ru 333px, ja 320px, it 320px,
+//   pt 305px, en 247px, hi 206px, zh 181px   (CTA width, 500px card)
+// so `es` is the binding case at 81% of the card. `hi` is here for a different
+// reason -- Devanagari, to catch a font-fallback or line-height regression
+// that a Latin-script measurement cannot see. `en` is the CONTROL: if it fails
+// too, the harness is broken rather than the translations.
+const LOCALES = ['en', 'es', 'hi'] as const;
+
+function localeStrings(lang: string): Record<string, string> {
+  return JSON.parse(
+    readFileSync(
+      fileURLToPath(
+        new URL(`../public/locales/${lang}/translation.json`, import.meta.url)
+      ),
+      'utf8'
+    )
+  );
+}
+
+/**
+ * Puts two real Chrome tab groups in the browser and returns how many exist.
+ *
+ * Made through the extension's own service worker, not faked: the offer is
+ * gated on countOpenTabGroups(), which reads `Tab.groupId` via
+ * chrome.tabs.query. That field is NOT privileged -- it arrives whether or not
+ * the optional tabGroups permission is granted, which is the premise of the
+ * whole feature (see liveTabGroups.ts). Creating them for real is what proves
+ * that still holds.
+ */
+async function createTabGroups(serviceWorker: Worker): Promise<number> {
+  return serviceWorker.evaluate(async () => {
+    const newTab = () =>
+      new Promise<chrome.tabs.Tab>((resolve) =>
+        chrome.tabs.create({ url: 'about:blank', active: false }, resolve)
+      );
+    const [a, b, c] = [await newTab(), await newTab(), await newTab()];
+    await chrome.tabs.group({ tabIds: [a.id!, b.id!] });
+    await chrome.tabs.group({ tabIds: [c.id!] });
+    const tabs = await chrome.tabs.query({});
+    return new Set(
+      tabs.map((t) => t.groupId).filter((g) => g !== undefined && g !== -1)
+    ).size;
+  });
+}
+
+async function openPopupIn(
+  context: BrowserContext,
+  extensionId: string,
+  lang: string
+): Promise<Page> {
+  await seedSessions(context, buildContainer());
+  // i18n reads `language` out of settingsData at MODULE LOAD (config/i18n.tsx),
+  // so this has to be seeded before the first render -- which seedSettings does
+  // via addInitScript. Setting it after navigation would be too late.
+  await seedSettings(context, { language: lang });
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/index.html`);
+  return page;
+}
+
+/**
+ * Opens the rate-and-review prompt, which is gated entirely on localStorage
+ * (`App.tsx`): installed more than a day ago, never rated, never opted out.
+ *
+ * `extensionInstalledTime` is a NUMBER of milliseconds -- `isValidDate`
+ * (`local.ts:12`) only accepts `typeof param === 'number'`, so a plausible ISO
+ * string reads as "never installed" and the modal silently never opens.
+ */
+async function openRatePromptIn(
+  context: BrowserContext,
+  extensionId: string,
+  lang: string
+): Promise<Page> {
+  await seedSettings(context, {
+    language: lang,
+    extensionInstalledTime: Date.now() - 2 * 24 * 60 * 60 * 1000,
+    // Reveals the second dismissal, so the card is at its tallest.
+    isSkippedUserReviewOnce: true,
+  });
+  await seedSessions(context, buildContainer());
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/index.html`);
+  return page;
+}
+
+/**
+ * How the CTA is sitting in its card: how many line boxes its label occupies,
+ * and whether the button has burst out of the card.
+ *
+ * Takes a Locator rather than an accessible name because the two CTAs are not
+ * addressable the same way -- the tab-groups button carries an explicit
+ * `ariaLabel`, the rate button does not and is named from its content.
+ */
+async function ctaFit(cta: Locator) {
+  return cta.evaluate((button: HTMLElement) => {
+    // The label, not the leading icon: Material Symbols renders its glyph as
+    // ligature TEXT in a span of its own, so the first span is the icon.
+    const label = Array.from(button.querySelectorAll('span')).find(
+      (s) => !s.className.includes('material-symbols')
+    );
+    if (!label) return null;
+    const range = document.createRange();
+    range.selectNodeContents(label);
+    // The card: nearest ancestor wider than the button. Measured rather than
+    // hardcoded to 500 -- a hardcoded bound passes trivially when the card
+    // itself is what shrank.
+    let card: HTMLElement | null = button.parentElement;
+    while (
+      card &&
+      card.getBoundingClientRect().width <= button.getBoundingClientRect().width
+    ) {
+      card = card.parentElement;
+    }
+    return {
+      lineBoxes: range.getClientRects().length,
+      burstsCardBy: card
+        ? Math.round(
+            button.getBoundingClientRect().right -
+              card.getBoundingClientRect().right
+          )
+        : null,
+      pageOverflowsX:
+        document.documentElement.scrollWidth >
+        document.documentElement.clientWidth,
+    };
+  });
+}
+
+function expectFits(fit: Awaited<ReturnType<typeof ctaFit>>, lang: string) {
+  expect(fit).not.toBeNull();
+  // The assertion that has teeth. The two below it are cheaper checks for a
+  // coarser break that neither of these layouts happens to produce.
+  expect(fit!.lineBoxes, `${lang}: CTA label must stay on one line`).toBe(1);
+  expect(fit!.burstsCardBy).toBeLessThanOrEqual(0);
+  expect(fit!.pageOverflowsX).toBe(false);
+}
+
+test.describe('translated UI still fits its layout', () => {
+  for (const lang of LOCALES) {
+    test(`the tab groups offer fits the card in ${lang}`, async ({
+      context,
+      serviceWorker,
+      extensionId,
+    }) => {
+      const t = localeStrings(lang);
+
+      const groupCount = await createTabGroups(serviceWorker);
+      // The fixture's own control. Without real groups the offer never opens,
+      // and every assertion below would fail as "element not found" -- which
+      // reads as a broken modal rather than a broken setup.
+      expect(groupCount, 'fixture must create real tab groups').toBe(2);
+
+      const page = await openPopupIn(context, extensionId, lang);
+
+      // Located by the LOCALIZED accessible name, so a locale that silently
+      // failed to load and fell back to English fails here rather than quietly
+      // passing the layout assertions against English text.
+      const cta = page.getByRole('button', {
+        name: t.TabGroupsPromptConfirm,
+        exact: true,
+      });
+      await expect(cta).toBeVisible();
+
+      expectFits(await ctaFit(cta), lang);
+    });
+  }
+
+  // KAN-78. The same check on the other "offer" modal, which had the defect
+  // this file exists to catch: its CTA was pinned to `width: 217px`, sized to
+  // the English label, and wrapped to two lines in 7 of the 10 locales.
+  //
+  // Note the rendered label is NOT the key -- en maps "Rate this app" to
+  // "Rate this extension" -- so the name is read from the locale file rather
+  // than written out here.
+  for (const lang of LOCALES) {
+    test(`the rate prompt fits the card in ${lang}`, async ({
+      context,
+      extensionId,
+    }) => {
+      const t = localeStrings(lang);
+      const page = await openRatePromptIn(context, extensionId, lang);
+
+      const cta = page.getByRole('button', {
+        name: t['Rate this app'],
+        exact: true,
+      });
+      await expect(cta).toBeVisible();
+
+      expectFits(await ctaFit(cta), lang);
+    });
+  }
+});

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -100,9 +100,9 @@
   "Synced changes from another device.": "Änderungen von einem anderen Gerät synchronisiert.",
   "Restored tabs successfully!": "Tabs erfolgreich wiederhergestellt!",
   "Unnamed group": "Unbenannte Gruppe",
-  "TabGroupsPromptTitle": "Ihre Tab-Gruppen speichern",
-  "TabGroupsPromptBodyOne": "Ohne Berechtigung kann Tab Keeper den Namen und die Farbe Ihrer Tab-Gruppe nicht speichern.",
-  "TabGroupsPromptBodyOther": "Ohne Berechtigung kann Tab Keeper die Namen und Farben Ihrer {{count}} Tab-Gruppen nicht speichern.",
+  "TabGroupsPromptTitle": "Tab Keeper kann Tab-Gruppen speichern",
+  "TabGroupsPromptBodyOne": "Aktivieren Sie die Funktion, und Ihre Tab-Gruppe kehrt genau so zurück, wie Sie sie angelegt haben.",
+  "TabGroupsPromptBodyOther": "Aktivieren Sie die Funktion, und Ihre {{count}} Tab-Gruppen kehren genau so zurück, wie Sie sie angelegt haben.",
   "TabGroupsPromptConfirm": "Tab-Gruppen-Unterstützung aktivieren",
   "TabGroupsPromptDismiss": "Jetzt nicht",
   "TabGroupsPromptNever": "Nicht mehr fragen"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -100,9 +100,9 @@
   "Synced changes from another device.": "Synced changes from another device.",
   "Restored tabs successfully!": "Restored tabs successfully!",
   "Unnamed group": "Unnamed group",
-  "TabGroupsPromptTitle": "Save your tab groups",
-  "TabGroupsPromptBodyOne": "Tab Keeper can't save the name and colour of your tab group without permission.",
-  "TabGroupsPromptBodyOther": "Tab Keeper can't save the names and colours of your {{count}} tab groups without permission.",
+  "TabGroupsPromptTitle": "Tab Keeper can save tab groups",
+  "TabGroupsPromptBodyOne": "Turn it on and your tab group comes back exactly as you set it up.",
+  "TabGroupsPromptBodyOther": "Turn it on and your {{count}} tab groups come back exactly as you set them up.",
   "TabGroupsPromptConfirm": "Enable tab group support",
   "TabGroupsPromptDismiss": "Not now",
   "TabGroupsPromptNever": "Don't ask again"

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -100,9 +100,9 @@
   "Synced changes from another device.": "Cambios sincronizados desde otro dispositivo.",
   "Restored tabs successfully!": "¡Pestañas restauradas correctamente!",
   "Unnamed group": "Grupo sin nombre",
-  "TabGroupsPromptTitle": "Guarda tus grupos de pestañas",
-  "TabGroupsPromptBodyOne": "Sin permiso, Tab Keeper no puede guardar el nombre y el color de tu grupo de pestañas.",
-  "TabGroupsPromptBodyOther": "Sin permiso, Tab Keeper no puede guardar los nombres y colores de tus {{count}} grupos de pestañas.",
+  "TabGroupsPromptTitle": "Tab Keeper puede guardar grupos de pestañas",
+  "TabGroupsPromptBodyOne": "Actívalo y tu grupo de pestañas volverá tal como lo creaste.",
+  "TabGroupsPromptBodyOther": "Actívalo y tus {{count}} grupos de pestañas volverán tal como los creaste.",
   "TabGroupsPromptConfirm": "Activar la compatibilidad con grupos de pestañas",
   "TabGroupsPromptDismiss": "Ahora no",
   "TabGroupsPromptNever": "No volver a preguntar"

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -100,9 +100,9 @@
   "Synced changes from another device.": "Modifications synchronisées depuis un autre appareil.",
   "Restored tabs successfully!": "Onglets restaurés avec succès !",
   "Unnamed group": "Groupe sans nom",
-  "TabGroupsPromptTitle": "Enregistrer vos groupes d'onglets",
-  "TabGroupsPromptBodyOne": "Sans autorisation, Tab Keeper ne peut pas enregistrer le nom et la couleur de votre groupe d'onglets.",
-  "TabGroupsPromptBodyOther": "Sans autorisation, Tab Keeper ne peut pas enregistrer les noms et les couleurs de vos {{count}} groupes d'onglets.",
+  "TabGroupsPromptTitle": "Tab Keeper peut enregistrer les groupes d'onglets",
+  "TabGroupsPromptBodyOne": "Activez-la et votre groupe d'onglets reviendra exactement tel que vous l'avez créé.",
+  "TabGroupsPromptBodyOther": "Activez-la et vos {{count}} groupes d'onglets reviendront exactement tels que vous les avez créés.",
   "TabGroupsPromptConfirm": "Activer la prise en charge des groupes d'onglets",
   "TabGroupsPromptDismiss": "Pas maintenant",
   "TabGroupsPromptNever": "Ne plus demander"

--- a/public/locales/hi/translation.json
+++ b/public/locales/hi/translation.json
@@ -100,9 +100,9 @@
   "Synced changes from another device.": "दूसरे डिवाइस से किए गए बदलाव सिंक कर दिए गए।",
   "Restored tabs successfully!": "टैब सफलतापूर्वक पुनर्स्थापित किए गए!",
   "Unnamed group": "बिना नाम का समूह",
-  "TabGroupsPromptTitle": "अपने टैब समूह सहेजें",
-  "TabGroupsPromptBodyOne": "अनुमति के बिना Tab Keeper आपके टैब समूह का नाम और रंग नहीं सहेज सकता।",
-  "TabGroupsPromptBodyOther": "अनुमति के बिना Tab Keeper आपके {{count}} टैब समूहों के नाम और रंग नहीं सहेज सकता।",
+  "TabGroupsPromptTitle": "Tab Keeper टैब समूह सहेज सकता है",
+  "TabGroupsPromptBodyOne": "इसे चालू करें और आपका टैब समूह ठीक वैसा ही वापस आएगा जैसा आपने बनाया था।",
+  "TabGroupsPromptBodyOther": "इसे चालू करें और आपके {{count}} टैब समूह ठीक वैसे ही वापस आएंगे जैसे आपने बनाए थे।",
   "TabGroupsPromptConfirm": "टैब समूह समर्थन चालू करें",
   "TabGroupsPromptDismiss": "अभी नहीं",
   "TabGroupsPromptNever": "फिर से न पूछें"

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -100,9 +100,9 @@
   "Synced changes from another device.": "Modifiche sincronizzate da un altro dispositivo.",
   "Restored tabs successfully!": "Tab ripristinati correttamente!",
   "Unnamed group": "Gruppo senza nome",
-  "TabGroupsPromptTitle": "Salva i tuoi gruppi di schede",
-  "TabGroupsPromptBodyOne": "Senza autorizzazione, Tab Keeper non può salvare il nome e il colore del tuo gruppo di schede.",
-  "TabGroupsPromptBodyOther": "Senza autorizzazione, Tab Keeper non può salvare i nomi e i colori dei tuoi {{count}} gruppi di schede.",
+  "TabGroupsPromptTitle": "Tab Keeper può salvare i gruppi di schede",
+  "TabGroupsPromptBodyOne": "Attivala e il tuo gruppo di schede tornerà esattamente come l'hai creato.",
+  "TabGroupsPromptBodyOther": "Attivala e i tuoi {{count}} gruppi di schede torneranno esattamente come li hai creati.",
   "TabGroupsPromptConfirm": "Attiva il supporto ai gruppi di schede",
   "TabGroupsPromptDismiss": "Non ora",
   "TabGroupsPromptNever": "Non chiedere più"

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -100,9 +100,9 @@
   "Synced changes from another device.": "別のデバイスからの変更を同期しました。",
   "Restored tabs successfully!": "タブを復元しました。",
   "Unnamed group": "名前のないグループ",
-  "TabGroupsPromptTitle": "タブグループを保存",
-  "TabGroupsPromptBodyOne": "権限がないと、Tab Keeper はタブグループの名前と色を保存できません。",
-  "TabGroupsPromptBodyOther": "権限がないと、Tab Keeper は {{count}} 個のタブグループの名前と色を保存できません。",
+  "TabGroupsPromptTitle": "Tab Keeper はタブグループを保存できます",
+  "TabGroupsPromptBodyOne": "オンにすると、タブグループは設定したときのまま復元されます。",
+  "TabGroupsPromptBodyOther": "オンにすると、{{count}} 個のタブグループは設定したときのまま復元されます。",
   "TabGroupsPromptConfirm": "タブグループのサポートを有効にする",
   "TabGroupsPromptDismiss": "後で",
   "TabGroupsPromptNever": "今後表示しない"

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -100,9 +100,9 @@
   "Synced changes from another device.": "Alterações sincronizadas de outro dispositivo.",
   "Restored tabs successfully!": "Abas restauradas com sucesso!",
   "Unnamed group": "Grupo sem nome",
-  "TabGroupsPromptTitle": "Salve seus grupos de guias",
-  "TabGroupsPromptBodyOne": "Sem permissão, o Tab Keeper não pode salvar o nome e a cor do seu grupo de guias.",
-  "TabGroupsPromptBodyOther": "Sem permissão, o Tab Keeper não pode salvar os nomes e as cores dos seus {{count}} grupos de guias.",
+  "TabGroupsPromptTitle": "O Tab Keeper pode salvar grupos de guias",
+  "TabGroupsPromptBodyOne": "Ative e seu grupo de guias voltará exatamente como você o criou.",
+  "TabGroupsPromptBodyOther": "Ative e seus {{count}} grupos de guias voltarão exatamente como você os criou.",
   "TabGroupsPromptConfirm": "Ativar o suporte a grupos de guias",
   "TabGroupsPromptDismiss": "Agora não",
   "TabGroupsPromptNever": "Não perguntar novamente"

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -100,9 +100,9 @@
   "Synced changes from another device.": "Изменения с другого устройства синхронизированы.",
   "Restored tabs successfully!": "Вкладки успешно восстановлены!",
   "Unnamed group": "Группа без имени",
-  "TabGroupsPromptTitle": "Сохраняйте свои группы вкладок",
-  "TabGroupsPromptBodyOne": "Без разрешения Tab Keeper не может сохранить название и цвет вашей группы вкладок.",
-  "TabGroupsPromptBodyOther": "Без разрешения Tab Keeper не может сохранить названия и цвета ваших групп вкладок ({{count}}).",
+  "TabGroupsPromptTitle": "Tab Keeper может сохранять группы вкладок",
+  "TabGroupsPromptBodyOne": "Включите её, и ваша группа вкладок вернётся точно такой, какой вы её создали.",
+  "TabGroupsPromptBodyOther": "Включите её, и ваши группы вкладок ({{count}}) вернутся точно такими, какими вы их создали.",
   "TabGroupsPromptConfirm": "Включить поддержку групп вкладок",
   "TabGroupsPromptDismiss": "Не сейчас",
   "TabGroupsPromptNever": "Больше не спрашивать"

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -100,9 +100,9 @@
   "Synced changes from another device.": "已同步来自其他设备的更改。",
   "Restored tabs successfully!": "标签页已成功恢复！",
   "Unnamed group": "未命名的群组",
-  "TabGroupsPromptTitle": "保存您的标签组",
-  "TabGroupsPromptBodyOne": "没有权限，Tab Keeper 无法保存标签组的名称和颜色。",
-  "TabGroupsPromptBodyOther": "没有权限，Tab Keeper 无法保存这 {{count}} 个标签组的名称和颜色。",
+  "TabGroupsPromptTitle": "Tab Keeper 可以保存标签组",
+  "TabGroupsPromptBodyOne": "开启后，标签组会完全按照你的设置恢复。",
+  "TabGroupsPromptBodyOther": "开启后，这 {{count}} 个标签组会完全按照你的设置恢复。",
   "TabGroupsPromptConfirm": "启用标签组支持",
   "TabGroupsPromptDismiss": "暂不",
   "TabGroupsPromptNever": "不再询问"

--- a/src/components/modals/RateAndReviewModal.tsx
+++ b/src/components/modals/RateAndReviewModal.tsx
@@ -86,6 +86,7 @@ export const RateAndReviewModal: React.FC<RateAndReviewModalProps> = ({
   // abstraction would have to carry the modal's whole visual language to earn
   // its name.
   const dismissStyle = css`
+    align-self: center;
     background: none;
     border: none;
     padding: 0;
@@ -121,7 +122,7 @@ export const RateAndReviewModal: React.FC<RateAndReviewModalProps> = ({
           border: 1px solid ${COLORS.BORDER_COLOR};
           width: 500px;
           padding: 20px;
-          align-items: center;
+          align-items: flex-start;
           border-radius: 0px;
           display: flex;
           flex-direction: column;
@@ -134,7 +135,7 @@ export const RateAndReviewModal: React.FC<RateAndReviewModalProps> = ({
             font-weight: 500;
             font-family: ${FONT_FAMILY};
             font-size: 1.3rem;
-            margin: 10px;
+            margin: 10px 0;
           `}
         >
           {t('RequestUserReviewHeader')}
@@ -156,17 +157,28 @@ export const RateAndReviewModal: React.FC<RateAndReviewModalProps> = ({
             font-family: ${FONT_FAMILY};
             font-size: 0.9rem;
             color: ${COLORS.TEXT_COLOR};
-            text-align: center;
+            text-align: left;
             margin: 0 0 10px 0;
           `}
         >
           {t(`RequestUserReviewText`)}
         </p>
+        {/* Full width, never a fixed one. This was `width: 217px` -- sized to
+            the English label and wrong for everyone else: measured in a real
+            browser, 7 of the 10 locales wrapped it onto two lines inside the
+            button while the card had 500px going spare (KAN-78). Spanning the
+            card removes the bet that no future translation outgrows a number.
+
+            Matches TabGroupsPermissionModal deliberately: both are "offer"
+            modals and should read as one component. FocusConfirmModal is a
+            different family -- a compact confirm with a right-aligned button
+            pair -- and is left alone. */}
         <Button
           text={t(`Rate this app`)}
           onClick={handleRateExtension}
+          ariaLabel={t(`Rate this app`)}
           iconType="thumb_up"
-          style="width: 217px; margin-bottom: 10px; cursor: pointer;"
+          style="width: 100%; margin-bottom: 10px; cursor: pointer; justify-content: center;"
         />
         <button type="button" css={dismissStyle} onClick={handleRemindLater}>
           {t(`Maybe Later`)}

--- a/src/components/modals/TabGroupsPermissionModal.tsx
+++ b/src/components/modals/TabGroupsPermissionModal.tsx
@@ -116,6 +116,7 @@ export const TabGroupsPermissionModal: React.FC<
   // NormalLabel is also `white-space: nowrap`, which ran the body sentence off
   // both edges of the 500px card. That is why the body below is a <p>.
   const dismissStyle = css`
+    align-self: center;
     background: none;
     border: none;
     padding: 0;
@@ -151,7 +152,7 @@ export const TabGroupsPermissionModal: React.FC<
           border: 1px solid ${COLORS.BORDER_COLOR};
           width: 500px;
           padding: 20px;
-          align-items: center;
+          align-items: flex-start;
           border-radius: 0px;
           display: flex;
           flex-direction: column;
@@ -164,7 +165,7 @@ export const TabGroupsPermissionModal: React.FC<
             font-weight: 500;
             font-family: ${FONT_FAMILY};
             font-size: 1.3rem;
-            margin: 10px;
+            margin: 10px 0;
           `}
         >
           {t('TabGroupsPromptTitle')}
@@ -174,22 +175,29 @@ export const TabGroupsPermissionModal: React.FC<
             font-family: ${FONT_FAMILY};
             font-size: 0.9rem;
             color: ${COLORS.TEXT_COLOR};
-            text-align: center;
+            text-align: left;
             margin: 0 0 10px 0;
           `}
         >
           {t(bodyKey, { count: tabGroupsPromptCount })}
         </p>
-        {/* No fixed width on the CTA: the label is a full phrase ("Enable tab
-            group support"), and several locales render it far longer still --
-            fr is "Activer la prise en charge des groupes d'onglets". The 217px
-            this started with would have clipped most of them. */}
+        {/* Full width, and that is a translation decision as much as a visual
+            one. The label is a whole phrase ("Enable tab group support") and
+            several locales run far longer -- fr is "Activer la prise en charge
+            des groupes d'onglets", es renders widest at 404px. A content-width
+            button left only ~48px of headroom in es; spanning the card gives
+            every locale the full 500px. Never reintroduce a fixed width: the
+            217px this started with clipped most of them.
+
+            The card is align-items: flex-start, so without width: 100% this
+            button would shrink to its own text and read as a stray chip in a
+            wide card -- which is what left-aligning the copy exposed. */}
         <Button
           text={t('TabGroupsPromptConfirm')}
           onClick={handleEnable}
           ariaLabel={t('TabGroupsPromptConfirm')}
           iconType="check_circle"
-          style="max-width: 100%; margin-bottom: 10px; cursor: pointer;"
+          style="width: 100%; max-width: 100%; margin-bottom: 10px; cursor: pointer; justify-content: center;"
         />
         <button type="button" css={dismissStyle} onClick={handleNotNow}>
           {t('TabGroupsPromptDismiss')}

--- a/src/tests/components/TabGroupsPermissionModal.test.tsx
+++ b/src/tests/components/TabGroupsPermissionModal.test.tsx
@@ -35,7 +35,7 @@ describe('TabGroupsPermissionModal', () => {
   test('renders nothing when no prompt is open', async () => {
     await renderWithProviders(<TabGroupsPermissionModal />);
 
-    expect(screen.queryByText('Save your tab groups')).toBeNull();
+    expect(screen.queryByText('Tab Keeper can save tab groups')).toBeNull();
   });
 
   test('renders the offer when a prompt is open', async () => {
@@ -43,7 +43,7 @@ describe('TabGroupsPermissionModal', () => {
       seedStore: openWith(2),
     });
 
-    expect(screen.getByText('Save your tab groups')).toBeTruthy();
+    expect(screen.getByText('Tab Keeper can save tab groups')).toBeTruthy();
     expect(
       screen.getByRole('button', { name: 'Enable tab group support' })
     ).toBeTruthy();
@@ -57,7 +57,7 @@ describe('TabGroupsPermissionModal', () => {
 
     expect(
       screen.getByText(
-        "Tab Keeper can't save the name and colour of your tab group without permission."
+        'Turn it on and your tab group comes back exactly as you set it up.'
       )
     ).toBeTruthy();
   });
@@ -71,7 +71,7 @@ describe('TabGroupsPermissionModal', () => {
 
     expect(
       screen.getByText(
-        "Tab Keeper can't save the names and colours of your 3 tab groups without permission."
+        'Turn it on and your 3 tab groups come back exactly as you set them up.'
       )
     ).toBeTruthy();
   });


### PR DESCRIPTION
`RateAndReviewModal.tsx:169` pinned the primary CTA to `width: 217px`. That number fits the English label and nothing else.

**Measured in a real browser at the popup's own 790x550, all ten locales:**

| locale | label | lines |
| --- | --- | --- |
| en | Rate this extension | 1 |
| pt | Avalie esta extensão | 1 |
| zh | 评价此扩展 | 1 |
| de | Bewerten Sie diese Erweiterung | **2** |
| es | Califica esta extensión | **2** |
| fr | Évaluez cette extension | **2** |
| hi | इस एक्सटेंशन को मूल्यांकन करें | **2** |
| it | Valuta questa estensione | **2** |
| ja | この拡張機能を評価する | **2** |
| ru | Оцените это расширение | **2** |

Seven of ten wrapped the primary call to action onto two lines inside a cramped button, while the card it sits in is 500px wide. German reads "Bewerten Sie diese / Erweiterung", on the one dialog whose entire job is to ask for a good review.

## The fix is `width: 100%`, not a bigger number

Any fixed width is a bet that no future translation outgrows it, re-checked by hand across ten locales every time copy changes. Spanning the card makes the constraint the card, which is the thing that actually bounds the layout. `TabGroupsPermissionModal` already carried a comment warning against exactly this.

## One layout for both offer modals

The two modals had been answering the same design question differently. Both are *offer* modals — a capability the user can opt into, one primary action, quiet dismissals — so both now use left-aligned copy, a full-width CTA and centred dismissals.

`FocusConfirmModal` is deliberately untouched. It is a compact confirm with a right-aligned `Cancel`/`Switch` pair, which is the correct shape for a decision rather than an offer. That reasoning is now recorded in the code so it does not get "fixed" later.

The rate CTA also gains the `ariaLabel` it was missing; its accessible name previously came from content, which worked only because KAN-56 made the icon `aria-hidden`.

## The tab-groups copy was selling the wrong thing

It led with what the app could not do — "can't save the names and colours" — which **understated** the loss as well as selling it badly. Without the permission `readCurrentWindowGroups` returns `null` (`capture.ts:134`), so no tab carries a `chromeGroupId` and no `chromeTabGroups` is stored: the grouping is lost *entirely*, not merely rendered grey.

It now names the benefit instead, in all ten locales:

> **Tab Keeper can save tab groups**
> Turn it on and your 2 tab groups come back exactly as you set them up.

Never shipped, so no user has seen the old wording and it needs no changelog line of its own.

## The new spec, and the two ways it was wrong first

`e2e/i18n-layout.spec.ts` renders both modals in `en` (control), `es` (widest CTA, 404px) and `hi` (Devanagari, to catch a font-fallback regression a Latin measurement cannot see), and asserts the CTA label occupies **one line box**.

That is the only assertion with teeth, which took two attempts to establish. A CTA too long for its button here does **not** clip and does **not** overflow — it wraps. Against a card deliberately shrunk to 300px: `scrollWidth === clientWidth`, the button's own height stays 56px, and the document never scrolls horizontally. The first version of this spec asserted exactly those three things and **passed against the broken layout**.

The obvious repair failed too: `span.getClientRects()` returns a single box because the label is `display: block`, so its own rect covers both lines. A `Range` over its contents reports one rect per line box, which is the real question being asked.

## Evidence

Written before the fix and **red against the real defect** — `es` and `hi` failed on the rate prompt while `en` passed as the control, then all six went green on the width change. No artificial mutation needed; the test failed against the shipped bug.

The expected strings are read from the locale files rather than hardcoded, so rewording never touches this spec. It fails only when the layout breaks — which is why today's copy rewrite required no edit to it.

**622 unit tests / 72 files. Playwright 49/49, up from 43.** `tsc --noEmit` 0, `typecheck:e2e` 0, `eslint src e2e` 0 errors / 25 warnings — the baseline exactly. Prettier clean.

## Checked, not assumed

The longer title was verified across all ten locales rather than eyeballed in English. French wraps to two lines (458px in a 460px content box) and Spanish clears it by 6px; both read correctly, because a heading is flow content and wrapping is its normal behaviour. No locale overflows vertically — the tallest card is French at 299px in a 550px popup.

Deliberately **not** asserted in the spec: a `titleLines === 1` check would be a change detector, failing the day someone adds a word to a heading for a problem that is not one. The line-count assertion earns its place on a fixed-size control and nowhere else.

## Scope

`RateAndReviewModal`'s CTA width is pre-existing and shipped in v1.5.0 and earlier (KAN-78). The tab-groups copy and layout are unreleased, part of the KAN-74 work still pending release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
