### PR TITLE
Say when the sync is done, and stop offering one that cannot run (KAN-79)

### DIFF
--- a/src/components/home/leftpane/MenuContainer.tsx
+++ b/src/components/home/leftpane/MenuContainer.tsx
@@ -23,6 +23,10 @@ export default function MenuContainer() {
     (state: RootState) => state.globalState.syncStatus
   );
 
+  const isSignedIn = useSelector(
+    (state: RootState) => state.globalState.isSignedIn
+  );
+
   const { t } = useTranslation();
   const dispatch: AppDispatch = useDispatch();
 
@@ -48,18 +52,35 @@ export default function MenuContainer() {
     dispatch(closeToast());
   }
 
-  // sync icon change with syncStatus
-  let syncIconType = '';
+  // The control offers "sync now" only when syncing is possible AND something
+  // is out of sync. Every other case shows what is true instead.
+  //
+  // `isSignedIn` is checked FIRST and beats any status, because it is the only
+  // one of the two that decides whether the action can work at all. It is not
+  // a startup flash: App.tsx dispatches setLoggedOut on a failed
+  // chrome.storage.sync write, on a read-back that does not match what was
+  // written, and on a token that is present but unusable. In each of those the
+  // control used to invite a click that called loadFromFirestore(userId!) with
+  // no userId (KAN-79).
+  //
+  // Note what is NOT used here: `isDirty`. globalState is rebuilt on every
+  // popup open, so `isDirty === false` means "no edits yet this session", not
+  // "the two sides agree" -- with auto-sync off nothing has been compared at
+  // all. Only a completed sync knows that, which is what syncStatus records.
+  let syncIconType: string;
   let isDisabled = false;
-  if (syncStatus === 'loading') {
+  if (!isSignedIn) {
+    syncIconType = 'cloud_off';
+    isDisabled = true;
+  } else if (syncStatus === 'loading') {
     syncIconType = 'cloud_sync';
     isDisabled = true;
   } else if (syncStatus === 'error') {
     syncIconType = 'sync_problem';
-  } else if (syncStatus === 'idle') {
-    syncIconType = 'sync';
   } else if (syncStatus === 'success') {
     syncIconType = 'cloud_done';
+  } else {
+    syncIconType = 'sync';
   }
 
   const containerStyle = css`

--- a/src/redux/slices/globalStateSlice.ts
+++ b/src/redux/slices/globalStateSlice.ts
@@ -203,9 +203,22 @@ export const syncStateWithFirestore = createAsyncThunk(
 
       if (changedFromCloud) {
         thunkAPI.dispatch(setIsDirtyWithoutSync());
+        // saveToFirestoreIfDirty's own fulfilled reducer reports the success.
         thunkAPI.dispatch(saveToFirestoreIfDirty());
       } else {
+        // Nothing to write, which is the MOST in-sync a user can be and the
+        // usual outcome of opening the popup. It has to say so: syncStatus is
+        // what the header icon reads, and leaving it at the initial 'idle'
+        // showed the actionable "sync now" icon on a session just confirmed up
+        // to date (KAN-79).
+        //
+        // `setIsNotDirty` alone is not enough, and deriving the icon from
+        // isDirty instead would not work either: globalState is rebuilt on
+        // every popup open, so `isDirty === false` means "no edits yet this
+        // session", not "the two sides agree". Only a completed sync knows
+        // that, so only a completed sync may claim it.
         thunkAPI.dispatch(setIsNotDirty());
+        thunkAPI.dispatch(setSyncStatus('success'));
       }
 
       if (changedFromLocal) {

--- a/src/tests/components/iconKeyboardActivation.test.tsx
+++ b/src/tests/components/iconKeyboardActivation.test.tsx
@@ -3,7 +3,10 @@ import { act, fireEvent, screen } from '@testing-library/react';
 
 import MenuContainer from '../../components/home/leftpane/MenuContainer';
 import { renderWithProviders } from '../setup/renderWithProviders';
-import { setSyncStatus } from '../../redux/slices/globalStateSlice';
+import {
+  setSignedIn,
+  setSyncStatus,
+} from '../../redux/slices/globalStateSlice';
 
 // KAN-63 changed how an Icon turns a keypress into its onClick: it used to
 // call onClick(e as any) directly, and now forwards to the element's own
@@ -22,12 +25,23 @@ const SYNC_PENDING = 'global/syncStateWithFirestore/pending';
 
 const syncIcon = () => screen.getByRole('button', { name: 'Sync now' });
 
+// Signed in, always. The store's initial isSignedIn is FALSE, and the sync
+// control is deliberately disabled with no account to sync to (KAN-79) -- so a
+// default store is the one state in which none of these assertions can hold.
+// Signing in is the precondition for the control existing as an action at all,
+// not a workaround: the thunk reads loadFromFirestore(userId!), and with no
+// userId its missing-document branch writes through saveToFirestore(null, ...).
+const renderMenu = () =>
+  renderWithProviders(<MenuContainer />, {
+    seedStore: (store) => store.dispatch(setSignedIn()),
+  });
+
 describe('Icon keyboard activation reaches the same handler as a click', () => {
   // The control. If the sync thunk stopped being dispatched by a plain mouse
   // click, every keyboard assertion below would fail for a reason that has
   // nothing to do with the keyboard.
   test('CONTROL: clicking the sync icon dispatches the sync thunk', async () => {
-    const { seen } = await renderWithProviders(<MenuContainer />);
+    const { seen } = await renderMenu();
     seen.length = 0;
 
     await act(async () => {
@@ -42,7 +56,7 @@ describe('Icon keyboard activation reaches the same handler as a click', () => {
     { key: ' ', name: 'Space' },
   ]) {
     test(`${key.name} on the sync icon dispatches the sync thunk`, async () => {
-      const { seen } = await renderWithProviders(<MenuContainer />);
+      const { seen } = await renderMenu();
       seen.length = 0;
 
       await act(async () => {
@@ -61,7 +75,7 @@ describe('Icon keyboard activation reaches the same handler as a click', () => {
   // second sync -- the re-entrancy this codebase has fixed before. Routing
   // through click() means the guard applies to the keyboard too.
   test('a disabled sync icon does not dispatch on Enter', async () => {
-    const { store, seen } = await renderWithProviders(<MenuContainer />);
+    const { store, seen } = await renderMenu();
 
     await act(async () => {
       store.dispatch(setSyncStatus('loading'));
@@ -80,7 +94,7 @@ describe('Icon keyboard activation reaches the same handler as a click', () => {
   // above would pass against an Icon that had stopped responding to the
   // keyboard entirely.
   test('the same icon syncs again once it is re-enabled', async () => {
-    const { store, seen } = await renderWithProviders(<MenuContainer />);
+    const { store, seen } = await renderMenu();
 
     await act(async () => {
       store.dispatch(setSyncStatus('loading'));

--- a/src/tests/components/keyboardReachability.test.tsx
+++ b/src/tests/components/keyboardReachability.test.tsx
@@ -6,7 +6,10 @@ import Icon from '../../components/common/Icon';
 import MenuContainer from '../../components/home/leftpane/MenuContainer';
 import TabGroupEntry from '../../components/home/leftpane/TabGroupEntry';
 import { renderWithProviders } from '../setup/renderWithProviders';
-import { setSyncStatus } from '../../redux/slices/globalStateSlice';
+import {
+  setSignedIn,
+  setSyncStatus,
+} from '../../redux/slices/globalStateSlice';
 import { tabContainerData } from '../../redux/slices/tabContainerDataStateSlice';
 
 // KAN-67 and KAN-68 are one defect wearing two prop names. Both `Button`'s
@@ -95,7 +98,12 @@ describe('enabled controls are reachable by keyboard', () => {
   // the re-entrancy KAN-63 closed. aria-disabled fixes the false "enabled"
   // announcement without the focus loss.
   test('a disabled Icon announces its state and keeps focus (KAN-66)', async () => {
-    const { store } = await renderWithProviders(<MenuContainer />);
+    // Signed in so that `loading` is the ONLY reason this control is disabled.
+    // Signed out disables it too (KAN-79), which would let this pass without
+    // the status ever being consulted.
+    const { store } = await renderWithProviders(<MenuContainer />, {
+      seedStore: (store) => store.dispatch(setSignedIn()),
+    });
 
     await act(async () => {
       store.dispatch(setSyncStatus('loading'));
@@ -110,7 +118,11 @@ describe('enabled controls are reachable by keyboard', () => {
   // disabled when it is not. Without this, setting aria-disabled
   // unconditionally would pass the test above.
   test('an enabled Icon does not claim to be disabled (KAN-66)', async () => {
-    await renderWithProviders(<MenuContainer />);
+    // Signed in: with no account to sync to there is no enabled state to
+    // assert, because the control is correctly disabled (KAN-79).
+    await renderWithProviders(<MenuContainer />, {
+      seedStore: (store) => store.dispatch(setSignedIn()),
+    });
 
     const sync = screen.getByRole('button', { name: 'Sync now' });
     expect(sync).not.toHaveAttribute('aria-disabled');

--- a/src/tests/components/syncAffordance.test.tsx
+++ b/src/tests/components/syncAffordance.test.tsx
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'vitest';
+import { screen } from '@testing-library/react';
+
+import MenuContainer from '../../components/home/leftpane/MenuContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  setLoggedOut,
+  setSignedIn,
+  setSyncStatus,
+} from '../../redux/slices/globalStateSlice';
+
+// KAN-79. The header's sync control is both a button and a status, and the
+// rule it has to keep is: offer "sync now" only when syncing is possible AND
+// something is out of sync. Every other case shows what is true instead.
+//
+// Asserted on the Material Symbols LIGATURE, which is the icon's rendered text
+// content -- the same reason golden-path.spec.ts has to pass `exact: true` to
+// stop "arrow_back" substring-matching "Back".
+
+const renderMenu = (
+  seed: (store: { dispatch: (a: unknown) => void }) => void
+) => renderWithProviders(<MenuContainer />, { seedStore: seed });
+
+const syncControl = () => screen.getByRole('button', { name: 'Sync now' });
+
+describe('the header sync affordance', () => {
+  // CONTROL for every assertion below: this is the one case that SHOULD offer
+  // the action, so a wrong icon elsewhere cannot be explained by the harness
+  // failing to render the control at all.
+  test('CONTROL: offers "sync now" when signed in with nothing yet confirmed', async () => {
+    await renderMenu((store) => {
+      store.dispatch(setSignedIn());
+      store.dispatch(setSyncStatus('idle'));
+    });
+
+    expect(syncControl().textContent).toBe('sync');
+    expect(syncControl().getAttribute('aria-disabled')).toBeNull();
+  });
+
+  test('reports agreement once a sync has confirmed it', async () => {
+    await renderMenu((store) => {
+      store.dispatch(setSignedIn());
+      store.dispatch(setSyncStatus('success'));
+    });
+
+    expect(syncControl().textContent).toBe('cloud_done');
+  });
+
+  test('shows the sync is under way, and takes the action away while it is', async () => {
+    await renderMenu((store) => {
+      store.dispatch(setSignedIn());
+      store.dispatch(setSyncStatus('loading'));
+    });
+
+    expect(syncControl().textContent).toBe('cloud_sync');
+    expect(syncControl().getAttribute('aria-disabled')).toBe('true');
+  });
+
+  test('reports a problem rather than inviting another attempt', async () => {
+    await renderMenu((store) => {
+      store.dispatch(setSignedIn());
+      store.dispatch(setSyncStatus('error'));
+    });
+
+    expect(syncControl().textContent).toBe('sync_problem');
+  });
+
+  // The defect this file adds. Signed out is not a transient startup flash --
+  // App.tsx dispatches setLoggedOut on a failed chrome.storage.sync write, a
+  // read-back that does not match, and an unusable token (which also raises
+  // UNREADABLE_ACCOUNT_TOKEN). In every one of those the control offered "sync
+  // now" and clicking it called loadFromFirestore(userId!) with no userId.
+  test('does not offer "sync now" when there is nothing to sync to', async () => {
+    await renderMenu((store) => {
+      store.dispatch(setLoggedOut());
+      store.dispatch(setSyncStatus('idle'));
+    });
+
+    expect(syncControl().textContent).toBe('cloud_off');
+    expect(syncControl().getAttribute('aria-disabled')).toBe('true');
+  });
+
+  // Signed out must win over a stale status. setLoggedOut already resets
+  // syncStatus to 'idle', so this pins that the icon cannot claim agreement
+  // with a cloud it can no longer reach.
+  test('a lost token stops the control claiming everything is in sync', async () => {
+    await renderMenu((store) => {
+      store.dispatch(setSignedIn());
+      store.dispatch(setSyncStatus('success'));
+      store.dispatch(setLoggedOut());
+    });
+
+    expect(syncControl().textContent).toBe('cloud_off');
+  });
+});

--- a/src/tests/redux/syncStatusReporting.test.ts
+++ b/src/tests/redux/syncStatusReporting.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Inlined rather than imported: a vi.hoisted block runs before the module
+// graph is evaluated, and common.ts reads window.screen at module load.
+// Keep in step with src/tests/setup/domStub.ts.
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+const mocks = vi.hoisted(() => ({
+  loadFromFirestore: vi.fn(async (): Promise<unknown> => undefined),
+  saveToFirestore: vi.fn<(userId: string, data: unknown) => Promise<void>>(
+    async () => undefined
+  ),
+}));
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: mocks.loadFromFirestore,
+  saveToFirestore: mocks.saveToFirestore,
+  displayToast: vi.fn(),
+}));
+
+import {
+  setSignedIn,
+  setUserId,
+  syncStateWithFirestore,
+} from '../../redux/slices/globalStateSlice';
+import { makeTestStore } from '../setup/makeStore';
+import type {
+  TabMasterContainer,
+  tabContainerData,
+} from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-79. `syncStatus` is not bookkeeping -- it is the only thing the header
+// icon reads (MenuContainer.tsx:54-63), and it is the only state that can say
+// "local and cloud are confirmed to agree".
+//
+// `isDirty` cannot say that, which is why the icon cannot be derived from it.
+// globalState is in-memory and rebuilt on every popup open, so `isDirty ===
+// false` at open means only "no edits yet this session" -- with auto-sync off,
+// nothing has been compared at all. Only a completed sync licenses `success`.
+
+function group(id: string, lastModified: number): tabContainerData {
+  return {
+    tabGroupId: id,
+    title: id,
+    createdTime: '2026-08-31 00:00:00',
+    windowCount: 1,
+    tabCount: 1,
+    isAutoSave: false,
+    isSelected: false,
+    lastModified,
+    windows: [
+      {
+        windowId: `w-${id}`,
+        windowHeight: 100,
+        windowWidth: 100,
+        windowOffsetTop: 0,
+        windowOffsetLeft: 0,
+        tabCount: 1,
+        title: 't',
+        tabs: [
+          {
+            tabId: `t-${id}`,
+            favicon: '',
+            title: 't',
+            url: 'https://example.com/',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+const agreeing = (): TabMasterContainer => ({
+  lastModified: 10,
+  selectedTabGroupId: 'a',
+  tabGroups: [group('a', 10)],
+  deletedTabGroups: [],
+});
+
+async function runSync(local: TabMasterContainer | null, cloud: unknown) {
+  if (local) localStorage.setItem('tabContainerData', JSON.stringify(local));
+  mocks.loadFromFirestore.mockResolvedValue(cloud);
+  const { store } = makeTestStore();
+  store.dispatch(setSignedIn());
+  store.dispatch(setUserId('u1'));
+  await store.dispatch(syncStateWithFirestore() as never);
+  return store;
+}
+
+describe('the sync status the header icon reads', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mocks.loadFromFirestore.mockReset();
+    mocks.saveToFirestore.mockReset().mockResolvedValue(undefined);
+  });
+
+  // The control, and the branch that already worked: with nothing stored
+  // locally the cloud document is taken wholesale, and that path dispatches
+  // setSyncStatus('success') explicitly. Without this, a failure below could
+  // just mean the thunk never ran.
+  it('CONTROL: reports success when the cloud document is taken wholesale', async () => {
+    const store = await runSync(null, agreeing());
+
+    expect(store.getState().globalState.syncStatus).toBe('success');
+  });
+
+  // The defect. Both sides already hold the same thing, so the merge writes
+  // nothing -- the MOST in-sync a user can be, and the most common state on
+  // any popup open. It was the one branch that left syncStatus at its initial
+  // 'idle', so the header showed the actionable "sync" icon on a session that
+  // had just been confirmed up to date.
+  it('reports success when local and cloud already agree', async () => {
+    const store = await runSync(agreeing(), agreeing());
+
+    expect(store.getState().globalState.syncStatus).toBe('success');
+  });
+
+  // Pins the reason the branch above is reachable at all: agreeing sides mean
+  // no write. If this ever fails, the test above is passing for the wrong
+  // reason -- it would be going through saveToFirestoreIfDirty's fulfilled
+  // reducer rather than the branch it is meant to cover.
+  it('and does so without writing to Firestore', async () => {
+    await runSync(agreeing(), agreeing());
+
+    expect(mocks.saveToFirestore).not.toHaveBeenCalled();
+  });
+
+  // A bad sync must not read as "up to date". This one already worked; it is
+  // here so a future change to the success paths cannot quietly make every
+  // outcome report success.
+  //
+  // The trigger is an UNREADABLE cloud document, not a failed read. The real
+  // loadFromFirestore never rejects -- it catches everything and returns
+  // undefined (external.ts:49-66), and `undefined` means "no document yet",
+  // which is a success path. A mock that rejects would be testing a contract
+  // the real function does not have.
+  it('reports error when the cloud document cannot be understood', async () => {
+    const store = await runSync(agreeing(), { not: 'a container' });
+
+    expect(store.getState().globalState.syncStatus).toBe('error');
+  });
+});


### PR DESCRIPTION
Opening the popup while signed in showed the actionable `sync` icon, not `cloud_done`, on a session that had *just* been confirmed up to date. Reported from the live extension.

## Why

`syncStateWithFirestore` has **no `extraReducers` cases at all**, unlike `saveToFirestoreIfDirty`. It therefore only moves `syncStatus` through explicit dispatches inside its branches, and those branches disagreed:

| branch | meaning | sets status | icon |
| --- | --- | --- | --- |
| cloud read failed | error | `setSyncStatus('error')` | `sync_problem` |
| no local data, cloud taken wholesale | first sync on this device | `setSyncStatus('success')` | `cloud_done` |
| merge, `changedFromCloud` true | local must be written back | via `saveToFirestoreIfDirty` | `cloud_done` |
| **merge, `changedFromCloud` false** | **already agree, nothing to write** | **nothing** | **`sync`** |

The last row is the **most** in-sync a user can be and the usual outcome of opening the popup. So the one state that is completely fine was the only one that did not say so.

## The second half: stop offering a sync that cannot run

`isSignedIn` is now checked **first** and beats any status, rendering `cloud_off` disabled.

Signed out is not a startup flash. `App.tsx` reaches it on a failed `chrome.storage.sync` write, on a read-back that does not match what was written, and on a token that is present but unusable (which also raises `UNREADABLE_ACCOUNT_TOKEN`). In each of those the control invited a click that ran `loadFromFirestore(userId!)` with no `userId` — and that function's missing-document branch goes on to write through `saveToFirestore(null, ...)`.

The control keeps its tab stop while disabled, which is what a disabled `Icon` already does and what KAN-66 settled: taking it out of the tab order at the moment it disables would drop focus to `<body>`.

## Not derived from `isDirty`, and that is the point

Deriving the icon from `isDirty` is the obvious shortcut and is wrong. `globalState` is rebuilt on every popup open, so `isDirty === false` means *"no edits yet this session"*, not *"the two sides agree"* — with auto-sync off, nothing has been compared at all.

Only a completed sync can know that, which is exactly what `syncStatus` records. The enum is not redundant bookkeeping; one branch simply forgot to write to it.

## Root cause worth recording

`markDirty` (`globalStateSlice.ts:293`) deliberately couples the two facts in the dirty direction — `isDirty = true` **and** `syncStatus = 'idle'`. There is no equivalent going clean: `setIsNotDirty` sets only `isDirty = false`, so every caller has to remember the status separately, and one did not.

Giving `setIsNotDirty` the same coupling would stop this recurring, but it touches every caller and each needs checking. Not done here; flagged instead.

## Evidence

**Four store tests** pin what the thunk reports, with the wholesale-cloud branch as the control (so a failure cannot mean "the thunk never ran") and an unreadable document proving not every outcome reports success. **Six component tests** pin the icon the header shows for each state, with the signed-in-and-idle case as the control.

**Mutations, each killing only its own tests:** removing `setSyncStatus('success')` fails 1 of the 4 store tests; removing the `!isSignedIn` branch fails 2 of the 6 component tests. Controls green in both.

**632 unit tests / 74 files**, up from 622/72. Playwright 43/43, `tsc --noEmit` 0, `typecheck:e2e` 0, `eslint src e2e` 0 errors / 25 warnings — the baseline exactly. Prettier clean.

Verified in the live extension after the fix: the header reads `cloud_done` with `aria-disabled: null` on open, where it previously read `sync`.

### One of my own tests was wrong first

I mocked `loadFromFirestore` to reject. The real one **never rejects** — it catches everything and returns `undefined` (`external.ts:49-66`), and `undefined` means "no document yet", which is a success path. The test was asserting a contract the function does not have. The genuine error trigger is an *unreadable* document, which is what it uses now.

### Two existing tests needed a corrected precondition

`iconKeyboardActivation` and `keyboardReachability` rendered `MenuContainer` against the default store — which is signed **out** — and asserted the sync icon was enabled and dispatching. They sign in now, which is the only state in which those assertions can hold.

The second had a subtler problem worth naming: its "disabled while loading" assertion would otherwise have started passing for the wrong reason, since signed out disables the control too. Signing in isolates the variable it means to test.

## Scope

Pre-existing and shipped. Display only — `isDirty` was always set correctly in every branch, so no data was at risk. Not a regression from KAN-74, 75, 77 or 78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
