### PR TITLE
Reveal a row's actions and fill the row off one condition (KAN-92)

### DIFF
--- a/e2e/row-state-feedback.spec.ts
+++ b/e2e/row-state-feedback.spec.ts
@@ -1,0 +1,128 @@
+import type { BrowserContext, Locator, Page } from '@playwright/test';
+
+import { test, expect } from './fixtures/extension';
+import { buildContainer, buildSession, seedSessions } from './fixtures/seed';
+
+// KAN-92. A session row shows two things when you engage with it: it REVEALS
+// its Open/Switch/Delete actions, and it FILLS with the hover colour. Those
+// were driven by two independent mechanisms and could disagree.
+//
+//   reveal (the action block's opacity) <- React `isHovered` state, OR the
+//                                          block's own :focus-within
+//   fill   (the row's inset box-shadow) <- the container's :hover, and only
+//                                          :hover
+//
+// The three action Icons each paint an opaque background of HOVER_COLOR --
+// load-bearing, because the block is absolutely positioned over the title and
+// has to mask it. So when the reveal fires without the fill, that background
+// becomes a hover-coloured strip glued to the right of a row that is not
+// hovered, with a hard vertical edge cutting the title in half.
+//
+// Reachable two ways, both real:
+//   1. Keyboard. Tab to an action: :focus-within reveals, :hover is false.
+//      That is what this spec pins, because it is deterministic.
+//   2. Mouse. onMouseLeave does not fire when the pointer leaves the window
+//      abruptly -- pressing a screenshot hotkey does exactly that -- so the
+//      React state stays true while :hover drops in the same frame. Not
+//      pinned here: leaving the OS window is not something Playwright can
+//      stage honestly.
+//
+// The assertion compares against a genuinely hovered row rather than against
+// a hard-coded rgb(). A literal would pin the LIGHT palette and go green on a
+// fix that filled the row with the wrong colour; the comparison says the only
+// thing that matters, which is that the two states agree.
+
+async function openWith(
+  context: BrowserContext,
+  extensionId: string
+): Promise<Page> {
+  await seedSessions(
+    context,
+    buildContainer([
+      buildSession({ tabGroupId: 'first', title: 'First session' }),
+      buildSession({ tabGroupId: 'second', title: 'Second session' }),
+    ])
+  );
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/index.html`);
+  return page;
+}
+
+/** The row container is the parent of the row's ClickableRow button. */
+const rowFor = (page: Page, title: string): Locator =>
+  page.getByRole('button', { name: title, exact: true }).locator('..');
+
+/** The absolutely-positioned Open/Switch/Delete block inside a row. */
+const actionsIn = (row: Locator): Locator => row.locator('> div').last();
+
+const fillOf = (row: Locator): Promise<string> =>
+  row.evaluate((el) => getComputedStyle(el).boxShadow);
+
+const TRANSPARENT = /rgba\(0, 0, 0, 0\)/;
+
+// The fill eases in over 0.2s (KAN-82 keeps the transition on the shadow
+// precisely so hover CAN ease), so reading it the moment the state changes
+// catches a partial alpha -- the first run of this spec captured
+// `rgba(223, 226, 230, 0.224)` and would have compared two arbitrary points
+// on the curve. A settled opaque colour serialises as `rgb(...)`; every
+// in-flight frame and the transparent start state serialise as `rgba(...)`,
+// so waiting for the absence of an alpha channel is exactly "the transition
+// has finished".
+async function settledFillOf(row: Locator): Promise<string> {
+  await expect
+    .poll(() => fillOf(row), {
+      message: 'the row fill should settle to a fully opaque colour',
+    })
+    .not.toMatch(/rgba\(/);
+  return fillOf(row);
+}
+
+test.describe('a row reveals its actions and fills as one state', () => {
+  test('a row whose actions the keyboard revealed is filled like a hovered one', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openWith(context, extensionId);
+    const first = rowFor(page, 'First session');
+    const second = rowFor(page, 'Second session');
+
+    // What a genuinely hovered row looks like. Playwright's hover is a real
+    // mouse move, so this is the actual :hover rendering, not a synthesized
+    // event -- which is why this spec can compare against it at all.
+    await first.hover();
+    const hoveredFill = await settledFillOf(first);
+
+    // CONTROL for the comparison: hovering really does change the fill. If
+    // this were transparent the main assertion could pass against a row that
+    // is never filled in any state.
+    expect(
+      hoveredFill,
+      'a hovered row should carry a non-transparent fill'
+    ).not.toMatch(TRANSPARENT);
+
+    // Park the pointer off every row, so nothing below is hover-driven.
+    await page.mouse.move(0, 0);
+    expect(
+      await fillOf(second),
+      'CONTROL: an untouched row starts unfilled'
+    ).toMatch(TRANSPARENT);
+
+    // Reveal the second row's actions with focus rather than the pointer.
+    // .focus() rather than a Tab walk on purpose: :focus-within does not
+    // distinguish the two, and this spec is about styling, not reachability
+    // (which KAN-68's tab-order specs already cover).
+    const open = actionsIn(second).getByRole('button', { name: 'Open' });
+    await open.focus();
+
+    // The reveal happened -- without this the fill assertion could go green
+    // simply because nothing was showing.
+    await expect(actionsIn(second)).toHaveCSS('opacity', '1');
+
+    await expect
+      .poll(() => fillOf(second), {
+        message:
+          'a row showing its actions must fill the same as a hovered row',
+      })
+      .toBe(hoveredFill);
+  });
+});

--- a/src/components/home/leftpane/TabGroupEntry.tsx
+++ b/src/components/home/leftpane/TabGroupEntry.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler, useState } from 'react';
+import React, { MouseEventHandler } from 'react';
 
 import { useSelector } from 'react-redux';
 
@@ -43,8 +43,6 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
   const FONT_FAMILY = useFontFamily();
   const { t, i18n } = useTranslation();
 
-  const [isHovered, setIsHovered] = useState(false);
-
   const isSearchPanel = useSelector(
     (state: RootState) => state.globalState.isSearchPanel
   );
@@ -55,9 +53,6 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
   const searchInputText = useSelector(
     (state: RootState) => state.globalState.searchInputText
   );
-
-  const handleMouseEnter = () => setIsHovered(true);
-  const handleMouseLeave = () => setIsHovered(false);
 
   const { title, createdTime, createdAt, windowCount, tabCount, isSelected } =
     tabGroupData;
@@ -84,15 +79,11 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
     height: 100%;
     justify-content: flex-start;
     align-items: center;
-    opacity: ${isHovered ? 1 : 0};
+    /* Hidden by default. What reveals it lives on the CONTAINER, not here --
+       see the engagement comment on containerStyle for why the two cannot be
+       allowed to drift apart. */
+    opacity: 0;
     transition: opacity 0.1s ease-out;
-    /* Hover reveals these to a pointer; focus-within is the same reveal for
-       the keyboard. Without it the controls are in the tab order (KAN-68) but
-       land on something invisible, which is arguably worse than not reaching
-       them at all. */
-    &:focus-within {
-      opacity: 1;
-    }
   `;
 
   const containerStyle = css`
@@ -123,8 +114,38 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
        fill it, and 100vw is comfortably past that at any popup size. */
     box-shadow: inset 0 0 0 100vw transparent;
     transition: box-shadow 0.2s;
-    &:hover {
+
+    /* ENGAGEMENT IS ONE STATE, SO IT GETS ONE CONDITION (KAN-92).
+
+       A row engaged with does two things: it reveals its Open/Switch/Delete
+       block, and it fills. Those used to run off different triggers -- the
+       reveal off a React isHovered set by onMouseEnter/onMouseLeave, or the
+       block's own :focus-within; the fill off this container's :hover alone.
+       Two triggers for one state will eventually disagree, and both ways of
+       making them disagree were reachable:
+
+         - Tab to an action. The block's :focus-within revealed it while
+           :hover stayed false, so the row did not fill.
+         - Leave the window abruptly, which is exactly what pressing a
+           screenshot hotkey does. onMouseLeave never fires, so the React
+           state stayed true while :hover dropped in the same frame.
+
+       Either way the action Icons -- which carry an opaque HOVER_COLOR
+       background, load-bearing because the block is positioned over the title
+       and has to mask it -- became a hover-coloured strip glued to the right
+       of a row with no fill, with a hard vertical edge through the title.
+
+       So the reveal is stated HERE, next to the fill, sharing one selector.
+       They can no longer drift, because there is nothing left to drift from:
+       the React state is gone. Note this deliberately also fires when the
+       row's own title button holds focus, not only the actions -- a row you
+       have tabbed to should show what you can do with it. */
+    &:hover,
+    &:focus-within {
       ${!isSelected && `box-shadow: inset 0 0 0 100vw ${COLORS.HOVER_COLOR};`}
+      [data-row-actions] {
+        opacity: 1;
+      }
     }
     background-color: ${isSelected && COLORS.SELECTION_COLOR};
   `;
@@ -141,11 +162,7 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
   // siblings. `leftStyle` is width: 100%, so the clickable area is unchanged;
   // the action block is absolutely positioned on top of it.
   return (
-    <div
-      css={containerStyle}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-    >
+    <div css={containerStyle}>
       <ClickableRow
         ariaLabel={title}
         onClick={onTabGroupClick}
@@ -184,7 +201,7 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
         </div>
       </ClickableRow>
       {!isSearchPanel && (
-        <div css={rightStyle}>
+        <div data-row-actions css={rightStyle}>
           <Icon
             tooltipText={t('Open session')}
             text={t('Open')}


### PR DESCRIPTION
Reported from a live screenshot while hovering the second session: a grey strip glued to the right of the row, with a hard vertical edge cutting the title, and the rest of the row unfilled.

## KAN-92 — the reveal and the fill were two triggers for one state

A row engaged with does two things. It **reveals** its Open/Switch/Delete block, and it **fills** with `HOVER_COLOR`.

| | driven by |
| --- | --- |
| reveal (block `opacity`) | React `isHovered` from `onMouseEnter`/`onMouseLeave`, **or** the block's own `:focus-within` |
| fill (row inset `box-shadow`) | the container's `:hover` — and only `:hover` |

The strip is the three action `Icon`s, each painting an opaque `HOVER_COLOR` background. **That background is load-bearing**: the block is absolutely positioned over the title and has to mask it. So when the reveal fires without the fill, the mask is left standing on a row with nothing behind it.

Both ways of reaching that are real:

```
rowIsHovered:      false
rowHasFocusWithin: true
actionsOpacity:    1                                   <- revealed
rowBoxShadow:      rgba(0, 0, 0, 0) 0 0 0 785px inset  <- not filled
iconBackground:    rgb(223, 226, 230)                  <- the strip
```

1. **Keyboard.** Tab to an action: `:focus-within` reveals, `:hover` is false. The measurement above, and what the spec pins.
2. **Mouse.** `onMouseLeave` does not fire when the pointer leaves the window abruptly — **pressing a screenshot hotkey does exactly that**. The React state stays true while `:hover` drops in the same frame. Almost certainly what was captured, and not something Playwright can stage honestly.

The fix states the reveal next to the fill, sharing one selector, and deletes the React state so there is nothing left to drift from. `useState`, both mouse handlers and `isHovered` all come out.

**Deliberate side effect**: focusing the row's *own* title button now engages it too, where before only focus inside the action block did. A row you have tabbed to should show what you can do with it.

**KAN-82 is untouched and still holds** — selection stays on `background-color` and does not transition, the fill stays on the inset shadow and still eases. Verified live rather than assumed: a selected idle row reads `background-color: rgb(203, 206, 211)` with a transparent shadow.

## Verification

`e2e/row-state-feedback.spec.ts` compares the focus-revealed row against a **genuinely hovered** row rather than a hard-coded `rgb()`. A literal would pin the LIGHT palette and go green on a fix that filled the row with the wrong colour; the comparison asserts the only thing that matters, which is that the two states agree.

Three controls, so the assertion cannot pass vacuously: the hovered fill is non-transparent, an untouched row starts unfilled, and the reveal actually happened.

The fill is read **settled**. The first run captured `rgba(223, 226, 230, 0.224)` mid-transition and would have compared two arbitrary points on the 0.2s curve; an opaque colour serialises as `rgb(...)` while every in-flight frame serialises as `rgba(...)`, so waiting for the absence of an alpha channel *is* "the transition finished".

Two mutations, both killed:

| mutation | killed by |
| --- | --- |
| drop `:focus-within` from the shared selector | the **reveal** assertion (`opacity` 0) |
| split them again — reveal on `:hover, :focus-within`, fill on `:hover` only, i.e. the original bug exactly | the **fill** assertion, reveal still passing |

The second is the decisive one: it proves the spec targets the defect rather than a side effect. Both mutants were confirmed **in the built bundle** before running — an early run of the spec silently tested the previous artifact because `playwright test` does not build.

**710 unit/component tests in 80 files. Playwright 52/52, up from 51.** `tsc --noEmit` 0, `typecheck:e2e` 0, `eslint src e2e` **0 errors / 25 warnings — the baseline exactly**. Verified live in the popup on a rebuilt artifact, in all four states: hovered, focus-revealed, idle, and selected-idle.

## Filed, not fixed here

**KAN-93.** `ICON_HOVER_COLOR` moves *lighter* on every theme, which is right on a dark ground and backwards on a light one — so hovering an icon inside a hovered row punches a bright hole in it.

```
theme              PRIMARY  HOVER    ICON_HOV SELECT   | icon vs row-hover
LIGHT_THEME        #F5F7FA #DFE2E6 #F8FAFC #CBCED3 | LIGHTER 1.24 (light) <-- INVERTED
WARM_LIGHT_THEME   #F8F3E8 #E9E5D8 #F8F6EC #E0DBBF | LIGHTER 1.16 (light) <-- INVERTED
BB_PINK_THEME      #FAD2E1 #F7B3D0 #F48FB1 #F89CB9 | darker  1.31 (light) OK
DARKENHEIMER_THEME #2A2A2A #3E3E3E #4A4A4A #3B3B3B | LIGHTER 1.21 (dark)  OK
BLUE_THEME         #2A2A3A #3E3E48 #4A4A58 #3B3B4A | LIGHTER 1.21 (dark)  OK
```

LIGHT is the default theme, and there `ICON_HOVER_COLOR` is lighter even than the pane behind everything. Picking replacements is a palette decision that lands in **KAN-87**'s deferred territory, so it is left to be done with that work rather than guessed at now.

## Scope

Pre-existing and shipped in 1.5.0. Cosmetic — no data, no sync, no behaviour change beyond the focus engagement noted above. Distinct from KAN-87, which is hover-vs-selection *contrast*; this was hover-vs-hover *disagreement*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
