### PR TITLE
Tell selection from hover by shape, not by three units of grey (KAN-87)

### DIFF
--- a/e2e/selection-is-distinguishable.spec.ts
+++ b/e2e/selection-is-distinguishable.spec.ts
@@ -1,0 +1,125 @@
+import type { BrowserContext, Locator, Page } from '@playwright/test';
+
+import { test, expect } from './fixtures/extension';
+import { buildContainer, buildSession, seedSessions } from './fixtures/seed';
+
+// KAN-87. Hover and selection were told apart only by lightness, and by
+// almost none of it: SELECTION_COLOR against HOVER_COLOR is 1.21:1 on Light
+// and 1.04:1 on Blue, where WCAG 1.4.11 asks 3:1 for a state a user has to
+// distinguish. So hovering an unselected row made it look selected, and with
+// two rows looking selected there was no way to tell which one the right pane
+// was actually showing.
+//
+// The mechanism was never the problem -- KAN-82 correctly split selection
+// (background-color, settled) from hover (inset box-shadow, eased), and that
+// still holds. The two properties were simply painted almost the same colour.
+//
+// No colour-only fix reaches 3:1 without making a selected row the LIGHTEST
+// thing in the pane, which inverts the visual hierarchy. So selection gains a
+// second cue of a different KIND -- a shape -- and that is what these specs
+// assert. A test that compared two fills could be satisfied by a palette tweak
+// that is still under 3:1; asserting on the bar's presence cannot be.
+//
+// The bar is a ::before, deliberately. ::after is reserved for the
+// drop-indicator line that drag-and-drop reordering will need, and an extra
+// inset box-shadow would recreate KAN-82 the moment a drag transition lands.
+//
+// Both panes are covered in one file on purpose: the defect was in the shared
+// palette, not in either component, so a per-component spec would have let the
+// two drift apart again.
+
+async function openPopup(
+  context: BrowserContext,
+  extensionId: string
+): Promise<Page> {
+  await seedSessions(
+    context,
+    buildContainer([
+      buildSession({ tabGroupId: 'first', title: 'First session' }),
+      buildSession({ tabGroupId: 'second', title: 'Second session' }),
+    ])
+  );
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/index.html`);
+  return page;
+}
+
+/** The session row's container is the parent of its ClickableRow button. */
+const sessionRow = (page: Page, title: string): Locator =>
+  page.getByRole('button', { name: title, exact: true }).locator('..');
+
+/**
+ * The marker the selected row carries and a hovered one must not.
+ *
+ * Read off ::before rather than off the row: `width` on a pseudo-element that
+ * was never generated computes to `auto`, so "no bar" and "a bar of zero
+ * width" are distinguishable, and a fix that drew the element but left it
+ * invisible cannot pass.
+ */
+async function accentBar(
+  row: Locator
+): Promise<{ width: string; color: string }> {
+  return row.evaluate((el) => {
+    const cs = getComputedStyle(el, '::before');
+    return { width: cs.width, color: cs.backgroundColor };
+  });
+}
+
+const barIsDrawn = (bar: { width: string; color: string }): boolean =>
+  /^\d+(\.\d+)?px$/.test(bar.width) &&
+  parseFloat(bar.width) > 0 &&
+  bar.color !== 'rgba(0, 0, 0, 0)';
+
+test.describe('selection is distinguishable from hover by shape', () => {
+  test('a selected session row carries an accent bar and a hovered one does not', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+    const first = sessionRow(page, 'First session');
+    const second = sessionRow(page, 'Second session');
+
+    await first.click({ position: { x: 20, y: 20 } });
+
+    // Hover the OTHER row -- the exact situation that was ambiguous: one row
+    // selected, a different one under the pointer.
+    await second.hover();
+
+    expect(
+      barIsDrawn(await accentBar(first)),
+      'the selected row should carry an accent bar'
+    ).toBe(true);
+
+    expect(
+      barIsDrawn(await accentBar(second)),
+      'CONTROL: a hovered but unselected row must NOT carry one, or the bar ' +
+        'would say nothing about which row is selected'
+    ).toBe(false);
+  });
+
+  test('a selected settings category carries an accent bar and a hovered one does not', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openPopup(context, extensionId);
+    await page.locator('[aria-label="Settings"]').click();
+
+    // Settings categories are real <button>s (KAN-64), named by their own
+    // translated label.
+    const selected = page.getByRole('button', { name: 'Sync & Privacy' });
+    const other = page.getByRole('button', { name: 'Data Management' });
+
+    await selected.click();
+    await other.hover();
+
+    expect(
+      barIsDrawn(await accentBar(selected)),
+      'the selected category should carry an accent bar'
+    ).toBe(true);
+
+    expect(
+      barIsDrawn(await accentBar(other)),
+      'CONTROL: a hovered but unselected category must NOT carry one'
+    ).toBe(false);
+  });
+});

--- a/src/components/home/leftpane/TabGroupEntry.tsx
+++ b/src/components/home/leftpane/TabGroupEntry.tsx
@@ -148,6 +148,38 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
       }
     }
     background-color: ${isSelected && COLORS.SELECTION_COLOR};
+
+    /* SELECTION IS TOLD APART BY SHAPE, NOT BY LIGHTNESS (KAN-87).
+
+       SELECTION_COLOR against HOVER_COLOR is 1.21:1 on Light and 1.04:1 on
+       Blue, where WCAG 1.4.11 asks 3:1 for a state a user must distinguish.
+       So a hovered row read as selected, and with two rows looking selected
+       there was no way to tell which one the right pane was showing.
+
+       No colour-only fix reaches 3:1 without making a selected row the
+       LIGHTEST thing in the pane, which inverts the hierarchy -- hover is
+       transient, selection is persistent, and the persistent state should be
+       the stronger signal. So selection gains a cue of a different KIND.
+
+       TEXT_COLOR, not SELECTION_COLOR: the bar has to carry the contrast the
+       fill cannot, and it is read against three different grounds. Measured
+       worst case across all five themes is 6.90:1, the same reasoning that
+       picked the theme swatch ring in KAN-88.
+
+       ::before, not ::after and not another inset shadow. ::after is reserved
+       for the drop-indicator line drag-and-drop reordering will need, and a
+       second inset shadow would put selection back on the property hover
+       already eases -- which is KAN-82, exactly. */
+    ${isSelected &&
+    `&::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: 3px;
+      background-color: ${COLORS.TEXT_COLOR};
+    }`}
   `;
 
   // The row's primary action lives on the inner ClickableRow, not on this

--- a/src/components/settings/leftpane/SettingsCategoryContainer.tsx
+++ b/src/components/settings/leftpane/SettingsCategoryContainer.tsx
@@ -47,10 +47,13 @@ const SettingsCategoryContainer: React.FC = () => {
   // A plain string, not css``: handed to ClickableRow's `style` prop. width
   // is explicit because a <button> shrink-wraps its content where the div it
   // replaced stretched to fill the flex column.
+  // `position: relative` is here only to anchor the selected category's accent
+  // bar below; the button had no positioned ancestor of its own.
   const selectableStyle = (isSelected: boolean) => `
     cursor: pointer;
     transition: background-color 0.2s;
     width: 100%;
+    position: relative;
     &:hover {
       background-color: ${!isSelected ? COLORS.HOVER_COLOR : 'unset'};
     }
@@ -58,6 +61,26 @@ const SettingsCategoryContainer: React.FC = () => {
       isSelected ? COLORS.SELECTION_COLOR : COLORS.PRIMARY_COLOR
     };
     padding: 15px clamp(10px, 12%, 38px);
+    /* KAN-87. Hover and selection differ by 1.04-1.21:1 across the themes, so
+       a hovered category read as the selected one. Selection therefore carries
+       a shape cue as well as a fill. The full reasoning -- why TEXT_COLOR, and
+       why ::before rather than ::after or a second inset shadow -- is on
+       TabGroupEntry's containerStyle, which does the same thing for the
+       session list. Kept identical on purpose: they share the palette that
+       caused this, so they must not drift apart again. */
+    ${
+      isSelected
+        ? `&::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: 3px;
+      background-color: ${COLORS.TEXT_COLOR};
+    }`
+        : ''
+    }
   `;
 
   return (


### PR DESCRIPTION
Reported against the settings sidebar: hovering a category looked the same as the selected one, so it felt like nothing was selected at all. The same defect is in the session list, and KAN-87 already named both.

## The measurement

`SELECTION_COLOR` against `HOVER_COLOR`, as WCAG contrast ratios:

| theme | selection | hover | contrast |
| --- | --- | --- | --- |
| Light | `#CBCED3` | `#DFE2E6` | 1.21 |
| Warm Light | `#E0DBBF` | `#E9E5D8` | 1.11 |
| BB Pink | `#F89CB9` | `#F7B3D0` | 1.18 |
| Darkenheimer | `#3B3B3B` | `#3E3E3E` | **1.05** |
| Blue | `#3B3B4A` | `#3E3E48` | **1.04** |

WCAG 1.4.11 asks 3:1 for a state a user has to distinguish. **Every theme is under 1.25:1.** Three units out of 255 per channel separate selected from hovered, against seventeen for an untouched row.

## The mechanism was never wrong

**KAN-82 is holding.** It correctly split selection (`background-color`, settled, no transition) from hover (inset `box-shadow`, eased) so the two stop sharing a transition — and the live samples confirm it still does. The two properties were simply painted almost the same colour. The collapse is in `useThemeColors.tsx`, one layer below both components, which is why both panes have it.

## Why a shape and not a colour

**No colour-only fix reaches 3:1 without making a selected row the lightest thing in the pane**, which inverts the hierarchy — hover is transient, selection is persistent, and the persistent state should be the stronger signal. So selection gains a cue of a different *kind*: a 3px accent bar on the leading edge. The palette is left alone.

**`TEXT_COLOR`, not `SELECTION_COLOR`.** The bar carries the contrast the fill cannot, and it is read against three different grounds:

```
theme          TEXT     | vs PRIMARY  vs HOVER  vs SELECTION   worst
LIGHT          #3B3D40 |     10.15      8.38         6.90     6.90 PASS
WARM_LIGHT     #28251F |     13.80     12.12        10.95    10.95 PASS
BB_PINK        #2A2A2A |     10.51      8.42         7.14     7.14 PASS
DARKENHEIMER   #D0D0D0 |      9.31      6.93         7.26     6.93 PASS
BLUE           #D0D0DF |      9.24      6.93         7.21     6.93 PASS
```

Same reasoning that picked the theme swatch ring in KAN-88, where `SELECTION_COLOR` would have been invisible on exactly the dark themes that needed it most.

**`::before`, not `::after` and not a second inset shadow.** `::after` is reserved for the drop-indicator line drag-and-drop reordering will need, and another inset shadow would put selection back on the property hover already eases — which is KAN-82, exactly.

## Verification

`e2e/selection-is-distinguishable.spec.ts` covers **both panes in one file on purpose**: the defect was in the shared palette, not in either component, so per-component specs would let them drift apart again.

It asserts the bar's **presence**, not a comparison of two fills — a fill comparison could be satisfied by a palette tweak that is still under 3:1. It reads `::before`, where a pseudo-element that was never generated computes `width: auto`, so "no bar" and "a zero-width bar" stay distinguishable.

Two mutations, both killed in both panes:

| mutation | killed by |
| --- | --- |
| draw the bar unconditionally | the **CONTROL** — a bar on every row says nothing about which is selected |
| draw it, but transparent | the **main assertion** — proves the spec checks visibility, not mere existence |

**710 unit/component tests. Playwright 54/54, up from 52.** `tsc` 0, `typecheck:e2e` 0, `eslint src e2e` **0 errors / 25 warnings — baseline**.

Verified live on **Darkenheimer, the 1.05:1 worst case**:

| | fill | bar |
| --- | --- | --- |
| Display / ALPHA (selected) | `rgb(59,59,59)` | **3px `rgb(208,208,208)`** |
| Data Management / BETA (hovered) | `rgb(62,62,62)` | `auto` — none |
| Language (idle) | `rgb(42,42,42)` | none |

The fills are still three units apart. That is deliberate and unchanged; the bar is what carries the distinction now.

## Scope

Closes KAN-87 for both panes. Pre-existing and shipped in every theme. Cosmetic, but it made the left pane ambiguous during ordinary pointer use, which is most of the time.

**Note for drag-and-drop.** This spends `::before` on the session row. `::after` stays free for the drop indicator, `transform` stays free for FLIP, and outset `box-shadow` stays free for the drag lift — so the allocation that work needs is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
