### PR TITLE
Engage a row on :focus-visible, not on any focus (KAN-94)

### DIFF
--- a/e2e/row-state-feedback.spec.ts
+++ b/e2e/row-state-feedback.spec.ts
@@ -77,6 +77,31 @@ async function settledFillOf(row: Locator): Promise<string> {
   return fillOf(row);
 }
 
+/**
+ * Press Tab until `target` holds focus.
+ *
+ * A real key press, not `.focus()`, because engagement keys off
+ * :focus-visible and Chrome decides that from the PRECEDING interaction --
+ * after a mouse move, a programmatic focus does not set it. `.focus()` would
+ * therefore test a state no keyboard user can reach, and would pass against
+ * code that never engages on Tab at all.
+ *
+ * Walking rather than pressing a fixed count: the number of stops ahead of
+ * this control is an unrelated fact about the header and the rows above it,
+ * and hard-coding it turns any change there into a failure here.
+ */
+async function tabUntilFocused(
+  page: Page,
+  target: Locator,
+  maxPresses = 40
+): Promise<void> {
+  for (let i = 0; i < maxPresses; i++) {
+    if (await target.evaluate((el) => el === document.activeElement)) return;
+    await page.keyboard.press('Tab');
+  }
+  throw new Error(`Tab never reached the target in ${maxPresses} presses`);
+}
+
 test.describe('a row reveals its actions and fills as one state', () => {
   test('a row whose actions the keyboard revealed is filled like a hovered one', async ({
     context,
@@ -107,12 +132,13 @@ test.describe('a row reveals its actions and fills as one state', () => {
       'CONTROL: an untouched row starts unfilled'
     ).toMatch(TRANSPARENT);
 
-    // Reveal the second row's actions with focus rather than the pointer.
-    // .focus() rather than a Tab walk on purpose: :focus-within does not
-    // distinguish the two, and this spec is about styling, not reachability
-    // (which KAN-68's tab-order specs already cover).
+    // Reveal the second row's actions with a REAL Tab press, not .focus().
+    // KAN-94: engagement now keys off :focus-visible, and Chrome decides that
+    // from the preceding interaction -- a programmatic .focus() after a mouse
+    // move does not set it. So .focus() would test a state no keyboard user
+    // can be in, and would go green against code that never engages on Tab.
     const open = actionsIn(second).getByRole('button', { name: 'Open' });
-    await open.focus();
+    await tabUntilFocused(page, open);
 
     // The reveal happened -- without this the fill assertion could go green
     // simply because nothing was showing.
@@ -124,5 +150,46 @@ test.describe('a row reveals its actions and fills as one state', () => {
           'a row showing its actions must fill the same as a hovered row',
       })
       .toBe(hoveredFill);
+  });
+
+  // KAN-94, a regression from the fix above. Collapsing reveal and fill onto
+  // one condition was right; :focus-within was the wrong condition. It matches
+  // ANY focus, including the focus a mouse click leaves behind -- so clicking a
+  // row engaged it indefinitely, and with no focus ring on a click there was
+  // nothing on screen to explain why. Reported as "why is hover state sticky".
+  //
+  // :focus-visible is the distinction that was wanted all along: the browser
+  // already decides whether a given focus deserves a visible indicator, and it
+  // says no for a click. Measured on the broken build with the pointer parked
+  // away: :focus-within true, :has(:focus-visible) false, actions opacity 1.
+  test('a row clicked with the mouse does not stay engaged once the pointer leaves', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openWith(context, extensionId);
+    const first = rowFor(page, 'First session');
+
+    await first.click({ position: { x: 20, y: 20 } });
+
+    // CONTROL: the click really did leave focus inside the row. Without this
+    // the test could pass on a build where clicking focuses nothing at all,
+    // which is a different app, not a fixed one.
+    expect(
+      await first.evaluate((el) => el.matches(':focus-within')),
+      'the click should leave focus inside the row -- otherwise this test ' +
+        'proves nothing about focus-driven stickiness'
+    ).toBe(true);
+
+    await page.mouse.move(0, 0);
+
+    await expect
+      .poll(
+        () => actionsIn(first).evaluate((el) => getComputedStyle(el).opacity),
+        {
+          message:
+            'a clicked row must not keep showing its actions after the pointer leaves',
+        }
+      )
+      .toBe('0');
   });
 });

--- a/src/components/home/leftpane/TabGroupEntry.tsx
+++ b/src/components/home/leftpane/TabGroupEntry.tsx
@@ -86,6 +86,16 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
     transition: opacity 0.1s ease-out;
   `;
 
+  // What "engaged" paints. Declared once and used by both rules below, so the
+  // hover and keyboard branches cannot drift apart -- which is the whole point
+  // of KAN-92 and the reason they are not written out twice.
+  const engagedStyle = `
+    ${!isSelected ? `box-shadow: inset 0 0 0 100vw ${COLORS.HOVER_COLOR};` : ''}
+    [data-row-actions] {
+      opacity: 1;
+    }
+  `;
+
   const containerStyle = css`
     position: relative;
     display: flex;
@@ -135,17 +145,36 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
        and has to mask it -- became a hover-coloured strip glued to the right
        of a row with no fill, with a hard vertical edge through the title.
 
-       So the reveal is stated HERE, next to the fill, sharing one selector.
+       So the reveal is stated HERE, next to the fill, sharing one condition.
        They can no longer drift, because there is nothing left to drift from:
-       the React state is gone. Note this deliberately also fires when the
-       row's own title button holds focus, not only the actions -- a row you
-       have tabbed to should show what you can do with it. */
-    &:hover,
-    &:focus-within {
-      ${!isSelected && `box-shadow: inset 0 0 0 100vw ${COLORS.HOVER_COLOR};`}
-      [data-row-actions] {
-        opacity: 1;
-      }
+       the React state is gone.
+
+       That condition is :has(:focus-visible), NOT :focus-within (KAN-94).
+       :focus-within matches any focus, including the focus a mouse click
+       leaves behind -- so clicking a row engaged it indefinitely, and since a
+       click draws no focus ring there was nothing on screen to explain why.
+       It read as a stuck hover, and it shipped that way for half an hour.
+
+       :focus-visible is the distinction that was wanted all along: the
+       browser already decides whether a given focus deserves a visible
+       indicator, and it answers no for a click and yes for a Tab. So the
+       intent -- a row you have TABBED to should show what you can do with it
+       -- is now stated by the selector rather than only by this comment.
+
+       TWO RULES, not one selector list. An invalid selector anywhere in a
+       comma-separated list invalidates the whole rule, so a combined
+       "&:hover, &:has(...)" would take hover down with it on any engine
+       without :has() (Chrome 105+). Split, :hover stands on its own and only
+       the keyboard affordance degrades. The declarations are shared rather
+       than typed twice, so the two rules cannot drift either.
+
+       (No backticks anywhere in this comment: it lives inside a css template
+       literal, and one would end the literal mid-comment.) */
+    &:hover {
+      ${engagedStyle}
+    }
+    &:has(:focus-visible) {
+      ${engagedStyle}
     }
     background-color: ${isSelected && COLORS.SELECTION_COLOR};
 


### PR DESCRIPTION
**Regression from KAN-92 (#184)**, reported within the hour: a clicked row kept its action block revealed after the pointer moved away, reading as a stuck hover. Never released — introduced in `cd0019d` and fixed here, both inside 1.6.0's unreleased range.

## What was wrong

KAN-92 was right that the reveal and the fill must share one condition. It picked the wrong condition.

Measured on the broken build, pointer parked elsewhere, after clicking a row:

```
activeElement:              BUTTON "BETA session"   <- the click left focus here
betaIsHovered:              false                   <- pointer is elsewhere
betaHasFocusWithin:         true                    <- so the row stays engaged
betaHasFocusVisibleInside:  false                   <- browser: this focus needs no ring
actionsOpacity:             1                       <- stuck
```

`:focus-within` matches **any** focus, including the focus a mouse click leaves behind. And because a click draws no focus ring, there was nothing on screen to explain why the row looked engaged.

That fourth line is the fix stated as a measurement: **`:focus-visible` is exactly the distinction wanted.** The browser already decides whether a given focus deserves a visible indicator, and it answers no for a click and yes for a Tab. KAN-92's comment claimed the intent was *"a row you have tabbed to should show what you can do with it"* — now the selector says that, rather than the comment.

## Two rules, not one selector list

An invalid selector anywhere in a comma-separated list invalidates the **entire** rule. So a combined `&:hover, &:has(...)` would take hover down with it on any engine without `:has()` — Chrome 105+, against an 89+ floor already set by `chrome.tabGroups`, with no `minimum_chrome_version` declared. Split into two rules, `:hover` stands on its own and only the keyboard affordance degrades.

The declarations are hoisted into one `engagedStyle` used by both, so the two rules cannot drift — which was KAN-92's whole point and still is.

## The spec change is a finding, not collateral

`row-state-feedback.spec.ts` drove the keyboard case with `.focus()`. **That does not reliably set `:focus-visible`** — Chrome decides from the *preceding* interaction, so a programmatic focus after a mouse move does not qualify. A `.focus()` version of this test would pass against code that never engages on Tab at all.

It now presses a real Tab and walks until the control holds focus, rather than a fixed count that would break on any change to the header above it.

## Verification

Two mutations, killed in **opposite directions** — which is what pins both halves rather than just one:

| mutation | killed by | other test |
| --- | --- | --- |
| revert to `:focus-within` | the new click test | keyboard still passes |
| delete the `:has(:focus-visible)` rule | the keyboard test | click test still passes |

**710 unit/component tests. Playwright 55/55, up from 54.** `tsc` 0, `typecheck:e2e` 0, `eslint src e2e` **0 errors / 25 warnings — baseline**.

Verified live with a **real CDP click**, pointer then moved away:

```
ALPHA (just clicked):  isHovered false   focusWithin true
                       hasFocusVisible false   actionsOpacity 0    <- no longer stuck
```

Worth recording: a first live probe using `dispatchEvent` + `.focus()` reported `hasFocusVisible: true` and would have said the fix had failed. It was measuring the harness, not the app — synthesized input does not reproduce Chrome's focus-visible heuristic. Only the real click is evidence.

## Scope

Cosmetic. No data, no sync, no behaviour beyond the engagement rule. KAN-92's invariant is untouched: reveal and fill still share one condition and cannot disagree — only the condition changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
