### PR TITLE
Mark the active theme swatch with its own border, not a ring (KAN-95)

### DIFF
--- a/e2e/theme-swatch-marker.spec.ts
+++ b/e2e/theme-swatch-marker.spec.ts
@@ -1,0 +1,118 @@
+import type { BrowserContext, Locator, Page } from '@playwright/test';
+
+import { test, expect } from './fixtures/extension';
+
+// KAN-95. The active theme swatch was marked with `outline: 2px solid
+// TEXT_COLOR; outline-offset: 2px`, which is wrong in two separable ways.
+//
+// Too loud: TEXT_COLOR against the page is 9.2-13.8:1, focus-ring weight for
+// a passive state marker. Contrast was the right axis to measure and the wrong
+// one to maximise -- the same mistake as KAN-87's accent bar, rejected on
+// sight within the hour for the same reason.
+//
+// Cramped: 2px of outline plus 2px of offset is 4px of ring, and the swatches
+// sit in a flex row with gap: 4px, so the ring consumed the whole gap and
+// touched its neighbours. Each swatch also carries its own 1px border, so the
+// active one drew two concentric lines with a space between them.
+//
+// The marker is now the swatch's OWN border, thickened. One line instead of
+// two, nothing drawn outside the box, so the collision cannot recur by
+// construction. box-sizing: border-box keeps the swatch the same size as it
+// thickens -- avoiding the layout shift that made KAN-88 reach for an outline
+// in the first place.
+//
+// Asserted at every swatch rather than only the active one: "the active
+// swatch differs" is satisfied by a build where ALL of them are 2px, which is
+// no marker at all.
+
+async function openThemes(
+  context: BrowserContext,
+  extensionId: string
+): Promise<Page> {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/index.html`);
+  await page.locator('[aria-label="Settings"]').click();
+  await expect(page.getByText('Themes')).toBeVisible();
+  return page;
+}
+
+const THEMES = ['Light', 'Warm Light', 'BB Pink', 'Darkenheimer', 'Blue'];
+
+const swatch = (page: Page, name: string): Locator =>
+  page.getByRole('button', { name, exact: true });
+
+async function markerOf(
+  s: Locator
+): Promise<{ border: string; outline: string; width: number }> {
+  return s.evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return {
+      border: cs.borderTopWidth,
+      outline: cs.outlineStyle,
+      width: el.getBoundingClientRect().width,
+    };
+  });
+}
+
+test.describe('the active theme swatch is marked by its own border', () => {
+  test('only the active swatch is thickened, and no outline is drawn', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openThemes(context, extensionId);
+
+    // Pick a theme explicitly rather than trusting whatever the profile had.
+    await swatch(page, 'BB Pink').click();
+    await expect(swatch(page, 'BB Pink')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+
+    const active = await markerOf(swatch(page, 'BB Pink'));
+
+    expect(
+      active.border,
+      'the active swatch should carry a thicker border'
+    ).toBe('2px');
+    expect(
+      active.outline,
+      'no outline at all -- an outline is drawn outside the box and is what ' +
+        'collided with the neighbouring swatches'
+    ).toBe('none');
+
+    // CONTROL: every other swatch stays thin. Without this the assertion above
+    // passes on a build where all five are 2px, which marks nothing.
+    for (const name of THEMES.filter((n) => n !== 'BB Pink')) {
+      const other = await markerOf(swatch(page, name));
+      expect(
+        other.border,
+        `${name} is not active and should keep the thin border`
+      ).toBe('1px');
+      expect(other.outline, `${name} should have no outline`).toBe('none');
+    }
+  });
+
+  test('thickening the border does not resize the swatch', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openThemes(context, extensionId);
+
+    // The width of one swatch while it is NOT active, then while it is. This
+    // is the whole reason KAN-88 used an outline: a border that changes the
+    // box shoves the other four sideways as selection moves. box-sizing:
+    // border-box is what makes the border safe to use here, and this is the
+    // assertion that holds it to that.
+    await swatch(page, 'Light').click();
+    const inactive = (await markerOf(swatch(page, 'Blue'))).width;
+
+    await swatch(page, 'Blue').click();
+    await expect(swatch(page, 'Blue')).toHaveAttribute('aria-pressed', 'true');
+    const activeWidth = (await markerOf(swatch(page, 'Blue'))).width;
+
+    expect(
+      activeWidth,
+      'the swatch must not change size when it activates'
+    ).toBe(inactive);
+  });
+});

--- a/src/components/settings/rightpane/SettingsDetailsContainer.tsx
+++ b/src/components/settings/rightpane/SettingsDetailsContainer.tsx
@@ -62,18 +62,33 @@ import { useTranslation } from 'react-i18next';
 // theme's colour, not a selection marker, and on a dark theme the active one
 // is the swatch that blends into the background.
 //
-// An OUTLINE rather than a border: a border would change the box and shove the
-// other four swatches sideways as the selection moved. outline is drawn
-// outside the box and costs no layout.
+// The marker is the swatch's OWN border, thickened (KAN-95).
 //
-// TEXT_COLOR rather than SELECTION_COLOR, deliberately. SELECTION_COLOR sits
-// within 1.05:1 of HOVER_COLOR in the dark themes (KAN-87), so a ring drawn in
-// it would be invisible on exactly the themes that need it most. TEXT_COLOR is
-// the one colour each theme guarantees is readable against its own background.
-const activeThemeRing = (isActive: boolean, textColor: string): string =>
-  isActive
-    ? `outline: 2px solid ${textColor}; outline-offset: 2px; z-index: 1;`
-    : '';
+// It was an outline in TEXT_COLOR, for a reason that was sound and a weight
+// that was not. Sound: a border changes the box, and growing one would shove
+// the other four swatches sideways as selection moved, so an outline avoided
+// the layout entirely. Not sound: TEXT_COLOR measures 9.2-13.8:1 against the
+// page, which is focus-ring weight on a passive state marker, and 2px of
+// outline plus 2px of offset exactly consumed the row's 4px gap, so the ring
+// touched its neighbours. With the swatch's own 1px border still underneath,
+// the active one drew two concentric lines. Reported as cramped, and rejected
+// for the same reason KAN-87's accent bar was: contrast is the right axis to
+// MEASURE and the wrong one to MAXIMISE.
+//
+// Growing the border is safe here because App.css sets `* { box-sizing:
+// border-box }` globally, so the swatch keeps its size and the row never
+// reflows. That is a property of the app, not of this helper -- an earlier
+// version of this comment claimed the helper established it, which was wrong:
+// a mutation removing the declaration changed nothing, because the global
+// reset had already done the work. themeSwatchMarker.spec's size assertion is
+// what holds the app to it, and it dies if this element is ever forced back to
+// content-box.
+//
+// LABEL_L3_COLOR, not BORDER_COLOR: measured against the page, BORDER_COLOR is
+// 1.38-1.73:1 on four of the five themes and would be invisible. LABEL_L3 is
+// the only existing token in a sane band (2.56-4.03:1).
+const themeSwatchMarker = (isActive: boolean, markerColor: string): string =>
+  isActive ? `border-color: ${markerColor}; border-width: 2px;` : '';
 
 const SettingsDetailsContainer: React.FC = () => {
   const COLORS = useThemeColors();
@@ -298,9 +313,9 @@ const SettingsDetailsContainer: React.FC = () => {
               width: 60px;
               border: 1px solid ${COLORS.BORDER_COLOR};
               background-color: ${LIGHT_THEME.PRIMARY_COLOR};
-              ${activeThemeRing(
+              ${themeSwatchMarker(
                 settingsData.theme === Theme.LIGHT,
-                COLORS.TEXT_COLOR
+                COLORS.LABEL_L3_COLOR
               )}
               &:hover {
                 background-color: ${LIGHT_THEME.PRIMARY_COLOR};
@@ -315,9 +330,9 @@ const SettingsDetailsContainer: React.FC = () => {
               width: 60px;
               border: 1px solid ${COLORS.BORDER_COLOR};
               background-color: ${WARM_LIGHT_THEME.PRIMARY_COLOR};
-              ${activeThemeRing(
+              ${themeSwatchMarker(
                 settingsData.theme === Theme.WARM_LIGHT,
-                COLORS.TEXT_COLOR
+                COLORS.LABEL_L3_COLOR
               )}
               &:hover {
                 background-color: ${WARM_LIGHT_THEME.PRIMARY_COLOR};
@@ -333,9 +348,9 @@ const SettingsDetailsContainer: React.FC = () => {
               width: 60px;
               border: 1px solid ${COLORS.BORDER_COLOR};
               background-color: ${BB_PINK_THEME.PRIMARY_COLOR};
-              ${activeThemeRing(
+              ${themeSwatchMarker(
                 settingsData.theme === Theme.BB_PINK,
-                COLORS.TEXT_COLOR
+                COLORS.LABEL_L3_COLOR
               )}
               &:hover {
                 background-color: ${BB_PINK_THEME.PRIMARY_COLOR};
@@ -350,9 +365,9 @@ const SettingsDetailsContainer: React.FC = () => {
               width: 60px;
               border: 1px solid ${COLORS.BORDER_COLOR};
               background-color: ${DARKENHEIMER_THEME.PRIMARY_COLOR};
-              ${activeThemeRing(
+              ${themeSwatchMarker(
                 settingsData.theme === Theme.DARKENHEIMER,
-                COLORS.TEXT_COLOR
+                COLORS.LABEL_L3_COLOR
               )}
               &:hover {
                 background-color: ${DARKENHEIMER_THEME.PRIMARY_COLOR};
@@ -367,9 +382,9 @@ const SettingsDetailsContainer: React.FC = () => {
               width: 60px;
               border: 1px solid ${COLORS.BORDER_COLOR};
               background-color: ${BLUE_THEME.PRIMARY_COLOR};
-              ${activeThemeRing(
+              ${themeSwatchMarker(
                 settingsData.theme === Theme.BLUE,
-                COLORS.TEXT_COLOR
+                COLORS.LABEL_L3_COLOR
               )}
               &:hover {
                 background-color: ${BLUE_THEME.PRIMARY_COLOR};

--- a/src/tests/components/settingsStateExposed.test.tsx
+++ b/src/tests/components/settingsStateExposed.test.tsx
@@ -145,35 +145,42 @@ describe('the theme picker marks the active theme (KAN-88)', () => {
   // The visual half. A screen reader gets aria-pressed; a sighted user needs
   // something drawn, and before this there was nothing at all.
   //
-  // Asserted as "the active swatch has a ring and no other does", not as a
-  // specific colour: the ring is drawn in the active theme's own TEXT_COLOR,
-  // so pinning the value would make this a change detector for the palette.
+  // Asserted as "the active swatch is marked and no other is", not as a
+  // specific colour: the marker is drawn in the active theme's own
+  // LABEL_L3_COLOR, so pinning the value would make this a change detector for
+  // the palette.
   //
-  // Read through the `outline` SHORTHAND. jsdom fills the shorthand but does
-  // not decompose it -- `outlineStyle` comes back "none" and `outlineWidth`
-  // "16px" on the very element whose `outline` is "2px solid #3b3d40". An
-  // assertion on the longhand therefore fails against correct code, which is
-  // exactly what it did on the first run of this test.
-  test('the active swatch is the only one drawn with a ring', async () => {
+  // The marker was an outline until KAN-95 and is now the swatch's own border,
+  // thickened -- an outline is drawn OUTSIDE the box and collided with the
+  // neighbouring swatches, and TEXT_COLOR made it far louder than the passive
+  // state it marks.
+  //
+  // Read through the `border` SHORTHAND, for the same jsdom reason the outline
+  // was: jsdom fills a shorthand it was given but does not reliably decompose
+  // it into longhands, so an assertion on borderWidth can fail against correct
+  // code. The real-browser widths are pinned by
+  // e2e/theme-swatch-marker.spec.ts, which is also the only place the
+  // no-resize guarantee can be measured at all.
+  test('the active swatch is the only one marked', async () => {
     const { container, store } = await renderOn(SettingsCategory.DISPLAY);
 
     act(() => {
       store.dispatch(setTheme(Theme.LIGHT));
     });
 
-    const ringed = swatches(container).filter((b) =>
-      /^2px solid /.test(getComputedStyle(b).outline)
+    const marked = swatches(container).filter((b) =>
+      /(^|\s)2px(\s|$)/.test(getComputedStyle(b).borderWidth)
     );
 
-    expect(ringed).toHaveLength(1);
-    expect(ringed[0].getAttribute('title')).toBe('Light');
+    expect(marked).toHaveLength(1);
+    expect(marked[0].getAttribute('title')).toBe('Light');
 
-    // The ring must move with the theme, not just exist somewhere.
+    // The marker must move with the theme, not just exist somewhere.
     act(() => {
       store.dispatch(setTheme(Theme.BLUE));
     });
     const moved = swatches(container).filter((b) =>
-      /^2px solid /.test(getComputedStyle(b).outline)
+      /(^|\s)2px(\s|$)/.test(getComputedStyle(b).borderWidth)
     );
     expect(moved).toHaveLength(1);
     expect(moved[0].getAttribute('title')).toBe('Blue');


### PR DESCRIPTION
Reported as cramped, with the black ring unwanted. Both halves were real and they are separable.

## Too loud

The ring was `TEXT_COLOR`, measured against the page it is drawn on:

| theme | ring | vs page |
| --- | --- | --- |
| Light | `#3B3D40` | 10.15 |
| Warm Light | `#28251F` | 13.80 |
| BB Pink | `#2A2A2A` | 10.51 |
| Darkenheimer | `#D0D0D0` | 9.31 |
| Blue | `#D0D0DF` | 9.24 |

That is focus-ring weight on a passive state marker — **the same mistake as KAN-87's accent bar, rejected the same way an hour earlier. Contrast is the right axis to *measure* and the wrong one to *maximise*.**

## Cramped

`outline: 2px` + `outline-offset: 2px` is 4px of ring, and the swatches sit in a flex row with `gap: 4px`. The ring consumed the gap exactly and touched its neighbours. Each swatch also keeps its own 1px border, so the active one drew two concentric lines with a space between them.

## The fix

The marker is the swatch's own border, thickened to 2px in `LABEL_L3_COLOR`. One line instead of two, nothing drawn outside the box, so the collision cannot recur by construction.

**Not `BORDER_COLOR`** — measured against the page it is 1.38–1.73:1 on four of five themes and would be invisible.

KAN-88's defect stays fixed: the active theme is still identifiable and still carries `aria-pressed`. Only the weight changes.

## Two corrections to my own work, both caught by mutation

**A false claim in a comment.** The first version emitted `box-sizing: border-box` with a comment calling it "the whole trick" that makes a growing border safe. Removing it changed nothing — `App.css` already sets `* { box-sizing: border-box }`, and another file's comment already said so. The declaration was redundant and the claim was false. Both are gone; the comment now credits the global reset and points at the test that holds the app to it. The mutation that **does** kill that test is forcing `content-box`, which takes the swatch 102px → 104px.

**A false pass.** The first mutation attempt did not compile (unused parameter), so `dist` was never rebuilt and the suite reported green against the previous bundle. Checked `dist` before trusting any mutant afterwards.

## Verification

`e2e/theme-swatch-marker.spec.ts` asserts at **every** swatch, not only the active one — "the active swatch differs" is satisfied by a build where all five are 2px, which marks nothing.

KAN-88's component test asserted the outline and was retargeted at the border. It is sensitive in both directions: no marker gives 0 matches, marking every swatch gives 5, and it wants exactly 1.

**Verified live on all five themes**, which was the risk flagged before starting — a 2px border might have read as barely different from 1px on the dark swatches. It does not, because the colour changes as well as the width:

```
Light         2px,1px,1px,1px,1px   no outline anywhere
Warm Light    1px,2px,1px,1px,1px
BB Pink       1px,1px,2px,1px,1px
Darkenheimer  1px,1px,1px,2px,1px
Blue          1px,1px,1px,1px,2px
```

**710 unit/component tests. Playwright 57/57, up from 55.** `tsc` 0, `typecheck:e2e` 0, `eslint` 0 errors / 25 warnings.

## One thing worth your eye

On the **Light** theme the active marker is *lighter* than the inactive borders, because that theme's `BORDER_COLOR` is unusually dark (7.54:1) and no softer token out-prominences it. It is still clearly distinguishable by thickness, and on the other four themes the marker correctly gains contrast over its neighbours. Flagging rather than deciding it silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
