### PR TITLE
Paint the action mask once, on the block, not on each icon (KAN-98)

### DIFF
--- a/e2e/row-state-feedback.spec.ts
+++ b/e2e/row-state-feedback.spec.ts
@@ -192,4 +192,86 @@ test.describe('a row reveals its actions and fills as one state', () => {
       )
       .toBe('0');
   });
+
+  // KAN-98. The action strip must never disagree with the row it masks.
+  //
+  // Icon carries `transition: background-color 0.2s` for its OWN hover, and
+  // TabGroupEntry was relaying the ROW's state colour through that same
+  // property. So on click the row's background snapped to the selection colour
+  // while the strip eased toward it over 200ms -- 20 measured frames with a
+  // hard vertical seam down the middle of the row.
+  //
+  // Asserted as agreement between the two, sampled every frame, rather than
+  // against literal colours: the invariant is that the mask matches what it is
+  // masking, whatever the palette says those colours are.
+  test('the action strip never disagrees with the row it masks', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openWith(context, extensionId);
+    const first = rowFor(page, 'First session');
+    const second = rowFor(page, 'Second session');
+
+    await first.click({ position: { x: 20, y: 20 } });
+    await second.hover({ position: { x: 20, y: 20 } });
+    await page.waitForTimeout(350);
+
+    await page.evaluate(() => {
+      const button = Array.from(
+        document.querySelectorAll('button[aria-label]')
+      ).find((b) => b.getAttribute('aria-label') === 'Second session');
+      const row = button!.parentElement!;
+      const actions = row.lastElementChild!;
+      const seen: { row: string; strip: string }[] = [];
+      (window as unknown as { __pairs: typeof seen }).__pairs = seen;
+
+      // The row's fill lives in TWO places by design (KAN-82): a selected row
+      // paints background-color, an unselected hovered one paints an inset
+      // box-shadow. Comparing background to background would therefore report
+      // a false disagreement on every hovered-unselected frame. What the eye
+      // sees is whichever of the two is painted, so that is what the strip
+      // must match.
+      const effectiveFill = (el: Element): string => {
+        const cs = getComputedStyle(el);
+        if (cs.backgroundColor !== 'rgba(0, 0, 0, 0)')
+          return cs.backgroundColor;
+        const shadow = cs.boxShadow.match(/rgba?\([^)]*\)/);
+        return shadow ? shadow[0] : cs.backgroundColor;
+      };
+
+      const tick = () => {
+        seen.push({
+          row: effectiveFill(row),
+          strip: getComputedStyle(actions).backgroundColor,
+        });
+        requestAnimationFrame(tick);
+      };
+      requestAnimationFrame(tick);
+    });
+
+    await second.click({ position: { x: 20, y: 20 } });
+    await page.waitForTimeout(500);
+
+    const pairs = await page.evaluate(
+      () =>
+        (window as unknown as { __pairs: { row: string; strip: string }[] })
+          .__pairs
+    );
+
+    // CONTROL: the sampler ran across the state change, so an empty
+    // disagreement list cannot mean it never observed anything.
+    expect(
+      new Set(pairs.map((p) => p.row)).size,
+      'the row background should have changed during the sample window'
+    ).toBeGreaterThan(1);
+
+    const disagreeing = pairs.filter((p) => p.row !== p.strip);
+
+    expect(
+      disagreeing.length,
+      `the strip must track the row exactly; saw ${disagreeing.length} ` +
+        `frames where they differed, e.g. row ${disagreeing[0]?.row} vs ` +
+        `strip ${disagreeing[0]?.strip}`
+    ).toBe(0);
+  });
 });

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -54,7 +54,11 @@ const Icon: React.FC<IconProps> = ({
   animationFrom,
   animationTo,
   animationDuration,
-  backgroundColor,
+  // Transparent by default, so an Icon paints nothing of its own unless a
+  // caller asks for it (KAN-98). It used to be undefined, which emotion
+  // emitted as `background-color: undefined` for the browser to discard --
+  // the same result by accident rather than by statement.
+  backgroundColor = 'transparent',
   ariaLabel,
   tooltipText,
   text,

--- a/src/components/home/leftpane/TabGroupEntry.tsx
+++ b/src/components/home/leftpane/TabGroupEntry.tsx
@@ -84,6 +84,30 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
        allowed to drift apart. */
     opacity: 0;
     transition: opacity 0.1s ease-out;
+
+    /* THE MASK LIVES HERE, ON ONE ELEMENT (KAN-98).
+
+       This block is absolutely positioned over the title, so it has to be
+       opaque or the text reads through the controls (KAN-92). That mask used
+       to be painted by the three Icons individually, via a backgroundColor
+       prop carrying the ROW's state colour.
+
+       Icon also carries a 0.2s background-color transition for its own hover.
+       So one property held two meanings -- the row's state, relayed in, and
+       the icon's own gesture -- and the single transition animated both. On
+       click the row's background snapped to the selection colour while the
+       strip eased toward it across 200ms: 20 measured frames with a hard
+       vertical seam down the middle of the row.
+
+       KAN-82's rule again, one component deeper: a transition is declared on a
+       property, not a reason. So the two reasons are now on two elements. The
+       mask is this block, painted from the same isSelected the row uses and in
+       the same render, with no transition on colour here -- only opacity eases.
+       The icons keep nothing but their own :hover, which may ease, because
+       that IS a gesture. */
+    background-color: ${isSelected
+      ? COLORS.SELECTION_COLOR
+      : COLORS.HOVER_COLOR};
   `;
 
   // What "engaged" paints. Declared once and used by both rules below, so the
@@ -254,9 +278,6 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
             text={t('Open')}
             ariaLabel={t('Open')}
             type="reopen_window"
-            backgroundColor={
-              isSelected ? COLORS.SELECTION_COLOR : COLORS.HOVER_COLOR
-            }
             onClick={(e) => {
               e.stopPropagation();
               onOpenAllClick(e);
@@ -268,9 +289,6 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
             text={t('Switch')}
             ariaLabel={t('Switch')}
             type="filter_center_focus"
-            backgroundColor={
-              isSelected ? COLORS.SELECTION_COLOR : COLORS.HOVER_COLOR
-            }
             onClick={(e) => {
               e.stopPropagation();
               onFocusClick(e);
@@ -282,9 +300,6 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
             text={t('Delete')}
             ariaLabel={t('Delete')}
             type="delete"
-            backgroundColor={
-              isSelected ? COLORS.SELECTION_COLOR : COLORS.HOVER_COLOR
-            }
             onClick={(e) => {
               e.stopPropagation();
               onDeleteClick(e);


### PR DESCRIPTION
Reported with a three-frame breakdown of a single click. The middle frame shows the row's left half already at the selection colour while the action strip is still the hover colour, with a hard vertical seam between them.

## Measured

```
ms  0   row rgb(203,206,211)   icon rgb(228,231,235)   <- row snaps to selection
ms  5   row rgb(203,206,211)   icon rgb(227,230,234)   <- icon eases toward it
ms 30   row rgb(203,206,211)   icon rgb(223,226,230)
ms 55   row rgb(203,206,211)   icon rgb(216,219,223)
```

**20 frames where a row and its own action strip disagreed.**

## Root cause

`Icon` carries a 0.2s `background-color` transition for its **own** hover. `TabGroupEntry` was relaying the **row's state colour** through that same property:

```js
backgroundColor={isSelected ? COLORS.SELECTION_COLOR : COLORS.HOVER_COLOR}
```

One property, two meanings, one transition animating both. **KAN-82's rule for the third time and one component deeper: a transition is declared on a *property*, not a *reason*.**

Checked, and the other callers are unaffected: `WindowEntryContainer` and `HeroContainerRight` pass **constants**, so their value never changes during an interaction and that transition never fires. Only this call site relayed a changing state colour.

## Fix

The two reasons go on two elements.

The opaque mask — load-bearing since KAN-92, because the block sits over the title — moves onto the action **block**, painted from the same `isSelected` the row uses, in the same render, with no colour transition there. The icons default to `transparent` and keep only their own `:hover`, which may still ease, because that genuinely *is* a gesture.

`Icon`'s `backgroundColor` now defaults to `'transparent'` rather than `undefined`. Emotion was emitting `background-color: undefined` for the browser to discard — the same result by accident rather than by statement.

## The test was wrong twice, in an instructive way

First it compared the strip's `background-color` against the **row's** `background-color`, and reported three false disagreements on hovered frames. A row's fill lives in **two** places by design (KAN-82): `background-color` when selected, an inset `box-shadow` when hovered-unselected. Getting that wrong is what surfaced the real invariant — *the mask matches what it is masking*, whichever property is carrying it. The spec now compares against the row's **effective fill**.

It carries a control asserting the row's fill actually changed during the sample window, so zero disagreements cannot mean the sampler watched nothing.

**Mutation:** relaying the colour through an `Icon` again gives **64** disagreeing frames.

## Evidence

**730 unit tests. Playwright 58/58**, up from 57. `tsc` 0, `typecheck:e2e` 0, `eslint` 0 errors / 25 warnings.

Verified live: **0 disagreeing frames across 73**, where the old build disagreed from the first post-click frame onward.

Also fixed on the way: a third backtick inside a `css` template-literal comment, which terminates the literal and surfaces as a bare `TS1005` pointing at prose. Three build failures in one session from the same cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
