### PR TITLE
Record what a step created, so undoing it can withdraw it (KAN-80, KAN-81)

### DIFF
--- a/src/redux/middleware/customMiddleware.ts
+++ b/src/redux/middleware/customMiddleware.ts
@@ -16,11 +16,13 @@ import {
   SAVE_TAB_CONTAINER_ACTION,
   SELECT_TAB_CONTAINER_ACTION,
   SET_ACTION,
+  TAB_CONTAINER_APPLY_UNDO_SNAPSHOT_ACTION,
   TAB_CONTAINER_REPLACE_STATE_ACTION,
   TAB_CONTAINER_RESTORE_ACTION,
   UNDO_ACTION,
   EDIT_WINDOWGROUP_TITLE_ACTION,
 } from '../../utils/constants/actionTypes';
+import type { RootState } from '../store';
 
 // add actions to capture under undo/redo
 const actionsToCapture = [
@@ -70,6 +72,20 @@ const viewStateOnlyActions = [SELECT_TAB_CONTAINER_ACTION];
 const isUndoRedoAction = (type: string) =>
   [UNDO_ACTION, REDO_ACTION].includes(type);
 
+// The session ids present after this action that were not present before it.
+//
+// Both states are read one action apart inside a single middleware pass, so
+// this is a statement about what the user's action did, not a guess recovered
+// later from two snapshots that have since drifted apart (KAN-80/KAN-83).
+const addedTabGroupIds = (prevState: RootState, nextState: RootState) => {
+  const before = new Set(
+    prevState.tabContainerDataState.tabGroups.map((g) => g.tabGroupId)
+  );
+  return nextState.tabContainerDataState.tabGroups
+    .map((g) => g.tabGroupId)
+    .filter((id) => !before.has(id));
+};
+
 const isDataStateChangeAction = (
   type: string,
   prevState: any,
@@ -81,6 +97,7 @@ const isDataStateChangeAction = (
     // Restoring history is not a new edit to capture; capturing it would push
     // the restored state back onto the undo stack.
     TAB_CONTAINER_RESTORE_ACTION,
+    TAB_CONTAINER_APPLY_UNDO_SNAPSHOT_ACTION,
   ];
   return (
     prevState.tabContainerDataState !== nextState.tabContainerDataState &&
@@ -129,16 +146,32 @@ export const customMiddleware: Middleware = (store) => {
 
     if (isUndoRedoAction(action.type)) {
       const presentState = nextState.undoRedo.present;
+
+      // Undoing retracts whatever the step being left had created; redoing
+      // creates nothing, so it withdraws nothing (KAN-80).
+      //
+      // Read off prevState, because by now the undo reducer has already moved
+      // `present` to the snapshot being restored -- the step being undone is
+      // the one that WAS present a moment ago.
+      const withdrawTabGroupIds =
+        action.type === UNDO_ACTION
+          ? prevState.undoRedo.present.addedTabGroupIds ?? []
+          : [];
+
       // update tabContainerDataState from the latest presentState
       //
-      // restoreContainer rather than replaceState: a snapshot taken before a
+      // applyUndoSnapshot rather than replaceState: a snapshot taken before a
       // delete brings the session back with no tombstone, but the cloud may
       // still hold the one that delete pushed up. Restoring blind lets the next
       // merge re-apply the delete, so undo appears to work and then reverses
-      // itself.
+      // itself. The create direction is the mirror image, and needs the
+      // withdrawal above for the same reason.
       store.dispatch({
-        type: TAB_CONTAINER_RESTORE_ACTION,
-        payload: presentState.tabContainerDataState,
+        type: TAB_CONTAINER_APPLY_UNDO_SNAPSHOT_ACTION,
+        payload: {
+          snapshot: presentState.tabContainerDataState,
+          withdrawTabGroupIds,
+        },
       });
       store.dispatch(setIsDirty());
     } else if (isDataStateChangeAction(action.type, prevState, nextState)) {
@@ -148,7 +181,14 @@ export const customMiddleware: Middleware = (store) => {
       store.dispatch(
         isViewStateOnly
           ? setPresentWithoutHistory({ tabContainerDataState })
-          : set({ tabContainerDataState })
+          : set({
+              tabContainerDataState,
+              // Computed here, from two states one action apart, because this
+              // is the only place where "what did the user just add" is
+              // knowable rather than inferable. Nothing can arrive from the
+              // cloud between these two reads. See UndoableStates.
+              addedTabGroupIds: addedTabGroupIds(prevState, nextState),
+            })
       );
 
       if (!isViewStateOnly) {

--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -862,95 +862,73 @@ export const tabContainerDataStateSlice = createSlice({
     // tombstone is being withdrawn are stamped - anything else in the payload
     // keeps its own history.
     restoreContainer: (state, action: PayloadAction<typeof state>) => {
-      const withdrawnAt = new Map(
-        (state.deletedTabGroups ?? []).map((grave) => [
-          grave.tabGroupId,
-          grave.deletedAt,
-        ])
-      );
-      // The mirror direction: a payload can also re-introduce a tombstone for a
-      // session that is currently live - redoing a delete after undoing it. The
-      // restored tombstone carries the original delete time, which the undo
-      // above has already stamped the session past, so without this the redo
-      // silently fails to delete anything.
+      const restored = reconcileAssertedContainer(state, action.payload);
+
+      // update localstorage
+      saveToLocalStorage('tabContainerData', restored);
+      return restored;
+    },
+
+    // Undo and redo. Reconciles exactly as restoreContainer does, then
+    // withdraws the sessions the step being undone had created (KAN-80).
+    //
+    // The ids arrive in the payload; they are never worked out here. That is
+    // the whole point of the split. A reducer can only see the container and
+    // the snapshot, and those two have drifted by the time it runs, so any rule
+    // of the form "missing from the snapshot means retracted" also catches
+    // sessions that merely arrived from another device -- which is precisely
+    // how KAN-83 deleted them. undoRedoSlice records what each step added at
+    // the moment it happens, and this reducer is handed the answer.
+    //
+    // Import deliberately does NOT come through here. The two callers want
+    // opposite things from a session the payload lacks: an undo means "retract
+    // it", an import means "leave it alone", because a backup file is a partial
+    // view of the world and tombstoning against it would let an old export
+    // delete every newer session on every device. Two reducers rather than one
+    // with a flag, so neither contract can be read as the other.
+    applyUndoSnapshot: (
+      state,
+      action: PayloadAction<{
+        snapshot: TabMasterContainer;
+        withdrawTabGroupIds: string[];
+      }>
+    ) => {
+      const { snapshot, withdrawTabGroupIds } = action.payload;
       const liveAt = new Map(
         state.tabGroups.map((tabGroup) => [
           tabGroup.tabGroupId,
           tabGroup.lastModified ?? state.lastModified,
         ])
       );
-      // KAN-55. The live copy of each session, to tell the sessions this
-      // restore actually changes from the ones it is merely carrying along.
-      const liveGroup = new Map(
-        state.tabGroups.map((tabGroup) => [tabGroup.tabGroupId, tabGroup])
+
+      const restored = reconcileAssertedContainer(state, snapshot);
+
+      const surviving = new Set(
+        restored.tabGroups.map((tabGroup) => tabGroup.tabGroupId)
       );
+      const graves = restored.deletedTabGroups ?? [];
 
-      const restored: TabMasterContainer = {
-        ...action.payload,
-        tabGroups: action.payload.tabGroups.map((tabGroup) => {
-          const current = liveGroup.get(tabGroup.tabGroupId);
+      for (const tabGroupId of withdrawTabGroupIds) {
+        // The snapshot still has it, so this step did not actually create it.
+        // Burying it would delete a session the user can still see.
+        if (surviving.has(tabGroupId)) continue;
 
-          // KAN-55. The second thing a restore may have to outrank, alongside
-          // a tombstone: a live session whose content this restore is
-          // reverting. The merge resolves each session by its own
-          // `lastModified` with cloud winning ties, so handing a reverted
-          // session back with its snapshot timestamp let the cloud copy --
-          // which still holds the edit -- win the next merge. The undo applied
-          // locally and sync silently put the edit back.
-          //
-          // Compared by content, not by timestamp. `touch()` does advance a
-          // session's timestamp on every content change, but two edits inside
-          // the same millisecond are indistinguishable by it, which is not
-          // hypothetical: saving and renaming in quick succession produces
-          // exactly that, and the timestamp version of this check passed or
-          // failed depending on where a millisecond boundary happened to fall.
-          //
-          // Only sessions that actually differ are stamped. Bumping every
-          // restored session would make an undo assert the whole container,
-          // overwriting edits made on another device to sessions the user
-          // never touched here.
-          const supersededAt =
-            current !== undefined && !sameSessionContent(current, tabGroup)
-              ? liveAt.get(tabGroup.tabGroupId)
-              : undefined;
-
-          const mustOutrank = [
-            withdrawnAt.get(tabGroup.tabGroupId),
-            supersededAt,
-          ].filter((at): at is number => at !== undefined);
-
-          // Neither buried nor superseded: this restore is not changing this
-          // session, so leave its timestamp exactly as it was.
-          if (mustOutrank.length === 0) return tabGroup;
-
-          return {
-            ...tabGroup,
-            // Strictly after whatever it must beat, not merely Date.now().
-            // Undoing promptly enough lands in the same millisecond, and the
-            // merge gives exact ties to cloud - so an equal timestamp loses to
-            // the very tombstone or edit this is superseding. The undo
-            // happened after the thing it undoes by definition; encode that
-            // rather than trusting clock granularity.
-            lastModified: Math.max(Date.now(), Math.max(...mustOutrank) + 1),
-          };
-        }),
-        // `?? []` before the map, not `?.map`. The optional call yields
-        // undefined for a payload with no tombstones - a backup exported before
-        // they existed - but the key is still written, and an explicit
-        // `deletedTabGroups: undefined` is not the same as an absent key.
-        // JSON.stringify erases that difference; Firestore does not. setDoc
-        // walks own enumerable properties and rejects undefined values, so the
-        // next cloud write failed with "Unsupported field value: undefined"
-        // (KAN-48).
-        deletedTabGroups: (action.payload.deletedTabGroups ?? []).map(
-          (grave) => {
-            const aliveAt = liveAt.get(grave.tabGroupId);
-            if (aliveAt === undefined) return grave;
-            // Same reasoning, other way round.
-            return { ...grave, deletedAt: Math.max(Date.now(), aliveAt + 1) };
-          }
-        ),
-      };
+        // Strictly after the copy it buries, for the same reason the restore
+        // direction stamps strictly after the tombstone it withdraws: the merge
+        // gives exact ties to the cloud, and undoing promptly enough lands in
+        // the same millisecond as the create.
+        const buriedAt = Math.max(
+          Date.now(),
+          (liveAt.get(tabGroupId) ?? 0) + 1
+        );
+        const existing = graves.find((g) => g.tabGroupId === tabGroupId);
+        if (existing) {
+          existing.deletedAt = buriedAt;
+        } else {
+          graves.push({ tabGroupId, deletedAt: buriedAt });
+        }
+      }
+      restored.deletedTabGroups = graves;
 
       // update localstorage
       saveToLocalStorage('tabContainerData', restored);
@@ -958,6 +936,157 @@ export const tabContainerDataStateSlice = createSlice({
     },
   },
 });
+
+// The tombstone ledger a restore should end up with (KAN-81).
+//
+// This used to be rebuilt wholly from the payload. An undo snapshot is a
+// photograph of the container taken BEFORE any later tombstone was written, so
+// it carries none of them -- and each undo therefore discarded every tombstone
+// accumulated since that snapshot. On `main` that was merely noisy: the lost
+// tombstone came back from the cloud on the same sync, and the only symptom
+// was a false "Synced changes from another device" on every undo after the
+// first.
+//
+// It stops being cosmetic once undo writes tombstones of its own (KAN-80),
+// because then the tombstone IS the retraction. Undoing two creates in a row
+// discarded the first withdrawal and the session came back.
+//
+// So live tombstones are carried across, and one thing drops them: the payload
+// asserting that session is alive again, which is exactly undoing a delete.
+// That case is already safe without the drop -- the restored session is
+// stamped to outrank its own tombstone -- but keeping graves for plainly live
+// sessions would grow the document forever.
+function carryTombstonesForward(
+  state: TabMasterContainer,
+  payload: TabMasterContainer,
+  liveAt: Map<string, number>
+): deletedTabGroup[] {
+  const assertedAlive = new Set(payload.tabGroups.map((g) => g.tabGroupId));
+  const ledger = new Map<string, deletedTabGroup>();
+
+  for (const grave of state.deletedTabGroups ?? []) {
+    if (assertedAlive.has(grave.tabGroupId)) continue;
+    ledger.set(grave.tabGroupId, { ...grave });
+  }
+
+  // `?? []` before the loop, not `?.`. The optional call yields undefined for a
+  // payload with no tombstones - a backup exported before they existed - but
+  // the key is still written, and an explicit `deletedTabGroups: undefined` is
+  // not the same as an absent key. JSON.stringify erases that difference;
+  // Firestore does not. setDoc walks own enumerable properties and rejects
+  // undefined values, so the next cloud write failed with "Unsupported field
+  // value: undefined" (KAN-48).
+  for (const grave of payload.deletedTabGroups ?? []) {
+    if (assertedAlive.has(grave.tabGroupId)) continue;
+    const aliveAt = liveAt.get(grave.tabGroupId);
+    // A payload can re-introduce a tombstone for a session that is currently
+    // live - redoing a delete after undoing it. The restored tombstone carries
+    // the original delete time, which the undo has already stamped the session
+    // past, so without this the redo silently fails to delete anything.
+    ledger.set(
+      grave.tabGroupId,
+      aliveAt === undefined
+        ? { ...grave }
+        : { ...grave, deletedAt: Math.max(Date.now(), aliveAt + 1) }
+    );
+  }
+
+  return Array.from(ledger.values());
+}
+
+// The shared body of the two reducers above. Everything about outranking a
+// tombstone or a superseded edit is identical for undo and for import; they
+// differ only in what a session missing from the payload means, which is the
+// caller's business rather than this function's.
+function reconcileAssertedContainer(
+  state: TabMasterContainer,
+  payload: TabMasterContainer
+): TabMasterContainer {
+  const withdrawnAt = new Map(
+    (state.deletedTabGroups ?? []).map((grave) => [
+      grave.tabGroupId,
+      grave.deletedAt,
+    ])
+  );
+  // The mirror direction: a payload can also re-introduce a tombstone for a
+  // session that is currently live - redoing a delete after undoing it. The
+  // restored tombstone carries the original delete time, which the undo
+  // above has already stamped the session past, so without this the redo
+  // silently fails to delete anything.
+  const liveAt = new Map(
+    state.tabGroups.map((tabGroup) => [
+      tabGroup.tabGroupId,
+      tabGroup.lastModified ?? state.lastModified,
+    ])
+  );
+  // KAN-55. The live copy of each session, to tell the sessions this
+  // restore actually changes from the ones it is merely carrying along.
+  const liveGroup = new Map(
+    state.tabGroups.map((tabGroup) => [tabGroup.tabGroupId, tabGroup])
+  );
+
+  const restored: TabMasterContainer = {
+    ...payload,
+    tabGroups: payload.tabGroups.map((tabGroup) => {
+      const current = liveGroup.get(tabGroup.tabGroupId);
+
+      // KAN-55. The second thing a restore may have to outrank, alongside
+      // a tombstone: a live session whose content this restore is
+      // reverting. The merge resolves each session by its own
+      // `lastModified` with cloud winning ties, so handing a reverted
+      // session back with its snapshot timestamp let the cloud copy --
+      // which still holds the edit -- win the next merge. The undo applied
+      // locally and sync silently put the edit back.
+      //
+      // Compared by content, not by timestamp. `touch()` does advance a
+      // session's timestamp on every content change, but two edits inside
+      // the same millisecond are indistinguishable by it, which is not
+      // hypothetical: saving and renaming in quick succession produces
+      // exactly that, and the timestamp version of this check passed or
+      // failed depending on where a millisecond boundary happened to fall.
+      //
+      // Only sessions that actually differ are stamped. Bumping every
+      // restored session would make an undo assert the whole container,
+      // overwriting edits made on another device to sessions the user
+      // never touched here.
+      const supersededAt =
+        current !== undefined && !sameSessionContent(current, tabGroup)
+          ? liveAt.get(tabGroup.tabGroupId)
+          : undefined;
+
+      const mustOutrank = [
+        withdrawnAt.get(tabGroup.tabGroupId),
+        supersededAt,
+      ].filter((at): at is number => at !== undefined);
+
+      // Neither buried nor superseded: this restore is not changing this
+      // session, so leave its timestamp exactly as it was.
+      if (mustOutrank.length === 0) return tabGroup;
+
+      return {
+        ...tabGroup,
+        // Strictly after whatever it must beat, not merely Date.now().
+        // Undoing promptly enough lands in the same millisecond, and the
+        // merge gives exact ties to cloud - so an equal timestamp loses to
+        // the very tombstone or edit this is superseding. The undo
+        // happened after the thing it undoes by definition; encode that
+        // rather than trusting clock granularity.
+        lastModified: Math.max(Date.now(), Math.max(...mustOutrank) + 1),
+      };
+    }),
+    // `?? []` before the map, not `?.map`. The optional call yields
+    // undefined for a payload with no tombstones - a backup exported before
+    // they existed - but the key is still written, and an explicit
+    // `deletedTabGroups: undefined` is not the same as an absent key.
+    // JSON.stringify erases that difference; Firestore does not. setDoc
+    // walks own enumerable properties and rejects undefined values, so the
+    // next cloud write failed with "Unsupported field value: undefined"
+    // (KAN-48).
+    deletedTabGroups: carryTombstonesForward(state, payload, liveAt),
+  };
+
+  return restored;
+}
 
 export const {
   saveToTabContainerInternal,
@@ -971,6 +1100,7 @@ export const {
   deleteTabInternal,
   replaceState,
   restoreContainer,
+  applyUndoSnapshot,
 } = tabContainerDataStateSlice.actions;
 
 export default tabContainerDataStateSlice.reducer;

--- a/src/redux/slices/undoRedoSlice.ts
+++ b/src/redux/slices/undoRedoSlice.ts
@@ -8,6 +8,25 @@ import { STACK_LEVEL } from '../../utils/constants/common';
 
 export interface UndoableStates {
   tabContainerDataState: TabMasterContainer;
+
+  // The sessions this step brought into existence, recorded when the step is
+  // pushed rather than worked out when it is popped (KAN-80).
+  //
+  // Undoing a create has to leave a tombstone, or the copy auto-sync already
+  // pushed to the cloud unions straight back and the undo silently reverses.
+  // Knowing WHICH session to withdraw is the whole difficulty: two previous
+  // attempts derived it by diffing the snapshot against something, and both
+  // were wrong, because every pair available at pop time has drifted --
+  // `replaceState` (the merge) enters the container but no snapshot, and
+  // `setPresentStartup` refreshes `present` but never `past`. So a session that
+  // merely ARRIVED from another device is indistinguishable from one the user
+  // retracted, and KAN-83 was that conflation deleting other devices' sessions.
+  //
+  // At push time no such ambiguity exists: the middleware holds the state from
+  // immediately before and immediately after the action, one instant apart,
+  // with no room for a cloud arrival in between. What that step added is a
+  // fact, so it is recorded as one instead of being reconstructed later.
+  addedTabGroupIds?: string[];
 }
 
 export interface undoRedoState {
@@ -55,8 +74,19 @@ export const undoRedoSlice = createSlice({
         state.present.tabContainerDataState.lastModified = Date.now();
       }
     },
+    // Also dispatched after every merge, not only at startup, which is why it
+    // carries `addedTabGroupIds` forward (KAN-80).
+    //
+    // A sync arriving is not a step the user took, so it cannot retract one
+    // they did take. The reported ordering is create, auto-sync, undo -- so
+    // dropping the ids here disarmed the withdrawal in exactly the case the
+    // bug was reported in, while leaving every test that syncs before the
+    // undone step green.
     setPresentStartup: (state, action: PayloadAction<UndoableStates>) => {
-      state.present = action.payload;
+      state.present = {
+        ...action.payload,
+        addedTabGroupIds: state.present.addedTabGroupIds,
+      };
     },
 
     // Keep `present` in step with the store without recording an undoable step
@@ -72,11 +102,21 @@ export const undoRedoSlice = createSlice({
     // Distinct from setPresentStartup, which happens to have the same body.
     // That one restores history at boot; sharing it would make a name that
     // says "startup" carry the selection path too.
+    //
+    // Carries `addedTabGroupIds` forward from the present it replaces. This is
+    // not bookkeeping: selecting a session is not a new step, so the last real
+    // edit is still the one an undo would retract. Dropping the ids here would
+    // mean creating a session and then clicking any other row silently
+    // disarmed the withdrawal, which is an ordinary thing to do -- and the
+    // resulting bug would look exactly like KAN-80 coming back.
     setPresentWithoutHistory: (
       state,
       action: PayloadAction<UndoableStates>
     ) => {
-      state.present = action.payload;
+      state.present = {
+        ...action.payload,
+        addedTabGroupIds: state.present.addedTabGroupIds,
+      };
     },
   },
 });

--- a/src/tests/redux/repeatedUndoToast.test.ts
+++ b/src/tests/redux/repeatedUndoToast.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Inlined rather than imported: a vi.hoisted block runs before the module
+// graph is evaluated, and common.ts reads window.screen at module load.
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+const mocks = vi.hoisted(() => ({
+  loadFromFirestore: vi.fn(async (): Promise<unknown> => undefined),
+  saveToFirestore: vi.fn<(userId: string, data: unknown) => Promise<void>>(
+    async () => undefined
+  ),
+}));
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: mocks.loadFromFirestore,
+  saveToFirestore: mocks.saveToFirestore,
+  displayToast: vi.fn(),
+}));
+
+import {
+  setSignedIn,
+  setUserId,
+  syncStateWithFirestore,
+} from '../../redux/slices/globalStateSlice';
+import { saveToTabContainerInternal } from '../../redux/slices/tabContainerDataStateSlice';
+import { undo } from '../../redux/slices/undoRedoSlice';
+import { makeTestStore } from '../setup/makeStore';
+import { TOAST_MESSAGES } from '../../utils/constants/common';
+import type { tabContainerData } from '../../redux/slices/tabContainerDataStateSlice';
+
+function group(id: string): tabContainerData {
+  return {
+    tabGroupId: id,
+    title: id,
+    createdTime: '2026-08-31 00:00:00',
+    createdAt: Date.UTC(2026, 7, 31, 0, 0, 0),
+    windowCount: 1,
+    tabCount: 1,
+    isAutoSave: false,
+    isSelected: false,
+    windows: [
+      {
+        windowId: `w-${id}`,
+        windowHeight: 100,
+        windowWidth: 100,
+        windowOffsetTop: 0,
+        windowOffsetLeft: 0,
+        tabCount: 1,
+        title: 'window',
+        tabs: [
+          { tabId: `t-${id}`, favicon: '', title: 't', url: 'https://a.co/' },
+        ],
+      },
+    ],
+  };
+}
+
+// KAN-81. Restoring a container rebuilt `deletedTabGroups` entirely from the
+// payload, and an undo snapshot is a photograph taken before any later
+// tombstone existed -- so every undo discarded the tombstones written since,
+// the next sync restored them from the cloud, the merged set differed from
+// local's, and `changedFromLocal` raised "Synced changes from another device"
+// on a device that has synced with nobody.
+//
+// The cloud here holds exactly what this device last wrote, so any claim that
+// something arrived from elsewhere is false by construction. That is what makes
+// this assertable at all: there is no other device.
+describe('repeated undo does not claim changes came from another device (KAN-81)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mocks.loadFromFirestore.mockReset();
+    mocks.saveToFirestore.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('raises no merge toast across three undos', async () => {
+    const { store, seen } = makeTestStore();
+    store.dispatch(setSignedIn());
+    store.dispatch(setUserId('u1'));
+
+    for (const id of ['s1', 's2', 's3', 's4']) {
+      store.dispatch(saveToTabContainerInternal(group(id)));
+    }
+
+    const roundsThatToasted: string[] = [];
+
+    // The cloud accumulates what THIS device pushed, which is the whole point:
+    // a tombstone local threw away is still up there to come back. Handing the
+    // cloud a copy of local-after-the-undo instead makes every round agree by
+    // construction, and the test then passes against the unfixed code -- which
+    // is exactly what it did before this was corrected.
+    let cloud: unknown = JSON.parse(
+      JSON.stringify(store.getState().tabContainerDataState)
+    );
+
+    for (let round = 1; round <= 3; round++) {
+      store.dispatch(undo());
+
+      localStorage.setItem(
+        'tabContainerData',
+        JSON.stringify(store.getState().tabContainerDataState)
+      );
+      mocks.loadFromFirestore.mockResolvedValue(cloud);
+
+      const before = seen.length;
+      await store.dispatch(syncStateWithFirestore() as never);
+      const during = seen.slice(before);
+      if (during.includes('global/showToast/pending')) {
+        roundsThatToasted.push(`round ${round}`);
+      }
+
+      // Whatever this device wrote is what the cloud now holds.
+      const writes = mocks.saveToFirestore.mock.calls;
+      if (writes.length > 0) cloud = writes[writes.length - 1][1];
+    }
+
+    // The control: the rounds really did run and really did sync, so an empty
+    // toast list cannot mean the loop did nothing.
+    expect(
+      seen.filter((t) => t === 'global/syncStateWithFirestore/fulfilled')
+    ).toHaveLength(3);
+    expect(TOAST_MESSAGES.SYNC_MERGED).toBe(
+      'Synced changes from another device.'
+    );
+    expect(roundsThatToasted).toEqual([]);
+  });
+});

--- a/src/tests/redux/undoCreateSurvivesSync.test.ts
+++ b/src/tests/redux/undoCreateSurvivesSync.test.ts
@@ -1,0 +1,399 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Inlined rather than imported: a vi.hoisted block runs before the module
+// graph is evaluated, and common.ts reads window.screen at module load.
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+const mocks = vi.hoisted(() => ({
+  loadFromFirestore: vi.fn(async (): Promise<unknown> => undefined),
+  saveToFirestore: vi.fn<(userId: string, data: unknown) => Promise<void>>(
+    async () => undefined
+  ),
+}));
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: mocks.loadFromFirestore,
+  saveToFirestore: mocks.saveToFirestore,
+  displayToast: vi.fn(),
+}));
+
+import {
+  setSignedIn,
+  setUserId,
+  syncStateWithFirestore,
+} from '../../redux/slices/globalStateSlice';
+import {
+  applyUndoSnapshot,
+  deleteTabContainerInternal,
+  saveToTabContainerInternal,
+  selectTabContainer,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import { redo, undo } from '../../redux/slices/undoRedoSlice';
+import { makeTestStore } from '../setup/makeStore';
+import type { tabContainerData } from '../../redux/slices/tabContainerDataStateSlice';
+
+function group(id: string): tabContainerData {
+  return {
+    tabGroupId: id,
+    title: id,
+    createdTime: '2026-08-31 00:00:00',
+    createdAt: Date.UTC(2026, 7, 31, 0, 0, 0),
+    windowCount: 1,
+    tabCount: 1,
+    isAutoSave: false,
+    isSelected: false,
+    windows: [
+      {
+        windowId: `w-${id}`,
+        windowHeight: 100,
+        windowWidth: 100,
+        windowOffsetTop: 0,
+        windowOffsetLeft: 0,
+        tabCount: 1,
+        title: 'window',
+        tabs: [
+          { tabId: `t-${id}`, favicon: '', title: 't', url: 'https://a.co/' },
+        ],
+      },
+    ],
+  };
+}
+
+const ids = (gs: tabContainerData[]) => gs.map((g) => g.tabGroupId).sort();
+
+// KAN-80. The create half of the family undoTombstone.test.ts covers for
+// deletes and undoContentSurvivesSync.test.ts covers for edits.
+//
+// mergeTabContainers unions by tabGroupId. A session present in the cloud but
+// absent locally is simply present: absence is not a signal, only a tombstone
+// is. Undoing a create removes the session locally and writes no tombstone, so
+// the copy auto-sync pushed up on creation unions straight back.
+//
+// Measured live on the built extension before this was written: the session
+// disappears and returns ~500ms later, and offline it stays gone -- which is
+// what proves the merge is the thing reversing it rather than a broken undo.
+describe('undoing a create survives the next sync (KAN-80)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mocks.loadFromFirestore.mockReset();
+    mocks.saveToFirestore.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('keeps a session the user undid creating out of the merged result', async () => {
+    const { store } = makeTestStore();
+    store.dispatch(setSignedIn());
+    store.dispatch(setUserId('u1'));
+
+    store.dispatch(saveToTabContainerInternal(group('existing')));
+    store.dispatch(saveToTabContainerInternal(group('created-here')));
+
+    // The cloud received the create, exactly as auto-sync would have pushed it.
+    const cloudAfterCreate = JSON.parse(
+      JSON.stringify(store.getState().tabContainerDataState)
+    );
+    expect(ids(cloudAfterCreate.tabGroups)).toEqual([
+      'created-here',
+      'existing',
+    ]);
+
+    store.dispatch(undo());
+
+    // The undo itself works -- this is not where the defect is. Without this
+    // control a merged result missing the session could mean the fixture never
+    // created it.
+    const afterUndo = store.getState().tabContainerDataState;
+    expect(ids(afterUndo.tabGroups)).toEqual(['existing']);
+
+    localStorage.setItem('tabContainerData', JSON.stringify(afterUndo));
+    mocks.loadFromFirestore.mockResolvedValue(cloudAfterCreate);
+    await store.dispatch(syncStateWithFirestore() as never);
+
+    expect(ids(store.getState().tabContainerDataState.tabGroups)).toEqual([
+      'existing',
+    ]);
+  });
+
+  // The withdrawal is worthless if it stays on this device: the other device
+  // still holds the session and would union it back for everyone.
+  it('pushes the withdrawal to the cloud', async () => {
+    const { store } = makeTestStore();
+    store.dispatch(setSignedIn());
+    store.dispatch(setUserId('u1'));
+
+    store.dispatch(saveToTabContainerInternal(group('created-here')));
+    const cloudAfterCreate = JSON.parse(
+      JSON.stringify(store.getState().tabContainerDataState)
+    );
+
+    store.dispatch(undo());
+
+    localStorage.setItem(
+      'tabContainerData',
+      JSON.stringify(store.getState().tabContainerDataState)
+    );
+    mocks.loadFromFirestore.mockResolvedValue(cloudAfterCreate);
+    await store.dispatch(syncStateWithFirestore() as never);
+
+    const calls = mocks.saveToFirestore.mock.calls;
+    const written = calls[calls.length - 1]?.[1] as
+      | { deletedTabGroups?: { tabGroupId: string }[] }
+      | undefined;
+    expect(written?.deletedTabGroups?.map((g) => g.tabGroupId)).toContain(
+      'created-here'
+    );
+  });
+
+  // An undo has to be as reversible as the thing it undoes. Redo restores the
+  // snapshot that still contains the session, and that snapshot's tombstone
+  // list predates the withdrawal -- so the tombstone is dropped and the
+  // session is stamped past it by the existing reconcile.
+  it('redo brings the session back and lifts its tombstone', async () => {
+    const { store } = makeTestStore();
+    store.dispatch(setSignedIn());
+    store.dispatch(setUserId('u1'));
+
+    store.dispatch(saveToTabContainerInternal(group('created-here')));
+    store.dispatch(undo());
+    expect(
+      (store.getState().tabContainerDataState.deletedTabGroups ?? []).map(
+        (g) => g.tabGroupId
+      )
+    ).toContain('created-here');
+
+    store.dispatch(redo());
+
+    const after = store.getState().tabContainerDataState;
+    expect(ids(after.tabGroups)).toEqual(['created-here']);
+    expect(
+      (after.deletedTabGroups ?? []).map((g) => g.tabGroupId)
+    ).not.toContain('created-here');
+  });
+
+  // CONTROL. The opposite outcome from the same action, so this cannot be
+  // "fixed" by making undo delete things in general: undoing a DELETE must
+  // still resurrect. If both tests can pass only one way, the fix is wrong.
+  it('undoing a delete still resurrects the session', async () => {
+    const { store } = makeTestStore();
+    store.dispatch(setSignedIn());
+    store.dispatch(setUserId('u1'));
+
+    store.dispatch(saveToTabContainerInternal(group('doomed')));
+    store.dispatch(deleteTabContainerInternal('doomed'));
+    expect(ids(store.getState().tabContainerDataState.tabGroups)).toEqual([]);
+
+    store.dispatch(undo());
+
+    const after = store.getState().tabContainerDataState;
+    expect(ids(after.tabGroups)).toEqual(['doomed']);
+    expect(
+      (after.deletedTabGroups ?? []).map((g) => g.tabGroupId)
+    ).not.toContain('doomed');
+  });
+
+  // The KAN-83 shape, run against the fix rather than the revert: a session
+  // this device never created is in the container at undo time. The previous
+  // two attempts could not tell it apart from the retracted one and tombstoned
+  // it, deleting it on the device that made it. Here the withdrawal names one
+  // id, so there is nothing to tell apart.
+  it('withdraws only the created session, not one that arrived from another device', async () => {
+    const { store } = makeTestStore();
+    store.dispatch(setSignedIn());
+    store.dispatch(setUserId('u1'));
+
+    store.dispatch(saveToTabContainerInternal(group('mine')));
+
+    // Another device's session arrives on a sync.
+    const local = JSON.parse(
+      JSON.stringify(store.getState().tabContainerDataState)
+    );
+    const cloud = {
+      ...local,
+      lastModified: Date.now() + 1000,
+      tabGroups: [
+        ...local.tabGroups,
+        { ...group('theirs'), lastModified: Date.now() + 1000 },
+      ],
+    };
+    localStorage.setItem('tabContainerData', JSON.stringify(local));
+    mocks.loadFromFirestore.mockResolvedValue(cloud);
+    await store.dispatch(syncStateWithFirestore() as never);
+    expect(ids(store.getState().tabContainerDataState.tabGroups)).toEqual([
+      'mine',
+      'theirs',
+    ]);
+
+    // Now create one here and undo it, with the foreign session present.
+    store.dispatch(saveToTabContainerInternal(group('created-here')));
+    store.dispatch(undo());
+
+    const graves = (
+      store.getState().tabContainerDataState.deletedTabGroups ?? []
+    ).map((g) => g.tabGroupId);
+    expect(graves).toContain('created-here');
+    expect(graves).not.toContain('theirs');
+    expect(graves).not.toContain('mine');
+  });
+
+  // The ordering the bug was actually reported in, and the one measured live:
+  // create, let auto-sync finish, THEN undo. The sync is what makes it hard --
+  // syncStateWithFirestore dispatches setPresentStartup, which replaces
+  // `present` wholesale. Anything recorded on the pending step has to survive
+  // that, or the withdrawal disarms in exactly the case the user hits.
+  //
+  // This is also the fixture that has teeth against the KAN-83 mistake:
+  // setPresentStartup refreshes `present` but never `past`, so a snapshot
+  // popped here predates the arrival of 'theirs' and a diff-based rule
+  // tombstones it. Ordering the sync before the undone step -- as an earlier
+  // draft of this file did -- hides that entirely.
+  it('still withdraws when a sync lands between the create and the undo', async () => {
+    const { store } = makeTestStore();
+    store.dispatch(setSignedIn());
+    store.dispatch(setUserId('u1'));
+
+    store.dispatch(saveToTabContainerInternal(group('mine')));
+    store.dispatch(saveToTabContainerInternal(group('created-here')));
+
+    // Auto-sync pushes the create up, and another device's session comes back.
+    const local = JSON.parse(
+      JSON.stringify(store.getState().tabContainerDataState)
+    );
+    const cloud = {
+      ...local,
+      lastModified: Date.now() + 1000,
+      tabGroups: [
+        ...local.tabGroups,
+        { ...group('theirs'), lastModified: Date.now() + 1000 },
+      ],
+    };
+    localStorage.setItem('tabContainerData', JSON.stringify(local));
+    mocks.loadFromFirestore.mockResolvedValue(cloud);
+    await store.dispatch(syncStateWithFirestore() as never);
+    expect(ids(store.getState().tabContainerDataState.tabGroups)).toEqual([
+      'created-here',
+      'mine',
+      'theirs',
+    ]);
+
+    store.dispatch(undo());
+
+    const graves = (
+      store.getState().tabContainerDataState.deletedTabGroups ?? []
+    ).map((g) => g.tabGroupId);
+    expect(graves).toContain('created-here');
+    expect(graves).not.toContain('theirs');
+    expect(graves).not.toContain('mine');
+
+    // And it stays retracted through the merge that follows.
+    localStorage.setItem(
+      'tabContainerData',
+      JSON.stringify(store.getState().tabContainerDataState)
+    );
+    mocks.loadFromFirestore.mockResolvedValue(cloud);
+    await store.dispatch(syncStateWithFirestore() as never);
+    const after = ids(store.getState().tabContainerDataState.tabGroups);
+    expect(after).not.toContain('created-here');
+    expect(after).toContain('theirs');
+  });
+
+  // Undoing twice in a row. The second undo restores a snapshot older than the
+  // first undo's tombstone, and restoreContainer rebuilt deletedTabGroups
+  // wholly from the payload -- so that tombstone was thrown away and the
+  // session it withdrew came back on the next merge (KAN-81).
+  //
+  // KAN-81 was filed as display-only, and on `main` it is: a discarded
+  // tombstone is restored from the cloud on the same sync, and nothing else
+  // depended on it. Once undo writes tombstones of its own that stops being
+  // true, because the tombstone IS the retraction. Same defect, promoted from
+  // a false toast to a lost undo.
+  it('keeps both withdrawals when the user undoes twice', async () => {
+    const { store } = makeTestStore();
+    store.dispatch(setSignedIn());
+    store.dispatch(setUserId('u1'));
+
+    store.dispatch(saveToTabContainerInternal(group('keep')));
+    store.dispatch(saveToTabContainerInternal(group('first')));
+    store.dispatch(saveToTabContainerInternal(group('second')));
+
+    const cloudWithBoth = JSON.parse(
+      JSON.stringify(store.getState().tabContainerDataState)
+    );
+
+    store.dispatch(undo());
+    store.dispatch(undo());
+    expect(ids(store.getState().tabContainerDataState.tabGroups)).toEqual([
+      'keep',
+    ]);
+
+    localStorage.setItem(
+      'tabContainerData',
+      JSON.stringify(store.getState().tabContainerDataState)
+    );
+    mocks.loadFromFirestore.mockResolvedValue(cloudWithBoth);
+    await store.dispatch(syncStateWithFirestore() as never);
+
+    expect(ids(store.getState().tabContainerDataState.tabGroups)).toEqual([
+      'keep',
+    ]);
+  });
+
+  // The reducer's own contract, exercised directly because the middleware
+  // cannot currently produce this call: a step's recorded ids are by
+  // construction absent from the snapshot taken before that step.
+  //
+  // It is still worth enforcing rather than assuming. `withdrawTabGroupIds` is
+  // an argument, and the cost of getting it wrong is asymmetric -- burying a
+  // session the snapshot still holds deletes something the user can see, on
+  // every device, with no undo left to reach for.
+  it('never buries a session the snapshot still contains', () => {
+    const { store } = makeTestStore();
+    store.dispatch(saveToTabContainerInternal(group('kept')));
+
+    const snapshot = JSON.parse(
+      JSON.stringify(store.getState().tabContainerDataState)
+    );
+
+    store.dispatch(
+      applyUndoSnapshot({ snapshot, withdrawTabGroupIds: ['kept'] })
+    );
+
+    const after = store.getState().tabContainerDataState;
+    expect(ids(after.tabGroups)).toEqual(['kept']);
+    expect(
+      (after.deletedTabGroups ?? []).map((g) => g.tabGroupId)
+    ).not.toContain('kept');
+  });
+
+  // Creating a session selects it, so reaching for any other row before
+  // undoing is ordinary. Selection replaces `present` without recording a
+  // step; if that dropped the recorded ids the withdrawal would silently
+  // disarm and the bug would look exactly as reported.
+  it('still withdraws after the user selects another session first', async () => {
+    const { store } = makeTestStore();
+    store.dispatch(setSignedIn());
+    store.dispatch(setUserId('u1'));
+
+    store.dispatch(saveToTabContainerInternal(group('existing')));
+    store.dispatch(saveToTabContainerInternal(group('created-here')));
+    const cloudAfterCreate = JSON.parse(
+      JSON.stringify(store.getState().tabContainerDataState)
+    );
+
+    store.dispatch(selectTabContainer('existing'));
+    store.dispatch(undo());
+
+    localStorage.setItem(
+      'tabContainerData',
+      JSON.stringify(store.getState().tabContainerDataState)
+    );
+    mocks.loadFromFirestore.mockResolvedValue(cloudAfterCreate);
+    await store.dispatch(syncStateWithFirestore() as never);
+
+    expect(ids(store.getState().tabContainerDataState.tabGroups)).toEqual([
+      'existing',
+    ]);
+  });
+});

--- a/src/utils/constants/actionTypes.ts
+++ b/src/utils/constants/actionTypes.ts
@@ -12,6 +12,11 @@ export const TAB_CONTAINER_REPLACE_STATE_ACTION =
 // restoreContainer in tabContainerDataStateSlice.
 export const TAB_CONTAINER_RESTORE_ACTION =
   'tabContainerDataState/restoreContainer';
+
+// Undo/redo only. Same reconciliation as restoreContainer, plus withdrawing the
+// sessions the undone step created; import must never take this path (KAN-80).
+export const TAB_CONTAINER_APPLY_UNDO_SNAPSHOT_ACTION =
+  'tabContainerDataState/applyUndoSnapshot';
 export const SELECT_TAB_CONTAINER_ACTION =
   'tabContainerDataState/selectTabContainer';
 export const SAVE_TAB_CONTAINER_ACTION =


### PR DESCRIPTION
Record what a step created, so undoing it can withdraw it (KAN-80, KAN-81)

Reported from the live extension: undoing a session you just created does not
stick, it comes back.

Measured in the popup before anything was changed. Sampling the persisted
container every 250ms across a create, a sync and an undo:

  ms  2251  4 sessions  c9be3eaa created
  ms  9385  4 sessions  synced
  ms 15752  3 sessions  undo applied, c9be3eaa gone
  ms 16252  4 sessions  c9be3eaa back
  ms 32401  4 sessions  still back

The same sequence with the network emulated Offline stays at 3 sessions for 16
seconds. Offline holds, online reverses, so the merge is what puts it back
rather than the undo failing to run. Confirming from the other side: after
restoring the network, Sync now brought back the session that had reached the
cloud and did NOT bring back one created while offline.

mergeTabContainers unions by tabGroupId. A session in the cloud but absent
locally is simply present, because absence is not a signal -- only a tombstone
is. Undoing a create removed the session and wrote no tombstone, so the copy
auto-sync pushed up on creation unioned straight back. The tombstone count sat
at 88 through every sample of the failing run.

Two previous attempts at this recovered the retracted session by diffing the
undo snapshot against something. Both were wrong, and one of them (KAN-80's
first fix, reverted as KAN-83) deleted sessions created on other devices. Every
pair of states available when an undo is applied has already drifted:
replaceState enters the container but no snapshot, and setPresentStartup
refreshes present but never past. So "missing from the snapshot" cannot
distinguish a session the user retracted from one that merely arrived.

So the ambiguity is removed rather than resolved. The middleware already holds
the state from immediately before and immediately after an action, one instant
apart, with no room for a cloud arrival in between; what a step added is a fact
there. undoRedoSlice records it on the history entry, and the undo path is
handed the ids to withdraw instead of deriving them.

restoreContainer is split rather than given a flag. Undo and import want
opposite things from a session the payload lacks -- retract it, versus leave it
alone, because a backup file is a partial view of the world and tombstoning
against it would let an old export delete every newer session on every device.
The ~90 lines of timestamp reasoning both share move to
reconcileAssertedContainer, so the two differ only where they genuinely
disagree.

KAN-81 is fixed here too, because this change promotes it from cosmetic to
data-affecting. Restoring a container rebuilt deletedTabGroups wholly from the
payload, and an undo snapshot predates any tombstone written since -- so each
undo discarded them. That was a false "Synced changes from another device" on
main, harmless because the cloud handed the tombstone back on the same sync.
Once undo writes tombstones of its own, the tombstone IS the retraction:
undoing two creates in a row discarded the first withdrawal and the session
came back. Live tombstones are now carried across a restore, dropped only when
the payload asserts that session alive again, which is undoing a delete.

Two things went wrong while writing this and are worth recording. The first
five tests all synced BEFORE the step being undone, which hides the whole
problem, because setPresentStartup refreshes present and the diff then looks
clean; the reported ordering is create, sync, undo, and against that ordering
the fix did nothing until setPresentStartup carried the ids forward too. And
the KAN-81 toast test passed against the unfixed code, because its cloud was a
copy of local taken after the undo, so there was no lost tombstone to hand
back. Both were found by mutation, not by reading.

Mutations, each verified present in the file before running:

  withdraw nothing (pre-fix)                    5 tests fail
  selection drops the recorded ids              1 test fails
  derive the withdrawal by diffing (KAN-83)     2 fail, incl. the regression guard
  setPresentStartup drops the recorded ids      1 test fails
  drop the surviving-session guard              1 test fails
  bury at Date.now(), not strictly after        3 tests fail
  rebuild tombstones from the payload (KAN-81)  2 tests fail

The KAN-83 guard, undoDoesNotDeleteRemoteSessions.test.ts, stays green
throughout and fails under the diffing mutation -- which is what distinguishes
this approach from the reverted one.

Verified live on the rebuilt artifact. Create, sync, undo: the session stays
gone through 18.7s and an explicit Sync now, with the tombstone count going 88
to 89 and a grave recorded for exactly that id. Redo brings it back and lifts
the tombstone, count returning to 88. Two creates then two undos leave both
withdrawn and take the count 88 to 90; before the KAN-81 half that second undo
discarded the first tombstone.

740 unit tests / 83 files (from 730 / 81), Playwright 58/58, tsc 0,
typecheck:e2e 0, eslint 0 errors / 25 warnings.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

