### PR TITLE
Fill a row in one frame, so its action strip cannot run ahead (KAN-100)

### DIFF
--- a/e2e/a11y-controls.spec.ts
+++ b/e2e/a11y-controls.spec.ts
@@ -368,20 +368,31 @@ test.describe('controls are reachable by keyboard', () => {
   // The other half of KAN-68: being in the tab order is useless if focus
   // lands on something painted at opacity 0. Hover is a pointer-only signal,
   // so :focus-within is what reveals these to a keyboard user.
+  //
+  // Asserted on the CONTROL, not on the block around it (KAN-100). The block
+  // carries the opaque mask and has to land in one frame with the row's fill,
+  // so it no longer fades and its opacity is 1 in every state; the reveal now
+  // lives on the icons. Reading the block here would be trivially true and
+  // would pass against a build that reveals nothing at all. It is also the
+  // more faithful target for what this test says it cares about -- whether the
+  // thing focus lands on is painted.
   test('focusing a row action reveals it (KAN-68)', async ({
     context,
     extensionId,
   }) => {
     const page = await openPopup(context, extensionId);
-    const actions = page.locator('div:has(> [aria-label="Delete"])');
+    const deleteAction = page.getByRole('button', {
+      name: 'Delete',
+      exact: true,
+    });
 
-    // The control: unfocused and unhovered, the block really is invisible, so
-    // the assertion below can tell the two states apart.
-    await expect(actions).toHaveCSS('opacity', '0');
+    // The control: unfocused and unhovered, it really is invisible, so the
+    // assertion below can tell the two states apart.
+    await expect(deleteAction).toHaveCSS('opacity', '0');
 
-    await page.getByRole('button', { name: 'Delete', exact: true }).focus();
+    await deleteAction.focus();
 
-    await expect(actions).toHaveCSS('opacity', '1');
+    await expect(deleteAction).toHaveCSS('opacity', '1');
   });
 
   // KAN-75. RateAndReviewModal rendered both dismissals as a NormalLabel with

--- a/e2e/row-state-feedback.spec.ts
+++ b/e2e/row-state-feedback.spec.ts
@@ -55,6 +55,151 @@ const rowFor = (page: Page, title: string): Locator =>
 /** The absolutely-positioned Open/Switch/Delete block inside a row. */
 const actionsIn = (row: Locator): Locator => row.locator('> div').last();
 
+/**
+ * How revealed the row's actions are, as an opacity string.
+ *
+ * Read from an ICON, not from the block (KAN-100). The block carries the
+ * opaque mask and must land in one frame, so it no longer fades and its own
+ * opacity is now 1 in every state. Asserting on the block would therefore be
+ * trivially true and would go green against a build that never reveals
+ * anything -- which is exactly what it did on the first run of this change.
+ */
+const revealOf = (row: Locator): Promise<string> =>
+  actionsIn(row)
+    .locator('> *')
+    .first()
+    .evaluate((el) => getComputedStyle(el).opacity);
+
+type SeamFrame = { left: string; right: string };
+
+/**
+ * Start sampling, every animation frame, what the eye sees on each side of the
+ * edge where the action strip begins.
+ *
+ * Composited, not declared (KAN-100). The strip's declared background IS the
+ * row's destination colour the whole time, so comparing declared values sees
+ * two identical strings and reports agreement even while the halves visibly
+ * differ. What matters is the strip's paint attenuated by the opacity revealing
+ * it, over whatever the row is currently showing.
+ */
+async function startSeamSampler(
+  page: Page,
+  rowLabel: string,
+  /**
+   * Where the strip sits relative to the labelled button. In a session row the
+   * button IS the row's left column and the strip is the row's last child; in
+   * a right-pane window row the labelled button is one of the strip's own
+   * icons, so the strip is its parent and the row is the strip's parent.
+   */
+  kind: 'session' | 'window' = 'session'
+): Promise<void> {
+  const surface = await page.evaluate(
+    () => getComputedStyle(document.body).backgroundColor
+  );
+  // CONTROL: compositing against the page needs an opaque page. A transparent
+  // body would collapse every composite to the same value and the assertions
+  // below could not fail.
+  expect(
+    surface,
+    'the page needs an opaque background to composite against'
+  ).not.toMatch(TRANSPARENT);
+
+  await page.evaluate(
+    ([label, pageColor, rowKind]: [string, string, string]) => {
+      // Both shapes, because Icon renders a `div role="button"` rather than a
+      // native <button> (it hand-rolls Enter AND Space), while ClickableRow
+      // renders a real one. A `button[aria-label]` selector silently matches
+      // nothing for a window row's icons.
+      const button = Array.from(
+        document.querySelectorAll(
+          'button[aria-label], [role="button"][aria-label]'
+        )
+      ).find((b) => b.getAttribute('aria-label') === label);
+      const row =
+        rowKind === 'window'
+          ? button!.parentElement!.parentElement!
+          : button!.parentElement!;
+      const actions =
+        rowKind === 'window' ? button!.parentElement! : row.lastElementChild!;
+
+      type Rgba = { r: number; g: number; b: number; a: number };
+      const parse = (c: string): Rgba | null => {
+        const m = c.match(/rgba?\(([^)]+)\)/);
+        if (!m) return null;
+        const p = m[1].split(',').map(Number);
+        return { r: p[0], g: p[1], b: p[2], a: p.length > 3 ? p[3] : 1 };
+      };
+      const over = (fg: Rgba | null, bg: Rgba): Rgba =>
+        fg === null
+          ? bg
+          : {
+              r: Math.round(fg.r * fg.a + bg.r * (1 - fg.a)),
+              g: Math.round(fg.g * fg.a + bg.g * (1 - fg.a)),
+              b: Math.round(fg.b * fg.a + bg.b * (1 - fg.a)),
+              a: 1,
+            };
+      const show = (c: Rgba) => `rgb(${c.r},${c.g},${c.b})`;
+
+      // The row's fill lives in two places by design (KAN-82): background-color
+      // when selected, an inset shadow when hovered-unselected. Whichever is
+      // painted is what the eye sees, so that is what gets composited.
+      const paintOf = (el: Element): Rgba | null => {
+        const cs = getComputedStyle(el);
+        const bg = parse(cs.backgroundColor);
+        if (bg && bg.a > 0) return bg;
+        const shadow = cs.boxShadow.match(/rgba?\([^)]*\)/);
+        return shadow ? parse(shadow[0]) : null;
+      };
+
+      const surfaceRgba = parse(pageColor)!;
+      const seen: { left: string; right: string }[] = [];
+      (window as unknown as { __seam: typeof seen }).__seam = seen;
+
+      const tick = () => {
+        const left = over(paintOf(row), surfaceRgba);
+        const strip = paintOf(actions);
+        const attenuated =
+          strip === null
+            ? null
+            : {
+                ...strip,
+                a: strip.a * Number(getComputedStyle(actions).opacity),
+              };
+        seen.push({ left: show(left), right: show(over(attenuated, left)) });
+        requestAnimationFrame(tick);
+      };
+      requestAnimationFrame(tick);
+    },
+    [rowLabel, surface, kind] as [string, string, string]
+  );
+}
+
+async function readSeam(page: Page): Promise<SeamFrame[]> {
+  return page.evaluate(
+    () => (window as unknown as { __seam: SeamFrame[] }).__seam
+  );
+}
+
+function expectNoSeam(frames: SeamFrame[], moment: string): void {
+  // CONTROL: the row's fill actually moved while the sampler was running. An
+  // empty disagreement list is only meaningful if there was a change to
+  // disagree during.
+  expect(
+    new Set(frames.map((f) => f.left)).size,
+    `the row fill should have changed while ${moment}`
+  ).toBeGreaterThan(1);
+
+  const disagreeing = frames.filter((f) => f.left !== f.right);
+
+  expect(
+    disagreeing.length,
+    `the row must fill uniformly while ${moment}; saw ${disagreeing.length} ` +
+      `of ${frames.length} frames where the strip and the row showed ` +
+      `different colours, e.g. left ${disagreeing[0]?.left} vs right ` +
+      `${disagreeing[0]?.right}`
+  ).toBe(0);
+}
+
 const fillOf = (row: Locator): Promise<string> =>
   row.evaluate((el) => getComputedStyle(el).boxShadow);
 
@@ -142,7 +287,7 @@ test.describe('a row reveals its actions and fills as one state', () => {
 
     // The reveal happened -- without this the fill assertion could go green
     // simply because nothing was showing.
-    await expect(actionsIn(second)).toHaveCSS('opacity', '1');
+    await expect.poll(() => revealOf(second)).toBe('1');
 
     await expect
       .poll(() => fillOf(second), {
@@ -183,13 +328,10 @@ test.describe('a row reveals its actions and fills as one state', () => {
     await page.mouse.move(0, 0);
 
     await expect
-      .poll(
-        () => actionsIn(first).evaluate((el) => getComputedStyle(el).opacity),
-        {
-          message:
-            'a clicked row must not keep showing its actions after the pointer leaves',
-        }
-      )
+      .poll(() => revealOf(first), {
+        message:
+          'a clicked row must not keep showing its actions after the pointer leaves',
+      })
       .toBe('0');
   });
 
@@ -273,5 +415,118 @@ test.describe('a row reveals its actions and fills as one state', () => {
         `frames where they differed, e.g. row ${disagreeing[0]?.row} vs ` +
         `strip ${disagreeing[0]?.strip}`
     ).toBe(0);
+  });
+
+  // KAN-100. The strip must not reach the hover colour BEFORE the row does.
+  //
+  // KAN-98 pinned the two against each other by colour, and by colour they
+  // already agree: the strip's background IS the row's destination colour,
+  // from frame zero. The disagreement is entirely in WHEN, so a colour-equality
+  // check reads it as correct. That is how this survived four passes over the
+  // same family.
+  //
+  // One state, two channels, two durations:
+  //   strip -- already at the final colour, only fades in: opacity 0.1s
+  //   row   -- has to travel there:                        0.2s on the fill
+  //
+  // So the strip is done at ~100ms and the row at ~183ms, and in between there
+  // is a hard vertical edge where the strip begins. Measured on main at 95ebbdc:
+  // 18 disagreeing frames of 64, peak delta 19.
+  //
+  // Asserted on COMPOSITED output, not on declared colours. An opaque layer at
+  // alpha a over the row's fill L shows a*H + (1-a)*L, which equals L only when
+  // a is 0 or L has already reached H. Comparing the declared background to the
+  // declared fill cannot see that, because both are the same string the whole
+  // time.
+  test('the action strip does not reach the hover colour before the row does', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openWith(context, extensionId);
+    const first = rowFor(page, 'First session');
+    const second = rowFor(page, 'Second session');
+
+    // Match the reported repro: row one selected, then the pointer moves onto
+    // row two. Selected is what puts row two in the hovered-UNSELECTED state,
+    // which is the state whose fill used to ease -- a selected row would not
+    // exercise this at all.
+    await first.click({ position: { x: 20, y: 20 } });
+    await page.mouse.move(0, 0);
+
+    await startSeamSampler(page, 'Second session');
+
+    // A real mouse move at x:20 -- the left edge of the row. The row's centre
+    // sits UNDER the action strip (measured: the strip starts at x=175.6 of a
+    // 336.8px row), so an unpositioned hover lands on the strip and adds an
+    // icon's own hover to what is being measured.
+    await second.hover({ position: { x: 20, y: 20 } });
+    await page.waitForTimeout(500);
+
+    expectNoSeam(await readSeam(page), 'the pointer arrives');
+  });
+
+  // KAN-100, the other direction, and it needs its own test because the entry
+  // test CANNOT see this one.
+  //
+  // Once the fill lands in a single frame, a mask that fades in is invisible on
+  // the way in: it fades the destination colour over the destination colour.
+  // Verified by mutation -- restoring the block's `opacity: 0; transition:
+  // opacity 0.1s` leaves the entry test green.
+  //
+  // Leaving is where it shows. The row drops back to the page colour in one
+  // frame while the mask is still fading out at the hover colour, so the strip
+  // is briefly the only lit part of an unlit row -- the same seam, mirrored.
+  test('the action strip does not outlast the row fill when the pointer leaves', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openWith(context, extensionId);
+    const first = rowFor(page, 'First session');
+    const second = rowFor(page, 'Second session');
+
+    await first.click({ position: { x: 20, y: 20 } });
+    await second.hover({ position: { x: 20, y: 20 } });
+
+    // Settle first: sampling must start from a fully engaged row, or the
+    // frames captured would be the arrival, not the departure.
+    await expect.poll(() => revealOf(second)).toBe('1');
+
+    await startSeamSampler(page, 'Second session');
+
+    await page.mouse.move(0, 0);
+    await page.waitForTimeout(500);
+
+    expectNoSeam(await readSeam(page), 'the pointer leaves');
+  });
+
+  // KAN-100 was measured at two sites, not one. The right pane's window row
+  // had the same pairing -- `transition: background-color 0.2s` on the fill,
+  // `transition: opacity 0.1s` on the strip -- and the same shape when
+  // sampled live: 17 disagreeing frames of 52, strip done at ~100ms, row at
+  // ~183ms.
+  //
+  // Covered here rather than left to the left pane's tests because the two
+  // panes are different components with separately declared styles, and
+  // nothing stops one from being fixed while the other regresses. The right
+  // pane also still drives its reveal from React state rather than the
+  // container's :hover, which is the KAN-92 defect unfixed -- out of scope
+  // here, but the reason these are not one shared implementation.
+  test('a right-pane window row also fills uniformly', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openWith(context, extensionId);
+
+    await rowFor(page, 'First session').click({ position: { x: 20, y: 20 } });
+    const windowRow = page.getByRole('button', { name: 'Morning reading' });
+    await expect(windowRow).toBeVisible();
+    await page.mouse.move(0, 0);
+
+    await startSeamSampler(page, 'Rename window group', 'window');
+
+    await windowRow.hover({ position: { x: 20, y: 20 } });
+    await page.waitForTimeout(500);
+
+    expectNoSeam(await readSeam(page), 'the pointer arrives on a window row');
   });
 });

--- a/src/components/home/leftpane/TabGroupEntry.tsx
+++ b/src/components/home/leftpane/TabGroupEntry.tsx
@@ -79,35 +79,40 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
     height: 100%;
     justify-content: flex-start;
     align-items: center;
-    /* Hidden by default. What reveals it lives on the CONTAINER, not here --
-       see the engagement comment on containerStyle for why the two cannot be
-       allowed to drift apart. */
-    opacity: 0;
-    transition: opacity 0.1s ease-out;
-
-    /* THE MASK LIVES HERE, ON ONE ELEMENT (KAN-98).
+    /* THE MASK LIVES HERE, ON ONE ELEMENT (KAN-98), AND IT NEVER FADES
+       (KAN-100).
 
        This block is absolutely positioned over the title, so it has to be
        opaque or the text reads through the controls (KAN-92). That mask used
        to be painted by the three Icons individually, via a backgroundColor
-       prop carrying the ROW's state colour.
+       prop carrying the ROW's state colour, which made one property carry both
+       the row's state and each icon's own gesture (KAN-98).
 
-       Icon also carries a 0.2s background-color transition for its own hover.
-       So one property held two meanings -- the row's state, relayed in, and
-       the icon's own gesture -- and the single transition animated both. On
-       click the row's background snapped to the selection colour while the
-       strip eased toward it across 200ms: 20 measured frames with a hard
-       vertical seam down the middle of the row.
+       It then used to FADE, via this block's opacity, over a row whose fill was
+       still travelling. That cannot be made to agree by tuning timings, and the
+       algebra says why. An opaque layer at alpha a over the row's fill L shows
+       a*H + (1-a)*L, which equals L only when a is 0 or L has already reached
+       H. So matching the two durations does not help -- it leaves f(1-f)(P-H),
+       which peaks at a quarter of the full colour distance halfway through.
+       Measured before this change: the strip arrived at 100ms and the row at
+       183ms, 18 disagreeing frames of 64 with a hard vertical edge between them.
 
-       KAN-82's rule again, one component deeper: a transition is declared on a
-       property, not a reason. So the two reasons are now on two elements. The
-       mask is this block, painted from the same isSelected the row uses and in
-       the same render, with no transition on colour here -- only opacity eases.
-       The icons keep nothing but their own :hover, which may ease, because
-       that IS a gesture. */
-    background-color: ${isSelected
-      ? COLORS.SELECTION_COLOR
-      : COLORS.HOVER_COLOR};
+       The only shapes that agree are "the mask is invisible" and "the row has
+       already arrived". So the mask is declared with NO transition and the fill
+       below has none either: both land in the same frame, in both directions.
+
+       What still eases is the icons, below. They are glyphs sitting on a
+       background that is already uniform, so fading them cannot produce an
+       edge -- which is the whole difference between them and this mask. */
+    background-color: transparent;
+
+    /* Hidden by default. What reveals them lives on the CONTAINER, not here --
+       see the engagement comment on containerStyle for why the two cannot be
+       allowed to drift apart. */
+    & > * {
+      opacity: 0;
+      transition: opacity 0.1s ease-out;
+    }
   `;
 
   // What "engaged" paints. Declared once and used by both rules below, so the
@@ -116,6 +121,11 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
   const engagedStyle = `
     ${!isSelected ? `box-shadow: inset 0 0 0 100vw ${COLORS.HOVER_COLOR};` : ''}
     [data-row-actions] {
+      background-color: ${
+        isSelected ? COLORS.SELECTION_COLOR : COLORS.HOVER_COLOR
+      };
+    }
+    [data-row-actions] > * {
       opacity: 1;
     }
   `;
@@ -141,31 +151,34 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
        and may ease. background-color carries the fact, an inset shadow carries
        the gesture, and only the shadow transitions.
        
-       The shadow is declared transparent up front rather than left as 'none':
-       interpolating from 'none' animates the SPREAD from 0, which sweeps a
-       rectangle inward instead of fading. Declared this way only the colour
-       changes. The spread must exceed half the row's largest dimension to
-       fill it, and 100vw is comfortably past that at any popup size. */
+       The shadow is declared transparent up front rather than left as 'none'
+       so that the row's fill is always readable as a colour, in every state,
+       by anything measuring it. The spread must exceed half the row's largest
+       dimension to fill it, and 100vw is comfortably past that at any popup
+       size. */
     box-shadow: inset 0 0 0 100vw transparent;
-    /* The shadow eases only while the row is UNSELECTED (KAN-97).
+    /* THE FILL DOES NOT EASE, IN EITHER DIRECTION (KAN-100).
 
        KAN-82 established that selecting is a fact and must land in one frame,
-       while hovering is a gesture and may ease -- and it fixed the row LOSING
-       selection. The row GAINING it was never checked, and had the same defect
-       through the other property.
+       while hovering is a gesture and MAY ease -- and for a while it did, over
+       0.2s. KAN-97 then had to remove that ease while selected, because the
+       shadow paints on top of the background and eased out over a freshly
+       selected row.
 
-       background-color lands instantly, correctly. But the inset shadow paints
-       ON TOP of the background, and on click the fill's declaration disappears
-       (it is guarded on !isSelected), so it transitioned from HOVER_COLOR to
-       transparent across 0.2s. The newly selected row was painted the light
-       hover colour and darkened into the selection colour over 22 measured
-       frames. That is what read as a flash.
+       What was left still could not work. The action strip is an opaque mask
+       over the title, and a mask is only invisible when it is fully
+       transparent or when the row underneath has already arrived at the
+       colour the mask is painted. While the fill travelled, the strip -- which
+       is at its destination colour from frame zero -- ran ahead of it, and the
+       row filled in two halves with a hard vertical edge between them.
 
-       Removing the transition while selected makes the shadow snap as the
-       selection colour lands, so the two agree in the same frame. Hovering an
-       unselected row still eases, which is the control KAN-82's spec asserts
-       and which must keep passing. */
-    transition: ${isSelected ? 'none' : 'box-shadow 0.2s'};
+       No timing fixes that. Equalising the two durations still leaves
+       f(1-f)(P-H) between the halves, a quarter of the full colour distance at
+       the midpoint. The fill has to arrive in one frame so that there is never
+       an intermediate state for the mask to disagree with.
+
+       So engagement is now a fact too, and lands like one. What remains a
+       gesture, and still eases, is the icons appearing -- see rightStyle. */
 
     /* ENGAGEMENT IS ONE STATE, SO IT GETS ONE CONDITION (KAN-92).
 

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -97,7 +97,12 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     position: relative;
     display: flex;
     justify-content: space-between;
-    transition: background-color 0.2s;
+    /* No transition on the fill, and none on the mask below (KAN-100). The
+       action strip is opaque and sits over the title, so it is invisible only
+       while it is fully transparent or while this row has already arrived at
+       the colour the strip is painted. Easing the fill guarantees a window
+       where neither is true, and the row fills in two halves with a hard
+       vertical edge between them -- measured here at 17 frames of 52. */
     &:hover {
       background-color: ${COLORS.HOVER_COLOR};
     }
@@ -116,11 +121,21 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     top: 50%;
     right: 0;
     transform: translateY(-50%);
-    opacity: ${isParentHovered ? 1 : 0};
-    transition: opacity 0.1s ease-out;
+    /* The mask lands in one frame with the row's fill; only the icons ease
+       (KAN-100). They are glyphs over a background that is already uniform, so
+       fading them cannot produce an edge -- which is what separates them from
+       the mask they sit on. */
+    background-color: ${isParentHovered ? COLORS.HOVER_COLOR : 'transparent'};
+    & > * {
+      opacity: ${isParentHovered ? 1 : 0};
+      transition: opacity 0.1s ease-out;
+    }
     /* The keyboard's equivalent of the hover reveal (KAN-68). */
     &:focus-within {
-      opacity: 1;
+      background-color: ${COLORS.HOVER_COLOR};
+      & > * {
+        opacity: 1;
+      }
     }
     /* Left below the focus-within rule on purpose: during search these
        controls do not apply, and visibility:hidden removes them from the tab
@@ -137,7 +152,8 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     display: flex;
     align-items: stretch;
     justify-content: space-between;
-    transition: background-color 0.2s;
+    /* No transition on the fill, for the same reason as parentStyle above
+       (KAN-100). */
     &:hover {
       background-color: ${COLORS.HOVER_COLOR};
     }
@@ -156,13 +172,22 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     top: 50%;
     right: 0;
     transform: translateY(-50%);
-    opacity: ${hoveredChildIndex === index ? 1 : 0};
-    transition: opacity 0.1s ease-out;
+    /* Mask in one frame, icons ease -- see parentRightStyle (KAN-100). */
+    background-color: ${hoveredChildIndex === index
+      ? COLORS.HOVER_COLOR
+      : 'transparent'};
+    & > * {
+      opacity: ${hoveredChildIndex === index ? 1 : 0};
+      transition: opacity 0.1s ease-out;
+    }
     /* The keyboard's equivalent of the hover reveal (KAN-68). Delete tab has
        no alternate path anywhere in the UI, so this row is the only way to
        reach it. */
     &:focus-within {
-      opacity: 1;
+      background-color: ${COLORS.HOVER_COLOR};
+      & > * {
+        opacity: 1;
+      }
     }
   `;
 
@@ -289,7 +314,6 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
             tooltipText={t('Delete tab')}
             ariaLabel={t('Delete tab')}
             type="delete"
-            backgroundColor={COLORS.HOVER_COLOR}
             onClick={(e) => {
               e.stopPropagation();
               dispatch(deleteTab({ tabGroupId, windowId, tabId }));
@@ -386,7 +410,6 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
               tooltipText={t('Save changes')}
               ariaLabel={t('Save changes')}
               type="done"
-              backgroundColor={COLORS.HOVER_COLOR}
               onClick={(e) => {
                 e.stopPropagation();
                 handleBlur();
@@ -397,7 +420,6 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
               tooltipText={t('Rename window group')}
               ariaLabel={t('Rename window group')}
               type="edit"
-              backgroundColor={COLORS.HOVER_COLOR}
               onClick={(e) => {
                 e.stopPropagation();
                 startEditing();
@@ -410,7 +432,6 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
               tooltipText={t('Add current tab')}
               ariaLabel={t('Add current tab')}
               type="add"
-              backgroundColor={COLORS.HOVER_COLOR}
               onClick={(e) => {
                 e.stopPropagation();
                 onAddCurrTabToWindowClick(e);
@@ -422,7 +443,6 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
               tooltipText={t('Delete window group')}
               ariaLabel={t('Delete window group')}
               type="delete"
-              backgroundColor={COLORS.HOVER_COLOR}
               onClick={(e) => {
                 e.stopPropagation();
                 onDeleteClick(e);


### PR DESCRIPTION
Reported with a six-frame breakdown of a hover: select row one, move onto row
two, and the row does not fill uniformly -- the action strip arrives at the
hover colour first, leaving a hard vertical edge where it begins.

Measured live on main at 95ebbdc, light theme, real pointer, every frame:

  ms   0  op 0.00  left rgb(245,247,250)  right rgb(245,247,250)
  ms  33  op 0.26  left rgb(244,246,249)  right rgb(240,242,245)
  ms  67  op 0.68  left rgb(238,240,244)  right rgb(231,234,238)   <- peak 19
  ms 100  op 0.96  left rgb(233,236,239)  right rgb(228,231,235)   <- strip done
  ms 183  op 1.00  left rgb(228,231,235)  right rgb(228,231,235)   <- row done

18 disagreeing frames of 64. One state reached through two channels with two
durations: the strip was already at the final colour and only faded in over
0.1s, while the row's fill had to travel there over 0.2s.

PRE-EXISTING, NOT A KAN-98 REGRESSION. Checked against the tag, not assumed:
v1.5.0 carries the same pair, and its icons painted `isSelected ? SELECTION :
HOVER`, a constant that does not move on hover, so the strip was already at its
destination there too. KAN-98 moved the mask from three icons onto one block
and carried both durations across untouched -- it fixed the strip LAGGING on
click and never looked at it LEADING on hover.

EQUALISING THE DURATIONS DOES NOT WORK, which is why the fix is shaped the way
it is. An opaque layer at alpha a over the row's fill L shows a*H + (1-a)*L,
equal to L only when a is 0 or L has already arrived. Matched durations leave
f(1-f)(P-H) -- simulated over the real palette, still peaking at delta 12
against 19 today. It shrinks the seam by about 40% and moves where it peaks.

So the fill lands in one frame and the mask lands with it. The strip's
background is declared with no transition, and the row's fill has none either;
what still eases is the icons, which are glyphs over a background that is
already uniform and therefore cannot produce an edge. Engagement becomes a fact
that lands like one, alongside selection (KAN-82).

TWO SITES, BOTH MEASURED. The right pane's window row had the same pairing and
the same shape: 17 disagreeing frames of 52. Its icons carried their own opaque
HOVER_COLOR, which after moving the mask onto the strip would have left them
fading out as lit patches over an unlit row -- so those five props are removed,
exactly as KAN-98 did for the left pane.

Tests, all against the real built extension:

  - the strip does not reach the hover colour before the row does
  - the strip does not outlast the row fill when the pointer leaves
  - a right-pane window row also fills uniformly

Asserted on COMPOSITED output, not declared colours. The strip's declared
background IS the row's destination colour the whole time, so KAN-98's
colour-equality check reads this as correct -- which is how it survived four
passes over the same family. The disagreement is entirely in WHEN.

Each carries a control asserting the row's fill actually moved during the
sample window, so zero disagreements cannot mean the sampler watched nothing.

MUTATIONS. Restoring the fill ease gives 19 disagreeing frames and fails the
entry test. Restoring the block's opacity fade leaves the ENTRY test green --
once the fill is instant, a fading mask fades the destination colour over the
destination colour -- and fails only the exit test, which is why both
directions needed their own. Restoring the right pane's fill transition fails
only the right-pane test, at 18 frames of 63.

Two existing assertions moved from the block to the icons, because the reveal
moved there. One of them was failing honestly; the other -- the KAN-68 control
in a11y-controls -- had started passing TRIVIALLY, since the block's opacity is
now 1 in every state. It would have gone green against a build that reveals
nothing at all. It also now reads the control that focus actually lands on,
which is what its own comment says it cares about.

Verified live on the rebuilt extension: 0 disagreeing frames of 64, max delta 0,
and the control shows 2 distinct fill colours where there were 16 -- the fill
now steps straight from the page colour to the hover colour.

740 unit tests, Playwright 61/61 (from 58), tsc 0, typecheck:e2e 0, eslint 0
errors / 25 warnings.
