### PR TITLE
Derive the row action block and icon boxes from the row (KAN-101, KAN-102, KAN-103)

### DIFF
--- a/e2e/row-action-inset.spec.ts
+++ b/e2e/row-action-inset.spec.ts
@@ -1,0 +1,160 @@
+import type { BrowserContext, Page } from '@playwright/test';
+
+import { test, expect } from './fixtures/extension';
+import { buildContainer, buildSession, seedSessions } from './fixtures/seed';
+
+// KAN-101. A hovered action icon met the row's border on some rows and sat
+// inside it on others -- same build, same theme, same control.
+//
+// It was never a layout difference. Every row measured identically:
+//
+//   row  67.081  = 8 padding + 18.1818 title + 2 + 13.6364 counts
+//                            + 5 + 12.2727 date + 8 padding
+//   icon 66.5412 = 28 padding + 38.544 content
+//
+// The row's height is three `line-height: normal` line boxes, which are
+// font-metric derived and never round. The icon's height is an unrelated
+// stack: its own padding plus glyph plus label. The two landed 0.27px apart by
+// COINCIDENCE, and 0.27px is below one device pixel -- so at a fractional
+// devicePixelRatio (2.2 on the reporter's display) the same CSS rasterised to a
+// 0px gap on some rows and 1px on others, and to 0 at the top and 1 at the
+// bottom on one row, which read as lopsided.
+//
+// The fix is not to pick a nicer fraction. It is that the icon's height must be
+// DERIVED FROM the row (`align-items: stretch`) rather than happening to come
+// out near it, with the inset then stated as a margin. That is what these tests
+// pin: not "the gap looks right", but "the gap is a number someone chose".
+//
+// Measured while choosing the value: no margin is stable at dpr 2.2 -- 1px
+// gives 2/3 device px, 2px gives 4/5, 3px gives 6/7, 4px gives 8/9. Every
+// option varies by one device pixel because the row positions are fractional.
+// So the goal is not an exact device-pixel gap, which is unreachable; it is
+// that the gap is stated in CSS and its minimum is comfortably above zero, so
+// it can never read as "touching the border" on one row and not another.
+
+/** Per side, in CSS px. Mirrors `ACTION_ICON_INSET` in TabGroupEntry.tsx. */
+const INSET_PER_SIDE = 2;
+const TOTAL_INSET = INSET_PER_SIDE * 2;
+
+// Compared with toBeCloseTo(_, 0) -- within half a CSS pixel -- and NOT with
+// exact equality. The row's height is snapped to the device pixel grid, so the
+// leftover is the declared inset plus or minus a fraction of a pixel: measured
+// at exactly 4 headless (dpr 1) and 3.9915 on a dpr 2.2 display. Asserting
+// equality would pin this spec to dpr 1 and fail on any HiDPI runner.
+//
+// The tolerance costs nothing in sensitivity. The defect being guarded leaves a
+// leftover of ~0.54 (icon sized by its own content) or, once the row grows, 17
+// -- both are whole pixels away from 4, not fractions.
+
+async function openWith(
+  context: BrowserContext,
+  extensionId: string
+): Promise<Page> {
+  await seedSessions(
+    context,
+    buildContainer([
+      buildSession({ tabGroupId: 'first', title: 'First session' }),
+      buildSession({ tabGroupId: 'second', title: 'Second session' }),
+      buildSession({ tabGroupId: 'third', title: 'Third session' }),
+    ])
+  );
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/index.html`);
+  return page;
+}
+
+type RowMetric = { rowH: number; iconH: number; leftover: number };
+
+/**
+ * Every session row's height alongside its first action icon's height.
+ *
+ * Read in CSS pixels rather than device pixels on purpose. The SYMPTOM is a
+ * device-pixel rounding flip, but that is display-dependent -- on an integer
+ * DPR the same defect may round identically on every row and vanish, so a
+ * device-pixel assertion would pass on CI and fail only on the reporter's
+ * machine. The DEFECT is in CSS: a leftover nobody chose. That reproduces
+ * everywhere.
+ */
+async function rowMetrics(page: Page): Promise<RowMetric[]> {
+  return page.evaluate(() =>
+    Array.from(document.querySelectorAll('[data-row-actions]')).map((block) => {
+      const row = block.parentElement as HTMLElement;
+      const icon = block.children[0] as HTMLElement;
+      const rowH = row.getBoundingClientRect().height;
+      const iconH = icon.getBoundingClientRect().height;
+      return { rowH, iconH, leftover: Number((rowH - iconH).toFixed(4)) };
+    })
+  );
+}
+
+test.describe('a row action icon is inset by a stated amount', () => {
+  test('every row leaves exactly the declared inset around its action icon', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openWith(context, extensionId);
+    const metrics = await rowMetrics(page);
+
+    // CONTROL: there are rows to measure at all, and they have real height.
+    // Without this an empty list would satisfy every assertion below.
+    expect(metrics.length, 'the seeded sessions should render').toBe(3);
+    expect(
+      metrics.every((m) => m.rowH > 0 && m.iconH > 0),
+      'rows and icons should have measurable height'
+    ).toBe(true);
+
+    for (const [i, m] of metrics.entries()) {
+      expect(
+        m.leftover,
+        `row ${i} should leave exactly ${TOTAL_INSET}px around its icon ` +
+          `(row ${m.rowH}, icon ${m.iconH}) -- a leftover that is not the ` +
+          `declared inset means the icon is sized independently of the row ` +
+          `and the remainder is a coincidence`
+      ).toBeCloseTo(TOTAL_INSET, 0);
+    }
+  });
+
+  // The assertion above pins the VALUE. This one pins that the value is
+  // DERIVED -- which is the actual defect, and the half a fixed number alone
+  // would not catch.
+  //
+  // A content-sized icon keeps its own height when the row grows, so the
+  // leftover changes. An icon stretched to the row keeps the leftover constant
+  // no matter what the row does. Growing the row is the only way to tell those
+  // apart, and nothing in the seeded data changes row height on its own --
+  // titles truncate to one line -- so the row is grown here directly.
+  test('the inset holds when the row grows', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openWith(context, extensionId);
+    const before = await rowMetrics(page);
+
+    await page.evaluate(() => {
+      document.querySelectorAll('[data-row-actions]').forEach((block) => {
+        const left = block.parentElement!.querySelector('button[aria-label]');
+        (left as HTMLElement).style.paddingBottom = '24px';
+      });
+    });
+
+    const after = await rowMetrics(page);
+
+    // CONTROL: the rows actually got taller. If they did not, the assertion
+    // below compares two identical measurements and cannot fail.
+    for (const [i, m] of after.entries()) {
+      expect(
+        m.rowH,
+        `row ${i} should have grown, otherwise this test proves nothing`
+      ).toBeGreaterThan(before[i].rowH);
+    }
+
+    for (const [i, m] of after.entries()) {
+      expect(
+        m.leftover,
+        `row ${i} should still leave exactly ${TOTAL_INSET}px after growing ` +
+          `(row ${m.rowH}, icon ${m.iconH}) -- a leftover that moved with the ` +
+          `row means the icon's height does not follow it`
+      ).toBeCloseTo(TOTAL_INSET, 0);
+    }
+  });
+});

--- a/e2e/row-action-inset.spec.ts
+++ b/e2e/row-action-inset.spec.ts
@@ -158,3 +158,89 @@ test.describe('a row action icon is inset by a stated amount', () => {
     }
   });
 });
+
+// KAN-103. The same lesson one level out: the BLOCK's box must be the row's
+// box, not a box computed to land near it.
+//
+// It used to be centred with `top: 50%` plus `transform: translateY(-50%)`.
+// `top: 50%` is a layout value, quantised to 1/64px; the transform is a float
+// from the element's own height. On a row height that makes those disagree the
+// block sat 0.0036px above the row.
+//
+// That is far below a device pixel and would be harmless, except the mask is
+// opaque and the row separator is immediately beneath it. At dpr 2.2 the
+// block's bottom edge and the separator's top landed on the same device pixel,
+// the mask antialiased over it, and the separator visibly broke where the strip
+// began -- reported with a zoomed screenshot showing the line stopping dead at
+// the strip's left edge.
+test.describe('the action block takes its box from the row', () => {
+  // Swept across many row heights rather than measured once, and that is the
+  // whole design of this test.
+  //
+  // Whether the quantisation error appears at all depends on the row's exact
+  // height: at an integer height the percentage and the transform cancel
+  // perfectly and the defect is invisible. Headless rows are integers, so a
+  // single measurement here would pass against the broken code and prove
+  // nothing -- the same trap as asserting device pixels would have been.
+  //
+  // Measured live on the reporter's display: 11 of 17 sampled heights showed
+  // the offset, 6 did not. Sweeping means the test does not depend on landing
+  // on a pathological height by luck.
+  test('the block matches the row at every row height', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openWith(context, extensionId);
+
+    const samples = await page.evaluate(() => {
+      const row = document.querySelectorAll('[data-row-actions]')[0]
+        .parentElement as HTMLElement;
+      const block = row.querySelector('[data-row-actions]') as HTMLElement;
+      const left = row.querySelector('button[aria-label]') as HTMLElement;
+      const out: { pad: number; rowH: number; top: number; bottom: number }[] =
+        [];
+      // Stepped in 1/64px -- Chrome's LayoutUnit -- and that is load-bearing.
+      //
+      // The first version of this swept in 1/16px steps and PASSED against the
+      // broken code. Every height was then a multiple of 1/16, so its half was
+      // a multiple of 1/32 and exactly representable, and `top: 50%` had
+      // nothing to round. The defect only appears when half the row height is
+      // NOT representable, which needs an ODD multiple of 1/64.
+      //
+      // Caught by reverting the fix and watching this test stay green. A sweep
+      // that cannot produce the pathological height is not a sweep.
+      for (let i = 0; i <= 32; i++) {
+        const pad = i / 64;
+        left.style.paddingBottom = `${pad}px`;
+        const r = row.getBoundingClientRect();
+        const b = block.getBoundingClientRect();
+        out.push({
+          pad,
+          rowH: Number(r.height.toFixed(4)),
+          top: Number((b.top - r.top).toFixed(4)),
+          bottom: Number((b.bottom - r.bottom).toFixed(4)),
+        });
+      }
+      left.style.paddingBottom = '';
+      return out;
+    });
+
+    // CONTROL: the sweep really did change the row's height. Without this,
+    // seventeen identical measurements would satisfy the assertion below.
+    expect(
+      new Set(samples.map((s) => s.rowH)).size,
+      'the sweep should produce a range of row heights'
+    ).toBeGreaterThan(8);
+
+    const off = samples.filter((s) => s.top !== 0 || s.bottom !== 0);
+
+    expect(
+      off.length,
+      `the block must sit exactly on the row at every height; ${off.length} ` +
+        `of ${samples.length} sampled heights were off, e.g. row height ` +
+        `${off[0]?.rowH} gave top ${off[0]?.top} bottom ${off[0]?.bottom}. ` +
+        `An offset here is sub-pixel but the mask is opaque and the separator ` +
+        `is directly beneath it, so it paints over the line.`
+    ).toBe(0);
+  });
+});

--- a/e2e/row-state-feedback.spec.ts
+++ b/e2e/row-state-feedback.spec.ts
@@ -168,7 +168,20 @@ async function startSeamSampler(
         seen.push({ left: show(left), right: show(over(attenuated, left)) });
         requestAnimationFrame(tick);
       };
-      requestAnimationFrame(tick);
+      // Record the CURRENT frame synchronously, before scheduling the next.
+      //
+      // Not `requestAnimationFrame(tick)` alone. That takes the first sample a
+      // frame after this call returns, and the caller's next action -- a mouse
+      // move -- can be processed in between. On the way IN that is harmless,
+      // because the un-hovered state persists until the pointer arrives. On the
+      // way OUT it is fatal: KAN-100 made the fill land in ONE frame, so the
+      // hovered state is gone immediately and the sampler records only the
+      // after state. The control then reports, correctly, that nothing changed.
+      //
+      // Measured: 3 failures in 3 runs of the exit test on f0e695a before this
+      // line. The flake was introduced by the fix it tests -- an instant
+      // transition leaves no window for a late sampler to catch.
+      tick();
     },
     [rowLabel, surface, kind] as [string, string, string]
   );
@@ -468,14 +481,27 @@ test.describe('a row reveals its actions and fills as one state', () => {
   // KAN-100, the other direction, and it needs its own test because the entry
   // test CANNOT see this one.
   //
-  // Once the fill lands in a single frame, a mask that fades in is invisible on
-  // the way in: it fades the destination colour over the destination colour.
-  // Verified by mutation -- restoring the block's `opacity: 0; transition:
-  // opacity 0.1s` leaves the entry test green.
+  // Once the fill lands in a single frame, a mask that lingers is invisible on
+  // the way in -- the row is already at the destination colour, so whatever the
+  // mask does over it composites to the same value. Leaving is where it shows:
+  // the row drops to the page colour in one frame while the mask is still on
+  // its way out, so the strip is briefly the only lit part of an unlit row.
   //
-  // Leaving is where it shows. The row drops back to the page colour in one
-  // frame while the mask is still fading out at the hover colour, so the strip
-  // is briefly the only lit part of an unlit row -- the same seam, mirrored.
+  // The mutation that pins this is giving the mask a colour transition
+  // (`transition: background-color 0.2s` on the block). Measured: the entry
+  // test stays green, this one fails 4 times out of 4.
+  //
+  // NOTE the margin is thin -- 1 to 2 disagreeing frames out of ~63, because
+  // the mask is leaving while the row has already gone. It is reliable, but if
+  // a future change makes it thinner this test degrades quietly rather than
+  // loudly. If that happens, do not loosen the assertion; sample the first
+  // post-departure frames directly instead.
+  //
+  // An earlier revision of this comment claimed the mutation was restoring the
+  // block's `opacity` fade. That was wrong: the mask now lives on
+  // background-color, which goes transparent instantly, so fading an already
+  // transparent block changes nothing. The test's apparent failure under that
+  // mutation was the flake below, not detection.
   test('the action strip does not outlast the row fill when the pointer leaves', async ({
     context,
     extensionId,

--- a/src/components/home/leftpane/TabGroupEntry.tsx
+++ b/src/components/home/leftpane/TabGroupEntry.tsx
@@ -85,12 +85,31 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
 
   const rightStyle = css`
     position: absolute;
-    top: 50%;
+    /* Both edges pinned to the row, NOT centred with a percentage and a
+       transform (KAN-103).
+
+       top: 50% is a layout value and is quantised to 1/64px; the matching
+       translateY(-50%) is a float computed from the element's own height.
+       On a row whose height makes those disagree -- which is most of them,
+       since the height is font-metric derived and never round -- the block
+       ended up 0.0036px above the row. Measured on 11 of 17 sampled row
+       heights.
+
+       That is far below one device pixel and would not matter, except the mask
+       is opaque and the row separator is the very next thing beneath it. At
+       dpr 2.2 the block's bottom edge landed on 573.93 and the separator began
+       at 573.94 -- the same device pixel -- so the mask antialiased over the
+       separator and the line visibly broke where the strip began. Reported with
+       a zoomed screenshot showing exactly that.
+
+       Pinning both edges makes the box the row's box, with no arithmetic in
+       between and nothing to quantise. Same lesson as ACTION_ICON_INSET above,
+       one level out: derive the box, do not approximate it. */
+    top: 0;
+    bottom: 0;
     right: 0;
-    transform: translateY(-50%);
     display: flex;
     flex-direction: row;
-    height: 100%;
     justify-content: flex-start;
     /* stretch, NOT center (KAN-101). Centring sized each icon by its own
        content and left the difference between that and the row as a remainder

--- a/src/components/home/leftpane/TabGroupEntry.tsx
+++ b/src/components/home/leftpane/TabGroupEntry.tsx
@@ -18,6 +18,20 @@ import {
 import { tabContainerData } from '../../../redux/slices/tabContainerDataStateSlice';
 import { useTranslation } from 'react-i18next';
 
+/**
+ * How far a row's action icon sits inside the row, per side, in CSS px.
+ *
+ * Stated here rather than left to fall out of the icon's own padding (KAN-101).
+ * The icon used to be sized by its content and centred in the row, which left
+ * ~0.27px over -- a number nobody chose, below one device pixel, and therefore
+ * rounded to a 0px gap on some rows and 1px on others. Now the icon's height is
+ * derived FROM the row and this is the only thing standing between them.
+ *
+ * `e2e/row-action-inset.spec.ts` asserts this value, and asserts it survives
+ * the row changing height.
+ */
+const ACTION_ICON_INSET = 2;
+
 interface TabGroupEntryProps {
   tabGroupData: tabContainerData;
   /**
@@ -78,7 +92,13 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
     flex-direction: row;
     height: 100%;
     justify-content: flex-start;
-    align-items: center;
+    /* stretch, NOT center (KAN-101). Centring sized each icon by its own
+       content and left the difference between that and the row as a remainder
+       -- 0.27px, which no one chose and which is below one device pixel, so it
+       rendered as a gap on some rows and no gap on others. Stretching makes the
+       icon's height derive from the row, and ACTION_ICON_INSET below is then
+       the only thing between them. */
+    align-items: stretch;
     /* THE MASK LIVES HERE, ON ONE ELEMENT (KAN-98), AND IT NEVER FADES
        (KAN-100).
 
@@ -112,6 +132,7 @@ const TabGroupEntry: React.FC<TabGroupEntryProps> = ({
     & > * {
       opacity: 0;
       transition: opacity 0.1s ease-out;
+      margin: ${ACTION_ICON_INSET}px 0;
     }
   `;
 


### PR DESCRIPTION
Reported with two screenshots of the same control on different rows: on one the
hovered icon's fill sits inside the row with a hairline above and below, on
another it runs straight into the row's top border.

It was never a layout difference. All eight rows measured identically:

  row  67.081  = 8 padding + 18.1818 title + 2 + 13.6364 counts
                           + 5 + 12.2727 date + 8 padding
  icon 66.5412 = 28 padding + 38.544 content

The row's height is three `line-height: normal` line boxes, which are
font-metric derived and never round. The icon's height is an unrelated stack --
its own padding plus glyph plus label. The two landed 0.27px apart by
COINCIDENCE. That is below one device pixel, so at dpr 2.2 the same CSS
rasterised to a 0px gap on rows 0/5/7, 1px on rows 1/2/4/6, and 0 at the top
with 1 at the bottom on row 3, which read as lopsided.

  row      0     1     2     3     4     5     6     7
  gap    0/0   1/1   1/1   0/1   1/1   0/0   1/1   0/0

THE FIX IS NOT A NICER FRACTION. Justine asked why we were dealing with
fractional px at all, which is the right question: nothing declares a height, so
two boxes that must be co-extensive are sized independently. The icon's height
now DERIVES from the row (`align-items: stretch`) and ACTION_ICON_INSET is the
only thing standing between them.

Mocked both candidate looks in the live popup before writing code. Flush
(stretch alone) gives an exact zero gap on every row; a stated inset gives a
visible tile. Justine picked the inset. Measured while choosing the value: NO
margin is stable at dpr 2.2 -- 1px gives 2/3 device px, 2px gives 4/5, 3px gives
6/7, 4px gives 8/9 -- because the row positions are fractional. So the goal is
not an exact device-pixel gap, which is unreachable; it is that the gap is
stated and its minimum never reaches zero.

Verified live on the branch build: leftover 3.9915px on every row, one distinct
value, gaps 4-5 device px, and never zero on any row.

Tests, against the real built extension:

  - every row leaves exactly the declared inset around its action icon
  - the inset holds when the row grows

The second is the one that matters. The first pins the VALUE; only growing the
row pins that the value is DERIVED, which is the actual defect. A content-sized
icon keeps its height when the row grows, so the leftover moves; a stretched one
holds it. Nothing in the seeded data changes row height on its own -- titles
truncate to one line -- so the row is grown directly.

Compared with toBeCloseTo, not equality, and that was found by measuring live
rather than trusting green CI: the row height is snapped to the device grid, so
the leftover is 4 exactly headless and 3.9915 at dpr 2.2. Asserting equality
would have pinned the spec to dpr 1 and failed on any HiDPI runner. The
tolerance costs no sensitivity -- the defect leaves 0.54, or 17 once the row
grows.

Mutations: `stretch` back to `center` fails both tests (leftover 0, then 17).
ACTION_ICON_INSET 2 to 0 fails both (leftover 0, staying 0). The first attempt
at that second mutation was INVALID -- deleting the margin left the constant
unused, tsc failed, and because the build output was piped to /dev/null the run
silently tested the previous bundle and reported the earlier mutation's numbers.
Redone as a change that compiles, with the artifact checked.

ALSO FIXES KAN-102, two defects in the exit spec added by #194 hours ago:

  1. It is flaky -- 3 failures in 3 runs on f0e695a with no other change. The
     sampler only recorded inside requestAnimationFrame, so its first sample
     landed a frame after install and `page.mouse.move(0, 0)` could be processed
     in between. Harmless on the way in, fatal on the way out: KAN-100 made the
     fill land in ONE frame, so the before state was already gone and the
     control correctly reported that nothing changed. The fix it tests is what
     removed its own margin. Now samples synchronously at install; 5 green runs.

  2. Its mutation evidence was invalid. #194 claimed restoring the block's
     opacity fade fails only the exit test. It does not -- the mask lives on
     background-color, which goes transparent instantly, so fading an already
     transparent block produces no seam. What I saw was defect 1 firing, read as
     detection without checking which assertion had failed. The mutation that
     belongs to that direction is making the mask LINGER
     (`transition: background-color 0.2s`): entry passes, exit fails 4 of 4.
     The conclusion in #194 was right; one line of its evidence was not.
     Corrected on KAN-100 so its closing comment does not stand as the record.

Detection margin on the exit spec is thin -- 1 to 2 frames of ~63 -- and that is
now stated in the spec, along with the instruction to sample the first
post-departure frames rather than loosen the assertion if it ever narrows.

740 unit tests, Playwright 63/63 (from 61), tsc 0, typecheck:e2e 0, eslint 0
errors / 25 warnings.


---

# KAN-103 — the strip painted over the row separator

Reported with a zoomed screenshot: hovering a row, the dark separator line above
it stops dead at the left edge of the action strip and does not resume. Right on
some rows, broken on others. Confirmed against a live toggle before any code was
written -- four earlier hypotheses had measured plausibly and been wrong.

The block was positioned with `top: 50%` PLUS `transform: translateY(-50%)`, and
those do not cancel. `top: 50%` is a layout value, quantised to Chrome's 1/64px
LayoutUnit; the transform is a float from the element's own height. When half the
row height is not representable in 1/64px they disagree and the block sits above
the row. Measured live at -0.0036px on every visible row.

Sub-pixel, and harmless except for what is underneath. The mask is opaque
(load-bearing since KAN-92, the block sits over the title) and the separator is a
0.909px element immediately below the row in the same wrapper. At dpr 2.2 the
block's bottom edge lands on 573.93 and the separator begins at 573.94 -- the
same device pixel -- so the mask antialiases over it and eats the line.

Pinning both edges makes the box the row's box, with nothing left to quantise.
Verified live: -0.0036 to exactly 0 on every row.

Same lesson as ACTION_ICON_INSET, one level out: derive the box, do not
approximate it.

THE TEST STARTED AS A FALSE PASS, and that is the part worth keeping. It sweeps
row heights and asserts the block sits exactly on the row at each. Swept in
1/16px it PASSED against the broken code: every height was a multiple of 1/16, so
its half was a multiple of 1/32 and exactly representable, and `top: 50%` had
nothing to round. Stepped in 1/64px it produces the odd multiples where half the
height is not representable -- 16 of 33 sampled heights fail, e.g. row height
58.0156 giving -0.0078, which is 1/128.

Caught only by reverting the fix and watching the test stay green. A sweep that
cannot produce the pathological value is not a sweep. A single measurement can
never work here either: headless rows are integers, where the two cancel
perfectly and the defect does not exist.

Two process failures on the way, both mine and both already recorded as traps:

  - A backtick inside a comment in an emotion css template literal ends the
    literal; it surfaced as bare TS1005s pointing at prose. Fourth time in this
    project.
  - That failed build was piped to /dev/null, so the run silently tested the
    PREVIOUS bundle and reported a green that meant nothing. Every mutation and
    revert check here now greps the artifact and prints the build result.

Not changed: WindowEntryContainer's two strips use the same construction but are
content-height rather than height: 100%, so pinning both edges there would resize
them rather than correct them. Left alone, and not measured for whether a
separator sits beneath them.

Pre-existing, so it ships in v1.5.0 and earns a changelog line.

740 unit tests, Playwright 64/64 (from 63), tsc 0, typecheck:e2e 0, eslint 0
errors / 25 warnings.
