### PR TITLE
Point the README screenshot at the hero rather than tab groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Tab Keeper saves your open Chrome windows and tabs as organized sessions. Restor
 
 ## Screenshots
 
-<a href="https://chromewebstore.google.com/detail/tab-keeper-chrome-tab-man/gpibgniomobngodpnikhheifblbpbbah?ref=github" target="_blank"><img src="store-assets/screenshots/tab-keeper-screenshot-2.png" width="800" alt="Tab Keeper showing saved browser sessions and their tabs"></a>
+<a href="https://chromewebstore.google.com/detail/tab-keeper-chrome-tab-man/gpibgniomobngodpnikhheifblbpbbah?ref=github" target="_blank"><img src="store-assets/screenshots/tab-keeper-screenshot-1.png" width="800" alt="Tab Keeper saving all open windows as one session, with a session row showing its Open, Switch and Delete actions"></a>
 
 [View All Screenshots →](https://github.com/justine-george/tab-keeper-react-chrome-extension/wiki/Screenshots)
 


### PR DESCRIPTION
The Screenshots section referenced `screenshot-2` by path. That slot was picked
when screenshot-2 was the annotated image that taught the UI; #200 replaced the
whole set, so the same path now resolves to "Your tab groups come with you". The
link never broke, which is why nothing caught it -- only the meaning changed.

Screenshot-1 is the better single image here:

- The marquee tile at the top of the README already leads on tab groups (its alt
  text is "now with Chrome tab group support"), so slot 2 was repeating that
  message thirty lines further down.
- It is the only screenshot that shows the loop **How It Works** describes: the
  session list plus a hovered row with Open, Switch and Delete labelled.
- **One-Click Switching** is a listed feature and Switch appears in no other image.

The trade is deliberate. Screenshot-2 is the only one of the five composed fully
inside its frame, so it sits more tidily at `width="800"`; screenshot-1 is layered
and bleeds off both edges. The message is worth the cropping on a page whose job
is to say what this is.

The alt text described neither image -- it was written for the old annotated
screenshot -- so it now describes what is actually on screen.

Checked that every `src` in the README still resolves on disk:

    store-assets/marquee promo tile/tab-keeper-marquee-promo-tile.png   OK
    store-assets/banners/chrome_web_store_download_button.png           OK
    store-assets/screenshots/tab-keeper-screenshot-1.png                OK

One line changed. No assets added or moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
