### PR TITLE
Search Chrome tab group titles (KAN-104)

### DIFF
--- a/src/components/home/leftpane/TabGroupEntryContainer.tsx
+++ b/src/components/home/leftpane/TabGroupEntryContainer.tsx
@@ -39,12 +39,20 @@ export default function TabGroupEntryContainer() {
     (state: RootState) => state.globalState.searchInputText
   );
 
+  const hasTabGroupsPermission = useSelector(
+    (state: RootState) => state.globalState.hasTabGroupsPermission
+  );
+
   const selectedTabGroupId = tabContainerDataList.selectedTabGroupId;
 
   // filter the tab group list
   let filteredTabGroups: tabContainerData[] = tabContainerDataList.tabGroups;
   if (isSearchActive(isSearchPanel, searchInputText)) {
-    filteredTabGroups = filterTabGroups(searchInputText, filteredTabGroups);
+    filteredTabGroups = filterTabGroups(
+      searchInputText,
+      filteredTabGroups,
+      hasTabGroupsPermission
+    );
   }
 
   // Select the first match as the query narrows -- but only while a search is

--- a/src/components/home/rightpane/HeroContainerRight.tsx
+++ b/src/components/home/rightpane/HeroContainerRight.tsx
@@ -52,6 +52,10 @@ export default function HeroContainerRight() {
     (state: RootState) => state.globalState.searchInputText
   );
 
+  const hasTabGroupsPermission = useSelector(
+    (state: RootState) => state.globalState.hasTabGroupsPermission
+  );
+
   useEffect(() => {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       const currentTab = tabs[0];
@@ -67,7 +71,8 @@ export default function HeroContainerRight() {
   const selectedTabGroup = selectVisibleTabGroups(
     tabContainerDataList.tabGroups,
     isSearchPanel,
-    searchInputText
+    searchInputText,
+    hasTabGroupsPermission
   )[0];
 
   // Belt and braces: RightPane does not mount this component when the list is

--- a/src/components/home/rightpane/RightPane.tsx
+++ b/src/components/home/rightpane/RightPane.tsx
@@ -20,12 +20,17 @@ export default function RightPane() {
     (state: RootState) => state.globalState.searchInputText
   );
 
+  const hasTabGroupsPermission = useSelector(
+    (state: RootState) => state.globalState.hasTabGroupsPermission
+  );
+
   // the same list both children below read, so the guard here cannot disagree
   // with what they find
   const visibleTabGroups = selectVisibleTabGroups(
     tabContainerDataList.tabGroups,
     isSearchPanel,
-    searchInputText
+    searchInputText,
+    hasTabGroupsPermission
   );
 
   // to identify whether no tab groups are selected

--- a/src/components/home/rightpane/TabGroupDetailsContainer.tsx
+++ b/src/components/home/rightpane/TabGroupDetailsContainer.tsx
@@ -38,11 +38,16 @@ export default function TabGroupDetailsContainer() {
     (state: RootState) => state.globalState.searchInputText
   );
 
+  const hasTabGroupsPermission = useSelector(
+    (state: RootState) => state.globalState.hasTabGroupsPermission
+  );
+
   // the same list RightPane derives its mount guard from
   const selectedTabGroup = selectVisibleTabGroups(
     tabContainerDataList.tabGroups,
     isSearchPanel,
-    searchInputText
+    searchInputText,
+    hasTabGroupsPermission
   )[0];
 
   // Belt and braces: RightPane does not mount this component when the list is

--- a/src/tests/components/searchGroupTitles.test.tsx
+++ b/src/tests/components/searchGroupTitles.test.tsx
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'vitest';
+import { screen } from '@testing-library/react';
+
+import RightPane from '../../components/home/rightpane/RightPane';
+import TabGroupEntryContainer from '../../components/home/leftpane/TabGroupEntryContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  openSearchPanel,
+  setHasTabGroupsPermission,
+  setSearchInputText,
+} from '../../redux/slices/globalStateSlice';
+import {
+  saveToTabContainerInternal,
+  selectTabContainer,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import type { makeTestStore } from '../setup/makeStore';
+
+// KAN-104, at the level the unit tests cannot reach. filterTabGroups can be
+// entirely correct while the permission never leaves the store -- four
+// components have to read it and hand it over, and a component that forgot
+// would show a pure-function suite that is still green.
+//
+// 'Quarterly' appears in no session title, window title, tab title or URL, so
+// every assertion below can only be answered by reading the group's title.
+const session = () => ({
+  tabGroupId: 'group-1',
+  title: 'Alpha',
+  createdTime: '2026-08-31 09:00:00',
+  windowCount: 1,
+  tabCount: 2,
+  isAutoSave: false,
+  isSelected: true,
+  windows: [
+    {
+      windowId: 'win-1',
+      windowHeight: 1080,
+      windowWidth: 1920,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 2,
+      title: 'Beta window',
+      chromeTabGroups: [{ groupId: 'g-1', title: 'Quarterly', color: 'blue' }],
+      tabs: [
+        {
+          tabId: 't1',
+          favicon: '',
+          title: 'Gamma',
+          url: 'https://example.com/gamma',
+          chromeGroupId: 'g-1',
+        },
+        {
+          tabId: 't2',
+          favicon: '',
+          title: 'Delta',
+          url: 'https://example.com/delta',
+        },
+      ],
+    },
+  ],
+});
+
+const searchFor =
+  (query: string, hasPermission: boolean) =>
+  (store: ReturnType<typeof makeTestStore>['store']) => {
+    store.dispatch(setHasTabGroupsPermission(hasPermission));
+    store.dispatch(saveToTabContainerInternal(session()));
+    store.dispatch(selectTabContainer('group-1'));
+    store.dispatch(openSearchPanel());
+    store.dispatch(setSearchInputText(query));
+  };
+
+describe('searching a Chrome group title, with the permission granted', () => {
+  test('the left pane keeps the session in the results', async () => {
+    await renderWithProviders(<TabGroupEntryContainer />, {
+      seedStore: searchFor('Quarterly', true),
+    });
+
+    expect(await screen.findByText('Alpha')).toBeTruthy();
+  });
+
+  test('the right pane shows the group members and drops the rest', async () => {
+    await renderWithProviders(<RightPane />, {
+      seedStore: searchFor('Quarterly', true),
+    });
+
+    expect(await screen.findByText('Gamma')).toBeTruthy();
+    expect(screen.queryByText('Delta')).toBeNull();
+  });
+
+  test('the right pane still draws the band that explains the match', async () => {
+    await renderWithProviders(<RightPane />, {
+      seedStore: searchFor('Quarterly', true),
+    });
+
+    expect(
+      await screen.findByRole('group', { name: 'Quarterly' })
+    ).toBeTruthy();
+  });
+});
+
+describe('searching a Chrome group title, without the permission', () => {
+  // The band is not drawn without the permission, so the title is invisible
+  // everywhere -- and a result narrowed by something the user cannot see is
+  // worse than no result.
+  test('the left pane drops the session from the results', async () => {
+    await renderWithProviders(<TabGroupEntryContainer />, {
+      seedStore: searchFor('Quarterly', false),
+    });
+
+    expect(screen.queryByText('Alpha')).toBeNull();
+  });
+
+  test('the right pane renders nothing at all', async () => {
+    const { container } = await renderWithProviders(<RightPane />, {
+      seedStore: searchFor('Quarterly', false),
+    });
+
+    expect(container.innerHTML).toBe('');
+  });
+});
+
+describe('the other search levels, with the permission granted', () => {
+  // Group matching narrows a window. These pin that it narrows ONLY the window
+  // it matched in, and only when the levels above it did not already match.
+  test('a session title still admits the whole session', async () => {
+    await renderWithProviders(<RightPane />, {
+      seedStore: searchFor('Alpha', true),
+    });
+
+    expect(await screen.findByText('Gamma')).toBeTruthy();
+    expect(screen.getByText('Delta')).toBeTruthy();
+  });
+
+  test('a tab title still admits just that tab', async () => {
+    await renderWithProviders(<RightPane />, {
+      seedStore: searchFor('Delta', true),
+    });
+
+    expect(await screen.findByText('Delta')).toBeTruthy();
+    expect(screen.queryByText('Gamma')).toBeNull();
+  });
+});

--- a/src/tests/utils/functions/local.test.ts
+++ b/src/tests/utils/functions/local.test.ts
@@ -223,7 +223,11 @@ describe('filterTabGroups', () => {
         ],
       },
     ];
-    expect(filterTabGroups('chrome', tabGroups)).toEqual(filteredTabGroups);
+    // Group titles are searched when the tabGroups permission is granted, so
+    // passing it granted here proves the other levels are unchanged by it.
+    expect(filterTabGroups('chrome', tabGroups, true)).toEqual(
+      filteredTabGroups
+    );
   });
 
   // KAN-23: a window's title is its identity and is user-editable, so a search
@@ -269,7 +273,7 @@ describe('filterTabGroups', () => {
 
     // 'kagi' matches neither the session title nor the window title, so the
     // filter descends to the tabs and rebuilds the window from the one match.
-    const [matchedGroup] = filterTabGroups('kagi', tabGroups);
+    const [matchedGroup] = filterTabGroups('kagi', tabGroups, true);
     const [matchedWindow] = matchedGroup.windows;
 
     expect(matchedWindow.title).toBe('Morning reading');

--- a/src/tests/utils/functions/searchGroupTitles.test.ts
+++ b/src/tests/utils/functions/searchGroupTitles.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  filterTabGroups,
+  selectVisibleTabGroups,
+} from '../../../utils/functions/local';
+import { buildSession } from '../../fixtures/sessionFixture';
+import type { tabContainerData } from '../../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-104. One window holding two named Chrome groups, an ungrouped tab, and a
+// tab whose chromeGroupId names a group that is not there -- the shape an
+// import or a merge can produce, and the one partitionTabsIntoRuns already has
+// to survive.
+//
+// No session title, window title, tab title or URL contains "Quarterly", so a
+// query for it can only be answered by reading the group's title. That is what
+// makes these tests fail against the three-level filter rather than pass by
+// coincidence of some other level matching.
+const grouped = (): tabContainerData =>
+  buildSession({
+    tabGroupId: 'session-grouped',
+    title: 'Alpha',
+    windowCount: 1,
+    tabCount: 5,
+    windows: [
+      {
+        windowId: 'window-1',
+        windowHeight: 1080,
+        windowWidth: 1920,
+        windowOffsetTop: 0,
+        windowOffsetLeft: 0,
+        tabCount: 5,
+        title: 'Beta window',
+        chromeTabGroups: [
+          { groupId: 'g-1', title: 'Quarterly', color: 'blue' },
+          { groupId: 'g-2', title: 'Personal', color: 'green' },
+        ],
+        tabs: [
+          {
+            tabId: 'tab-1',
+            favicon: '',
+            title: 'Gamma',
+            url: 'https://example.com/gamma',
+            chromeGroupId: 'g-1',
+          },
+          {
+            tabId: 'tab-2',
+            favicon: '',
+            title: 'Delta',
+            url: 'https://example.com/delta',
+          },
+          {
+            tabId: 'tab-3',
+            favicon: '',
+            title: 'Epsilon',
+            url: 'https://example.com/epsilon',
+            chromeGroupId: 'g-1',
+          },
+          {
+            tabId: 'tab-4',
+            favicon: '',
+            title: 'Zeta',
+            url: 'https://example.com/zeta',
+            chromeGroupId: 'g-2',
+          },
+          {
+            tabId: 'tab-5',
+            favicon: '',
+            title: 'Orphaned',
+            url: 'https://example.com/orphaned',
+            chromeGroupId: 'g-vanished',
+          },
+        ],
+      },
+    ],
+  });
+
+const titlesOf = (groups: tabContainerData[]): string[] =>
+  groups.flatMap((group) =>
+    group.windows.flatMap((window) => window.tabs.map((tab) => tab.title))
+  );
+
+describe('filterTabGroups matching a Chrome group title', () => {
+  test('finds a session whose only match is a group title', () => {
+    expect(filterTabGroups('Quarterly', [grouped()], true)).toHaveLength(1);
+  });
+
+  test('admits the group members and nothing else in the window', () => {
+    const matched = filterTabGroups('Quarterly', [grouped()], true);
+
+    expect(titlesOf(matched)).toEqual(['Gamma', 'Epsilon']);
+  });
+
+  test('narrows the counts to what matched', () => {
+    const [matched] = filterTabGroups('Quarterly', [grouped()], true);
+
+    expect(matched.windowCount).toBe(1);
+    expect(matched.tabCount).toBe(2);
+  });
+
+  test('keeps the group definitions so the band still renders', () => {
+    const [matched] = filterTabGroups('Quarterly', [grouped()], true);
+
+    expect(matched.windows[0].chromeTabGroups).toEqual([
+      { groupId: 'g-1', title: 'Quarterly', color: 'blue' },
+      { groupId: 'g-2', title: 'Personal', color: 'green' },
+    ]);
+  });
+
+  test('is case insensitive, like every other level', () => {
+    expect(titlesOf(filterTabGroups('quarterly', [grouped()], true))).toEqual([
+      'Gamma',
+      'Epsilon',
+    ]);
+  });
+
+  test('matches on a substring, like every other level', () => {
+    expect(titlesOf(filterTabGroups('quart', [grouped()], true))).toEqual([
+      'Gamma',
+      'Epsilon',
+    ]);
+  });
+
+  test('admits each group separately', () => {
+    expect(titlesOf(filterTabGroups('Personal', [grouped()], true))).toEqual([
+      'Zeta',
+    ]);
+  });
+
+  test('keeps a tab that matches on its own alongside the group members', () => {
+    const session = grouped();
+    session.windows[0].tabs[1] = {
+      tabId: 'tab-2',
+      favicon: '',
+      title: 'Quarterly review doc',
+      url: 'https://example.com/delta',
+    };
+
+    // In stored order: the ungrouped match sits between the two group members.
+    expect(titlesOf(filterTabGroups('Quarterly', [session], true))).toEqual([
+      'Gamma',
+      'Quarterly review doc',
+      'Epsilon',
+    ]);
+  });
+});
+
+describe('filterTabGroups without the tabGroups permission', () => {
+  // The right pane only draws group bands when the permission is granted
+  // (WindowEntryContainer), so without it a group title is invisible
+  // everywhere in the UI. Matching one would narrow a window to a subset of
+  // its tabs with nothing on screen saying why.
+  test('does not match a group title', () => {
+    expect(filterTabGroups('Quarterly', [grouped()], false)).toEqual([]);
+  });
+
+  test('still matches the levels that are visible', () => {
+    expect(filterTabGroups('Alpha', [grouped()], false)).toHaveLength(1);
+    expect(filterTabGroups('Beta window', [grouped()], false)).toHaveLength(1);
+    expect(titlesOf(filterTabGroups('Gamma', [grouped()], false))).toEqual([
+      'Gamma',
+    ]);
+  });
+});
+
+describe('filterTabGroups group matching, off the happy path', () => {
+  test('a tab pointing at a group that is not there is not admitted', () => {
+    // 'g-vanished' has no definition, so nothing can match its title. The tab
+    // is reachable only by its own title.
+    expect(filterTabGroups('vanished', [grouped()], true)).toEqual([]);
+    expect(titlesOf(filterTabGroups('Orphaned', [grouped()], true))).toEqual([
+      'Orphaned',
+    ]);
+  });
+
+  test('an unnamed group never matches a query', () => {
+    // Chrome allows a group with no name; its stored title is ''. Every
+    // non-empty query must miss it -- ''.includes(q) is false -- rather than
+    // it swallowing the window.
+    const session = grouped();
+    session.windows[0].chromeTabGroups = [
+      { groupId: 'g-1', title: '', color: 'blue' },
+      { groupId: 'g-2', title: '', color: 'green' },
+    ];
+
+    expect(filterTabGroups('Quarterly', [session], true)).toEqual([]);
+  });
+
+  test('a window with no groups at all is unaffected', () => {
+    const session = grouped();
+    delete session.windows[0].chromeTabGroups;
+
+    expect(filterTabGroups('Quarterly', [session], true)).toEqual([]);
+    expect(titlesOf(filterTabGroups('Delta', [session], true))).toEqual([
+      'Delta',
+    ]);
+  });
+
+  test('an empty group list is unaffected', () => {
+    const session = grouped();
+    session.windows[0].chromeTabGroups = [];
+
+    expect(filterTabGroups('Quarterly', [session], true)).toEqual([]);
+  });
+
+  test('a group whose members have all gone contributes no window', () => {
+    // The group definition outlives its tabs after a delete. It must not
+    // resurrect the window as an empty match.
+    const session = grouped();
+    session.windows[0].chromeTabGroups = [
+      { groupId: 'g-orphan', title: 'Quarterly', color: 'blue' },
+    ];
+
+    expect(filterTabGroups('Quarterly', [session], true)).toEqual([]);
+  });
+
+  test('a session title match still wins outright over group narrowing', () => {
+    // 'Alpha' is the session title, so the whole session is admitted whole --
+    // group matching must not narrow a level that already matched above it.
+    const matched = filterTabGroups('Alpha', [grouped()], true);
+
+    expect(titlesOf(matched)).toEqual([
+      'Gamma',
+      'Delta',
+      'Epsilon',
+      'Zeta',
+      'Orphaned',
+    ]);
+  });
+
+  test('a window title match still wins outright over group narrowing', () => {
+    const matched = filterTabGroups('Beta window', [grouped()], true);
+
+    expect(titlesOf(matched)).toEqual([
+      'Gamma',
+      'Delta',
+      'Epsilon',
+      'Zeta',
+      'Orphaned',
+    ]);
+  });
+});
+
+describe('selectVisibleTabGroups carries the permission through', () => {
+  const selected = () => ({ ...grouped(), isSelected: true });
+
+  test('matches a group title when the permission is granted', () => {
+    const visible = selectVisibleTabGroups(
+      [selected()],
+      true,
+      'Quarterly',
+      true
+    );
+
+    expect(titlesOf(visible)).toEqual(['Gamma', 'Epsilon']);
+  });
+
+  test('does not when it is not', () => {
+    expect(
+      selectVisibleTabGroups([selected()], true, 'Quarterly', false)
+    ).toEqual([]);
+  });
+
+  test('the permission changes nothing while no search is running', () => {
+    expect(selectVisibleTabGroups([selected()], false, '', false)).toHaveLength(
+      1
+    );
+    expect(selectVisibleTabGroups([selected()], false, '', true)).toHaveLength(
+      1
+    );
+  });
+});

--- a/src/tests/utils/functions/visibleTabGroups.test.ts
+++ b/src/tests/utils/functions/visibleTabGroups.test.ts
@@ -39,12 +39,19 @@ const session = (
 // This is the predicate the whole right pane agrees on: RightPane derives its
 // mount guard from the length of this list, and both of its children read
 // element [0] of it. The tests below are the contract those three share.
+//
+// The last argument is the live tabGroups permission. These sessions carry no
+// Chrome groups, so it is passed as granted throughout: that is the setting
+// under which group titles ARE searched, which makes these the proof that
+// adding that level left the other three alone. Group matching has its own
+// tests in searchGroupTitles.test.ts.
 describe('selectVisibleTabGroups', () => {
   test('keeps only the selected sessions', () => {
     const visible = selectVisibleTabGroups(
       [session('Research', true), session('Errands', false)],
       false,
-      ''
+      '',
+      true
     );
 
     expect(visible.map((group) => group.title)).toEqual(['Research']);
@@ -54,7 +61,8 @@ describe('selectVisibleTabGroups', () => {
     const visible = selectVisibleTabGroups(
       [session('Research', true, 'Kagi Search')],
       true,
-      'kagi'
+      'kagi',
+      true
     );
 
     expect(visible.map((group) => group.title)).toEqual(['Research']);
@@ -64,7 +72,8 @@ describe('selectVisibleTabGroups', () => {
     const visible = selectVisibleTabGroups(
       [session('Research', true, 'Kagi Search')],
       false,
-      'nothing matches this'
+      'nothing matches this',
+      true
     );
 
     expect(visible.map((group) => group.title)).toEqual(['Research']);
@@ -76,7 +85,8 @@ describe('selectVisibleTabGroups', () => {
     const visible = selectVisibleTabGroups(
       [session('Research', true, 'Kagi Search')],
       true,
-      'nothing matches this'
+      'nothing matches this',
+      true
     );
 
     expect(visible).toEqual([]);
@@ -84,14 +94,14 @@ describe('selectVisibleTabGroups', () => {
 
   test('returns an empty list when nothing is selected at all', () => {
     expect(
-      selectVisibleTabGroups([session('Research', false)], false, '')
+      selectVisibleTabGroups([session('Research', false)], false, '', true)
     ).toEqual([]);
   });
 
   test('does not mutate the list it is given', () => {
     const groups = [session('Research', true), session('Errands', false)];
 
-    selectVisibleTabGroups(groups, true, 'kagi');
+    selectVisibleTabGroups(groups, true, 'kagi', true);
 
     expect(groups.map((group) => group.title)).toEqual(['Research', 'Errands']);
   });

--- a/src/utils/functions/local.ts
+++ b/src/utils/functions/local.ts
@@ -115,9 +115,26 @@ export function classifyStoredToken(value: unknown): TokenAction {
 }
 
 // filter tabGroup
+//
+// A containment cascade: session -> window -> Chrome group -> tab. A match at
+// one level admits everything below it, so only the levels BELOW the deepest
+// match get narrowed.
+//
+// `searchGroupTitles` is the live tabGroups permission, and it is required
+// rather than defaulted because four components have to agree on the list this
+// produces (KAN-16, KAN-39 are the crash when they disagreed). A default would
+// let a new call site silently opt out; a required parameter makes the same
+// mistake a compile error.
+//
+// It gates the group level because WindowEntryContainer only draws group bands
+// when the permission is granted -- a session synced from a permitted device
+// still carries chromeTabGroups on a device that never granted it. Matching a
+// title that renders nowhere would narrow a window to a subset of its tabs
+// with nothing on screen saying why. KAN-104.
 export const filterTabGroups = (
   searchText: string,
-  tabGroups: tabContainerData[]
+  tabGroups: tabContainerData[],
+  searchGroupTitles: boolean
 ): tabContainerData[] => {
   const loweredSearchText = searchText.toLowerCase();
 
@@ -133,11 +150,26 @@ export const filterTabGroups = (
           if (window.title.toLowerCase().includes(loweredSearchText)) {
             windowAcc.push(window);
           } else {
+            // The groups whose own title matched. Membership is the join from
+            // tabData.chromeGroupId, so a tab naming a group that is not in
+            // this list -- an import or a merge can produce one -- simply
+            // never joins, exactly as partitionTabsIntoRuns treats it.
+            const matchedGroupIds = new Set(
+              (searchGroupTitles ? window.chromeTabGroups ?? [] : [])
+                .filter((group) =>
+                  group.title.toLowerCase().includes(loweredSearchText)
+                )
+                .map((group) => group.groupId)
+            );
+
             // add only matched tabs if window title doesn't match
             const matchedTabs = window.tabs.filter(
               (tab) =>
                 tab.title.toLowerCase().includes(loweredSearchText) ||
-                (tab.url && tab.url.toLowerCase().includes(loweredSearchText))
+                (tab.url &&
+                  tab.url.toLowerCase().includes(loweredSearchText)) ||
+                (tab.chromeGroupId !== undefined &&
+                  matchedGroupIds.has(tab.chromeGroupId))
             );
 
             if (matchedTabs.length) {
@@ -192,12 +224,17 @@ export const filterTabGroups = (
 export const selectVisibleTabGroups = (
   tabGroups: tabContainerData[],
   isSearchPanel: boolean,
-  searchInputText: string
+  searchInputText: string,
+  hasTabGroupsPermission: boolean
 ): tabContainerData[] => {
   const selectedTabGroups = tabGroups.filter((tabGroup) => tabGroup.isSelected);
 
   return isSearchActive(isSearchPanel, searchInputText)
-    ? filterTabGroups(searchInputText, selectedTabGroups)
+    ? filterTabGroups(
+        searchInputText,
+        selectedTabGroups,
+        hasTabGroupsPermission
+      )
     : selectedTabGroups;
 };
 


### PR DESCRIPTION
Closes KAN-104.

## The defect

A Chrome tab group the user named — and can see drawn as a coloured band in the right pane — was unfindable by name. Searching its title returned nothing unless the string happened to occur in a session title, a window title, a tab title or a URL.

Reproduced against the built, pruned artifact with the permission actually granted. One window holding a group named `Quarterly` with two members (`Gamma`, `Epsilon`) and one ungrouped tab (`Delta`):

```
after searching "Quarterly": { Gamma: 0, Epsilon: 0, Delta: 0 }
```

## Root cause

`filterTabGroups` is a containment cascade, and a match at one level admits everything below it:

```
session title  ->  window title  ->  tab title / url
```

Chrome groups added a fourth level of containment — session → window → **group** → tab — but only the renderer (`partitionTabsIntoRuns`) learned about it. The filter still modelled a three-level tree and never read `windows[].chromeTabGroups[]`.

Not a regression. `filterTabGroups` last changed in #163 (KAN-60); `chromeTabGroups` arrived later in #173 (KAN-11, v1.5.0) and search was never extended. The level has been unsearchable since the feature shipped.

## What changed

The groups in a window whose own title matches contribute their members to the match set, joined by `tabData.chromeGroupId`.

- **A group match admits that group's tabs and nothing else in the window**, mirroring the level above it: a window match admits its tabs, and a group is a container inside the window. Admitting the whole window would overstate the match — tabs outside the group had nothing to do with the query. The band still renders with its title, so the user sees why it matched.
- **Membership is the join, not the storage shape.** A tab naming a group that is not in the list — an import or a merge can produce one — simply never joins, exactly as `partitionTabsIntoRuns` already treats it.
- **The window keeps its `chromeTabGroups` whole** when it narrows, so the band survives the filter.

### The permission gate

`WindowEntryContainer` only draws group bands when the live `tabGroups` permission is granted, and that gate is deliberate: a session synced from a permitted device still carries `chromeTabGroups` on a device that never granted it, where `applyTabGroups` silently no-ops. So without the permission a group title is invisible everywhere in the UI, and matching one would narrow a window to a subset of its tabs with nothing on screen saying why. Search follows the same gate.

The cost is real and taken deliberately: identical data now searches differently on two devices. The alternative is a result the user cannot account for.

### Both new parameters are required, not defaulted

`filterTabGroups(searchText, tabGroups, searchGroupTitles)` and `selectVisibleTabGroups(tabGroups, isSearchPanel, searchInputText, hasTabGroupsPermission)`.

Four components have to agree on the list this produces — `RightPane` derives its mount guard from it and both children read element `[0]` — and KAN-16/KAN-39 are the crash when they disagreed. A default would let a call site silently opt out. A required parameter makes the same mistake a compile error, and it did the work: `tsc` named exactly the four production call sites and the existing tests, and nothing else.

## Tests

| file | what it holds down |
|---|---|
| `searchGroupTitles.test.ts` | the fourth level: what a group match admits, the narrowed counts, the surviving band, case and substring parity with the other levels, and both permission branches |
| `searchGroupTitles.test.tsx` | that the permission actually leaves the store — both panes, both branches. A correct pure function proves nothing about whether four components hand the flag over |
| `visibleTabGroups.test.ts` | unchanged contract, now asserted with group matching **enabled**, so it is the proof the new level left the other three alone |

Off the happy path: an unnamed group (stored title `''`) never matches a query, a tab pointing at a group that is not there is not admitted, a group whose members have all gone contributes no window, and a session or window title match still wins outright rather than being narrowed by the level below it.

**767 tests pass** (was 760). `tsc --noEmit` clean. `npm run lint` 0 errors / 25 warnings, unchanged from `main`. Playwright `64 passed`.

### Mutation testing

Each mutation was applied to disk, run, and reverted:

| mutation | result |
|---|---|
| group matching removed | 12 failed |
| permission ignored — group titles always searched | 4 failed |
| a group match admits the whole window | 9 failed |
| group-title predicate dropped — every group matches | 10 failed |
| left pane hardcodes `false` | 1 failed — left-pane test only |
| `TabGroupDetailsContainer` hardcodes `false` (the KAN-16/39 divergence shape) | 2 failed — right-pane tests only |

The last two matter as a pair: each fails only the tests for the component it broke, so the component coverage is per-component rather than one assertion covering for the rest.

## Live verification

The E2E suite cannot pre-grant an optional permission in a Playwright profile — `golden-path.spec.ts` says so, and that leaves the granted path uncovered by it. Verified instead by installing a scratch **copy** of `dist` whose manifest moves `tabGroups` into required `permissions`, so Chrome grants it at install. The shipped manifest is untouched.

```
popup sees tabGroups permission: true
group band rendered before search: 1
before search:               { Gamma: 1, Epsilon: 1, Delta: 1 }
after searching "Quarterly": { Gamma: 1, Epsilon: 1, Delta: 0 }
group band still rendered: 1
```

Two controls, because a probe that cannot report failure proves nothing:

- the same probe against a build with only the new clause disabled: `{ Gamma: 0, Epsilon: 0, Delta: 0 }` — the defect, reproduced in the shipping bundle
- a query matching nothing at all: every count zero

The row label reads `Matches: 1 Window - 2 Tabs` under the new level, so KAN-60's rule still holds.

## Scope notes

- The permission-granted path is covered by component tests and the run above, not by an automated E2E spec. The permission-denied path is covered at every level.
- One full E2E run had `row-action-inset.spec.ts` fail under parallel load. It passes alone and on a clean re-run, and exercises row geometry with no search involvement. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
