### PR TITLE
Wait for the popup to render before measuring it (KAN-105)

### DIFF
--- a/e2e/row-action-inset.spec.ts
+++ b/e2e/row-action-inset.spec.ts
@@ -60,6 +60,18 @@ async function openWith(
   );
   const page = await context.newPage();
   await page.goto(`chrome-extension://${extensionId}/index.html`);
+
+  // KAN-105. `goto` resolves on `load`, which is BEFORE React mounts, i18n
+  // initialises and the store hydrates from localStorage -- so the page it
+  // returns is empty for a few more frames. Every measurement in this spec is
+  // a raw `page.evaluate`, which (unlike a locator) does not auto-wait, so
+  // without this the spec races the first paint and fails about one full run
+  // in six, on a different test each time.
+  //
+  // Waiting on the COUNT rather than the first node, because that is what the
+  // tests below actually assume: three seeded sessions, all rendered.
+  await expect(page.locator('[data-row-actions]')).toHaveCount(3);
+
   return page;
 }
 

--- a/e2e/selection-feedback.spec.ts
+++ b/e2e/selection-feedback.spec.ts
@@ -31,6 +31,27 @@ async function openWith(
   );
   const page = await context.newPage();
   await page.goto(`chrome-extension://${extensionId}/index.html`);
+
+  // KAN-105. `goto` resolves on `load`, which is BEFORE React mounts, i18n
+  // initialises and the store hydrates from localStorage, so for a few more
+  // frames this page has no rows on it.
+  //
+  // The samplers below look their row up with a raw `page.evaluate`, which --
+  // unlike a locator -- does not auto-wait, and then take `button!.parentElement!`
+  // on the result. Those non-null assertions are what turns losing the race
+  // into `TypeError: Cannot read properties of undefined (reading
+  // 'parentElement')` rather than a legible failure. Measured over 8 full
+  // suite runs, the CONTROL test below lost it twice.
+  //
+  // Waiting on the two seeded rows BY NAME, because that is exactly what the
+  // evaluates look up; a bare node count would let a half-rendered list pass.
+  await expect(
+    page.getByRole('button', { name: 'First session', exact: true })
+  ).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'Second session', exact: true })
+  ).toBeVisible();
+
   return page;
 }
 


### PR DESCRIPTION
`row-action-inset.spec.ts` and `selection-feedback.spec.ts` fail intermittently in a full E2E run and pass when run alone. Both are test defects, not product defects.

## The race

`openWith` returned as soon as `page.goto` resolved. `goto` resolves on `load`, which is before React mounts, i18n initialises and the store hydrates from localStorage, so for a few more frames the page it handed back had no rows on it.

Both specs then measure with raw `page.evaluate`, which — unlike a Playwright locator — does not auto-wait or retry. Under load the evaluate wins the race and reads an empty DOM. The two failure screenshots settle it: `test-failed-1.png` is a completely blank page, and `test-failed-2.png`, taken moments later, shows every seeded session rendered correctly.

## The exposure is per test, not per spec

This is what the first pass at this got wrong, and it is why `selection-feedback` was initially thought immune. All three of its tests share one `openWith`, but they do not share exposure:

| Test | First act after `goto` | Outcome |
|---|---|---|
| line 42 | `rowFor(...).click()` — a locator, auto-waits | protected by accident |
| line 93 (CONTROL) | raw `page.evaluate` | **fails** |
| line 139 | `rowFor(...).hover()` — a locator, auto-waits | protected by accident |

"The spec uses locators" is not a safety property. A spec is only as safe as its least-gated test.

## Evidence

Eight consecutive full-suite runs, with `row-action-inset` already fixed and `selection-feedback` untouched:

| Run | Result | Failure |
|-----|--------|---------|
| 1 | 64 passed | — |
| 2 | 64 passed | — |
| 3 | 63 passed, 1 failed | `selection-feedback.spec.ts:93` CONTROL |
| 4 | 64 passed | — |
| 5 | 64 passed | — |
| 6 | 63 passed, 1 failed | `selection-feedback.spec.ts:93` CONTROL |
| 7 | 64 passed | — |
| 8 | 64 passed | — |

`row-action-inset`: 8/8, having failed about 1 run in 6 before the fix. `selection-feedback:93`: 2 of 8, the same test both times, the same error:

```
Error: page.evaluate: TypeError: Cannot read properties of undefined (reading 'parentElement')
```

### Confirmed deterministically, not by luck

Waiting on a 1-in-6 flake is not a proof, so the race was forced by throttling the CPU 20× over CDP before `goto`.

**Unfixed + throttled — 4 failed, 2 passed:**

```
✘ 1 row-action-inset.spec.ts:93  › every row leaves exactly the declared inset…
✘ 2 row-action-inset.spec.ts:128 › the inset holds when the row grows
✘ 3 row-action-inset.spec.ts:191 › the block matches the row at every row height
✓ 4 selection-feedback.spec.ts:44  › a deselected row does not fade its highlight out
✘ 5 selection-feedback.spec.ts:95  › CONTROL: hover still eases…
✓ 6 selection-feedback.spec.ts:139 › a row gaining selection does not fade into it

Error: the seeded sessions should render   (Expected: 3, Received: 0)
TypeError: Cannot read properties of undefined (reading 'rowH')
TypeError: Cannot read properties of undefined (reading 'parentElement')  ×2
```

**Fixed + same throttle — 6 passed.**

The probe discriminates rather than merely breaking things: the two locator-gated tests stay green under the same 20× throttle. That is what shows the cause is the missing wait and not general slowness. The throttle is **not** committed — it would slow both specs and risk timeouts elsewhere.

## Why these particular barriers

Each waits for what its own tests actually look up.

- `row-action-inset` asserts three `[data-row-actions]` nodes, because its measurements assume three rendered rows.
- `selection-feedback` waits on its two seeded rows **by name**, because its evaluates find them by `aria-label` and then take `.parentElement`. A bare node count would let a half-rendered list through.

## Deferred

`cursor-affordance.spec.ts` and `i18n-layout.spec.ts` have the same helper shape and are left alone. Neither has been observed to fail, and the earlier reason for skipping them — that their first act is locator-based — is the same reasoning that missed `selection-feedback`, so it is not relied on here. If either flakes, the same one-line barrier applies.

## Verification

- Full E2E suite on this branch: **64 passed**
- Unit/component: **740 passed** (83 files)
- `typecheck:e2e`: clean
- `eslint` on both changed files: clean; repo total unchanged from `main` at 0 errors / 25 warnings
- `prettier --check` on both changed files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)