### PR TITLE
Release 1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ Your sessions are stored locally on your device. When device sync is enabled, sa
 
 ## Changelog
 
-### v.1.6.0 (Latest)
+### v.1.6.1 (Latest)
+
+#### Fixes
+
+- Search now finds Chrome tab groups by name, and narrows the session to that group's tabs
+
+### v.1.6.0
 
 #### Features
 
@@ -105,22 +111,6 @@ Your sessions are stored locally on your device. When device sync is enabled, sa
 #### Improvements
 
 - Selecting or searching a session no longer triggers a cloud sync
-
-### v.1.4.1
-
-#### Fixes
-
-- Search results now show a window's own title when only its tabs match, instead of borrowing the title of one of those tabs
-- Collapsing or renaming a window no longer affects the wrong row after a window or tab is added to a session
-- Switching themes now applies the new colors immediately instead of fading through the old ones, and the scrollbar changes with them
-- The Auto Sync button no longer flashes as you move between settings sections
-- A backup too large to sync is now refused when you restore it, with an explanation, instead of being loaded and leaving sync stuck
-- Restoring a backup now tells you when it could not be saved to the cloud, instead of always reporting success
-- Restoring a backup saved by an older version no longer fails to sync on its first attempt
-
-#### Improvements
-
-- Dependent packages updated to latest versions
 
 [View All Changelog →](https://github.com/justine-george/tab-keeper-react-chrome-extension/wiki/Changelog)
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Justine George",
   "description": "Efficiently save and synchronize tabs across devices without the need for personal logins.",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "name": "Tab Keeper - Chrome Tab Manager & Sync Tool",
   "description": "Efficiently save and synchronize tabs across devices without the need for personal logins.",
   "action": {


### PR DESCRIPTION
Cuts 1.6.1 so the tab-group search fix ships with the release instead of after it.

## Why a patch now

v1.6.0 was tagged at `bf8b3ba`, built and uploaded to the Web Store, but **never submitted** — nothing has reached users. Since that tag, `main` gained 7 commits, and exactly one of them changes what users receive:

| Commit | PR | Files under `src/` or `public/` |
|---|---|---|
| `27843d8` KAN-104 search group titles | #202 | **5** |
| `1ca5b74` KAN-105 e2e barriers | #203 | 0 |
| `31c3ea4` README screenshot | #201 | 0 |
| `357dc1d` store screenshots, KAN-38 | #200 | 0 |
| `abacf35` marquee tile wording | #199 | 0 |
| `596f9c9` README banner | #198 | 0 |
| `c1287f5` README overview | #197 | 0 |

The rest are README copy and Web Store listing assets, which are uploaded through the dashboard and are not part of the extension package.

The reason to bump rather than wait: **the listing assets already uploaded lead on tab groups** — marquee tile, promo tile and all five screenshots. KAN-104 is exactly "tab groups cannot be found by name". Shipping that listing against a build with that defect is the pairing this avoids.

PATCH rather than MINOR: KAN-104 is typed Bug, and the behaviour has been broken since tab groups shipped in 1.5.0.

## Changes

- `package.json` and `public/manifest.json` → 1.6.1
- README changelog gains a `v.1.6.1 (Latest)` section with the single user-facing fix; 1.6.0 is demoted and 1.4.1 drops off the bottom, keeping the latest three

KAN-105 gets no changelog line — test-only, matching the KAN-102 precedent.

## Verification

Local `build:e2e` artifact, checked after the build rather than assumed:

| Check | Result |
|---|---|
| `dist/manifest.json` version | **1.6.1** |
| KAN-104 code present in bundle | `chromeGroupId` found in `index-*.js` and `windows-*.js` |
| Locales in artifact | 10 (de en es fr hi it ja pt ru zh) |
| Remotely hosted script URLs | none — ran the workflow's own `grep -rEo` check, passes |
| Service worker declared | `{"service_worker":"background.js","type":"module"}` |
| Unit / component | 767 passed (85 files) |
| `prettier --check` on all three changed files | clean |

## Follow-ups, not in this PR

- The **wiki changelog needs the same 1.6.1 section** — the README must stay a byte-identical prefix of it.
- `package-lock.json` still reads `1.4.1`. Pre-existing drift, unrelated to this change, and it does not affect the build: the release workflow reads the version from `public/manifest.json`. Left out to keep the release diff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)