### PR TITLE
Sync package-lock's version with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tab-keeper-react-chrome-extension",
-  "version": "1.4.1",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tab-keeper-react-chrome-extension",
-      "version": "1.4.1",
+      "version": "1.6.1",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.11.0",


### PR DESCRIPTION
`package-lock.json` read `1.4.1` while `package.json` and `public/manifest.json` read `1.6.1`. The lockfile's two version fields mirror `package.json` and had stopped being updated when versions were bumped by hand.

Harmless in practice — the release workflow reads the version from `public/manifest.json`, so nothing shipped was ever wrong — but a lockfile that disagrees with its own `package.json` costs someone a few minutes the first time they trust it.

## Approach

Regenerated with `npm install --package-lock-only` rather than hand-edited, so the file is exactly what npm would write.

```diff
-  "version": "1.4.1",
+  "version": "1.6.1",
-      "version": "1.4.1",
+      "version": "1.6.1",
```

2 insertions, 2 deletions. No dependency added, removed, or moved.

## Verification

| Check | Result |
|---|---|
| `npm ls --depth=0` | clean — lockfile still resolves |
| Unit / component | 767 passed (85 files) |
| `npm run build` | succeeds, `dist/manifest.json` reads 1.6.1 |

Does not affect the submitted v1.6.1 artifact, which was built and verified before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)