### PR TITLE
Paint the overflow menu's destructive item like every other one (KAN-111)

### DIFF
--- a/src/components/common/OverflowMenu.tsx
+++ b/src/components/common/OverflowMenu.tsx
@@ -148,11 +148,18 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({ ariaLabel, items }) => {
     transition-property: background-color;
     transition-duration: 150ms;
     transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
+    /* Destructive hover is a red FILL behind a dark glyph, not a red glyph.
+       DELETE_ICON_HOVER_COLOR is a background token everywhere else in the
+       app -- Icon.tsx:115 feeds it to background-color and leaves the glyph
+       at TEXT_COLOR -- so tinting the glyph instead made this item read as a
+       different kind of control from the row delete icons beside it. */
     &:hover {
-      background-color: ${COLORS.HOVER_COLOR};
+      background-color: ${danger
+        ? COLORS.DELETE_ICON_HOVER_COLOR
+        : COLORS.HOVER_COLOR};
     }
     &:hover .overflow-menu-glyph {
-      color: ${danger ? COLORS.DELETE_ICON_HOVER_COLOR : COLORS.TEXT_COLOR};
+      color: ${COLORS.TEXT_COLOR};
     }
   `;
 

--- a/src/tests/components/overflowMenu.test.tsx
+++ b/src/tests/components/overflowMenu.test.tsx
@@ -197,3 +197,83 @@ describe('OverflowMenu keyboard navigation', () => {
     ).toHaveFocus();
   });
 });
+
+describe('OverflowMenu destructive styling', () => {
+  // The app expresses "this action destroys something" as a red FILL behind a
+  // dark glyph -- Icon.tsx:115 picks DELETE_ICON_HOVER_COLOR as the hover
+  // BACKGROUND, and the glyph stays TEXT_COLOR. The first version of this menu
+  // used the token the other way round, tinting the glyph on a grey row, which
+  // read as a different control entirely beside the row delete icons.
+  //
+  // Asserted against the generated CSS rather than a rendered hover, because
+  // jsdom applies no :hover pseudo-class -- getComputedStyle would report the
+  // resting state for both branches and pass against either. The real hover is
+  // verified in a browser.
+  const hoverRulesFor = (el: Element) => {
+    const classes = [...el.classList].map((c) => `.${c}`);
+    const out: string[] = [];
+    for (const sheet of [...document.styleSheets]) {
+      let rules: CSSRuleList;
+      try {
+        rules = sheet.cssRules;
+      } catch {
+        continue;
+      }
+      for (const rule of [...rules]) {
+        const text = rule.cssText;
+        if (text.includes(':hover') && classes.some((c) => text.includes(c))) {
+          out.push(text);
+        }
+      }
+    }
+    return out.join('\n');
+  };
+
+  test('a danger item fills with the delete colour on hover', async () => {
+    const user = userEvent.setup();
+    await renderMenu({
+      items: [
+        {
+          key: 'delete',
+          label: 'Delete group',
+          icon: 'delete',
+          danger: true,
+          onSelect: () => undefined,
+        },
+      ],
+    });
+    await user.click(trigger());
+
+    const item = screen.getByRole('menuitem', { name: 'Delete group' });
+    const rules = hoverRulesFor(item);
+
+    // #FF8080, as a BACKGROUND
+    expect(rules).toMatch(
+      /background-color:\s*(#FF8080|rgb\(255, ?128, ?128\))/i
+    );
+  });
+
+  // THE CONTROL. Asserting only that the token appears would pass against the
+  // original bug, which used the very same token -- as a foreground colour.
+  test('CONTROL: a non-danger item does not use the delete colour', async () => {
+    const user = userEvent.setup();
+    await renderMenu({
+      items: [
+        {
+          key: 'ungroup',
+          label: 'Ungroup',
+          icon: 'label_off',
+          onSelect: () => undefined,
+        },
+      ],
+    });
+    await user.click(trigger());
+
+    const rules = hoverRulesFor(
+      screen.getByRole('menuitem', { name: 'Ungroup' })
+    );
+
+    expect(rules).not.toMatch(/#FF8080|rgb\(255, ?128, ?128\)/i);
+    expect(rules).toMatch(/background-color/);
+  });
+});


### PR DESCRIPTION
Closes KAN-111.

## The defect

Reported from the UI: the overflow menu's **Delete group** item did not look like the app's other destructive controls.

| | glyph | fill on hover |
|---|---|---|
| shipped row delete icons | dark (`TEXT_COLOR`) | salmon (`DELETE_ICON_HOVER_COLOR`) |
| the menu item, before | salmon | ordinary grey (`HOVER_COLOR`) |

Sitting directly beside the row delete icons it inherits meaning from, it read as a different kind of control.

## Root cause

A token used the wrong way round. `DELETE_ICON_HOVER_COLOR` is a **background** token everywhere else:

```js
// Icon.tsx:115
const hoverColor = type === 'delete' ? COLORS.DELETE_ICON_HOVER_COLOR : COLORS.ICON_HOVER_COLOR;
// containerStyle:  &:hover { background-color: ${hoverColor}; }
// iconStyle:       color: ${COLORS.TEXT_COLOR};   // always
```

The name says `..._COLOR`, which is what invited the misuse; nothing in the type system distinguishes a background token from a foreground one.

## The fix

The row fills with the delete colour and the glyph stays `TEXT_COLOR` — the same pairing the session, window and tab delete icons already use.

## Testing

Asserted against the **generated CSS**, not a rendered hover: jsdom applies no `:hover` pseudo-class, so `getComputedStyle` reports the resting state for both spellings and would pass against either.

The control earns its place here more than usual. The bug used the *correct token* — just as a foreground — so a test asserting only that `#FF8080` appears would have passed against the broken code. The control asserts a non-danger item never uses it at all.

Mutation: reverting to the glyph tint fails the new test, 1 of 16.

**839 tests pass.** `tsc` clean, lint 0 errors / 25 warnings unchanged, prettier clean.

## Verified in a real browser

Hovering the item against the built artifact:

```
hoveredDeleteItem:  background rgb(255, 128, 128)   // #FF8080
                    labelColor rgb(59, 61, 64)      // #3B3D40 TEXT_COLOR
                    glyphColor rgb(59, 61, 64)
referenceRowDeleteIconGlyph:   rgb(59, 61, 64)      // identical
unhoveredUngroupItem:          rgba(0, 0, 0, 0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)