### PR TITLE
Lift the group row that owns an open overflow menu (KAN-112)

### DIFF
--- a/src/components/common/OverflowMenu.tsx
+++ b/src/components/common/OverflowMenu.tsx
@@ -22,6 +22,16 @@ interface OverflowMenuProps {
   /** Names the trigger. Must be translated. */
   ariaLabel: string;
   items: OverflowMenuItem[];
+  /**
+   * Fires whenever the menu opens or closes.
+   *
+   * Exists because the menu cannot solve its own z-order: it is confined to
+   * the stacking context of whichever action strip hosts it, so a SIBLING
+   * strip with the same z-index paints over it purely by DOM order. The host
+   * has to lift the row that owns the open menu, and this is how it learns
+   * which row that is.
+   */
+  onOpenChange?: (isOpen: boolean) => void;
 }
 
 /**
@@ -54,11 +64,27 @@ interface OverflowMenuProps {
  * WindowEntryContainer. jsdom computes no paint order, so only a real browser
  * shows this.
  */
-const OverflowMenu: React.FC<OverflowMenuProps> = ({ ariaLabel, items }) => {
+const OverflowMenu: React.FC<OverflowMenuProps> = ({
+  ariaLabel,
+  items,
+  onOpenChange,
+}) => {
   const COLORS = useThemeColors();
   const FONT_FAMILY = useFontFamily();
 
   const [isOpen, setIsOpen] = useState(false);
+
+  // Every open/close goes through here, so onOpenChange cannot fall out of
+  // step with the state it reports.
+  const setOpen = useCallback(
+    (next: boolean) => {
+      setIsOpen((current) => {
+        if (current !== next) onOpenChange?.(next);
+        return next;
+      });
+    },
+    [onOpenChange]
+  );
   const wrapperRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
@@ -66,14 +92,17 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({ ariaLabel, items }) => {
   // Focus goes back where it came from, or a keyboard user is dropped at
   // <body> and loses their place -- the same failure the Icon comment about
   // aria-disabled describes.
-  const close = useCallback((returnFocus: boolean) => {
-    setIsOpen(false);
-    if (returnFocus) {
-      const trigger =
-        triggerRef.current?.querySelector<HTMLElement>('[role="button"]');
-      (trigger ?? triggerRef.current)?.focus();
-    }
-  }, []);
+  const close = useCallback(
+    (returnFocus: boolean) => {
+      setOpen(false);
+      if (returnFocus) {
+        const trigger =
+          triggerRef.current?.querySelector<HTMLElement>('[role="button"]');
+        (trigger ?? triggerRef.current)?.focus();
+      }
+    },
+    [setOpen]
+  );
 
   // Opening moves focus to the first item, which is what makes the menu
   // operable without a pointer at all.
@@ -181,7 +210,7 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({ ariaLabel, items }) => {
           ariaExpanded={isOpen}
           onClick={(e) => {
             e.stopPropagation();
-            setIsOpen((open) => !open);
+            setOpen(!isOpen);
           }}
         />
       </div>

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -76,6 +76,11 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
   // put every one of them into edit mode at once.
   const [editingGroupId, setEditingGroupId] = useState<string | null>(null);
   const [groupDraft, setGroupDraft] = useState('');
+  // Which group's overflow menu is open, so its action strip can outrank its
+  // siblings. Every strip is a stacking context of its own (transform), so
+  // equal z-indexes leave DOM order deciding -- and a LOWER group's strip then
+  // painted over an open menu belonging to the group above it.
+  const [openMenuGroupId, setOpenMenuGroupId] = useState<string | null>(null);
   const [hoveredChildIndex, setHoveredChildIndex] = useState<number | null>(
     null
   );
@@ -673,7 +678,11 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                              the tab rows below, which are later siblings with
                              position: relative. Lifting the context itself is
                              what puts the menu over them. */
-                          z-index: 1;
+                          /* The row owning an open menu outranks its
+                             siblings; see openMenuGroupId above. */
+                          z-index: ${openMenuGroupId === run.group.groupId
+                            ? 3
+                            : 1};
                         `}
                       >
                         <Icon
@@ -701,6 +710,19 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                             a word rather than a glyph. */}
                         <OverflowMenu
                           ariaLabel={t('More actions')}
+                          // Guarded on identity rather than assigning blindly:
+                          // opening a second menu closes the first, and the
+                          // close can land after the open, which would
+                          // otherwise clear the row that just opened.
+                          onOpenChange={(open) =>
+                            setOpenMenuGroupId((prev) =>
+                              open
+                                ? run.group.groupId
+                                : prev === run.group.groupId
+                                  ? null
+                                  : prev
+                            )
+                          }
                           items={[
                             {
                               key: 'ungroup',

--- a/src/tests/components/chromeGroupRowActions.test.tsx
+++ b/src/tests/components/chromeGroupRowActions.test.tsx
@@ -185,3 +185,126 @@ describe('the group row action set', () => {
     expect(getComputedStyle(strip as Element).zIndex).not.toBe('auto');
   });
 });
+
+// Two groups in one window, so sibling interactions are observable.
+async function renderTwoGroups() {
+  const tabs = [
+    {
+      tabId: 'a1',
+      favicon: '',
+      title: 'Learn one',
+      url: 'https://a.co',
+      chromeGroupId: 'g1',
+    },
+    {
+      tabId: 'b1',
+      favicon: '',
+      title: 'Create one',
+      url: 'https://b.co',
+      chromeGroupId: 'g2',
+    },
+  ];
+  const groups: chromeTabGroupData[] = [
+    { groupId: 'g1', title: 'Learn', color: 'yellow' },
+    { groupId: 'g2', title: 'Create', color: 'purple' },
+  ];
+  return renderWithProviders(
+    <WindowEntryContainer
+      title="Window 1"
+      tabGroupId="tg"
+      windowId="w"
+      tabs={tabs}
+      chromeTabGroups={groups}
+      onWindowTitleClick={() => undefined}
+      onUpdateWindowGroupTitle={() => undefined}
+      onAddCurrTabToWindowClick={() => undefined}
+      onDeleteClick={() => undefined}
+    />,
+    {
+      seedStore: (store) => {
+        store.dispatch(setHasTabGroupsPermission(true));
+        store.dispatch(
+          saveToTabContainerInternal({
+            tabGroupId: 'tg',
+            title: 'Session',
+            createdTime: '2026-09-06 00:00:00',
+            windowCount: 1,
+            tabCount: 2,
+            isAutoSave: false,
+            isSelected: false,
+            windows: [
+              {
+                windowId: 'w',
+                windowHeight: 100,
+                windowWidth: 100,
+                windowOffsetTop: 0,
+                windowOffsetLeft: 0,
+                tabCount: 2,
+                title: 'Window 1',
+                tabs,
+                chromeTabGroups: groups,
+              },
+            ],
+          })
+        );
+      },
+    }
+  );
+}
+
+const stripFor = (groupName: string) => {
+  const group = screen.getByRole('group', { name: groupName });
+  return group.querySelector('.group-rename-reveal') as HTMLElement;
+};
+
+describe('two group rows in one window', () => {
+  // Every strip carried the SAME z-index, so among siblings DOM order decided
+  // and the LOWER group's action strip painted over the upper group's open
+  // menu. Reproduced in a browser: the boxes overlap by 96x13px and the strip
+  // won that region.
+  test('the row whose menu is open outranks its siblings', async () => {
+    const user = userEvent.setup();
+    await renderTwoGroups();
+
+    const before = getComputedStyle(stripFor('Learn')).zIndex;
+
+    await user.click(
+      screen.getAllByRole('button', { name: 'More actions' })[0]
+    );
+
+    const openStrip = Number(getComputedStyle(stripFor('Learn')).zIndex);
+    const siblingStrip = Number(getComputedStyle(stripFor('Create')).zIndex);
+
+    expect(openStrip).toBeGreaterThan(siblingStrip);
+    // and it is the OPENING that lifts it, not a constant
+    expect(String(openStrip)).not.toBe(before);
+  });
+
+  // THE CONTROL. The assertion above would also pass if every strip were
+  // lifted permanently; this pins that a closed row does not outrank its
+  // sibling, so the lift is tied to the menu being open.
+  test('CONTROL: with nothing open, neither row outranks the other', async () => {
+    await renderTwoGroups();
+
+    expect(getComputedStyle(stripFor('Learn')).zIndex).toBe(
+      getComputedStyle(stripFor('Create')).zIndex
+    );
+  });
+
+  // Already true via the mousedown listener, but stated as an invariant here
+  // so a later change to the dismiss mechanism cannot quietly allow two.
+  test('opening one menu closes any other', async () => {
+    const user = userEvent.setup();
+    await renderTwoGroups();
+    const triggers = screen.getAllByRole('button', { name: 'More actions' });
+
+    await user.click(triggers[0]);
+    expect(screen.getAllByRole('menu')).toHaveLength(1);
+
+    await user.click(triggers[1]);
+
+    expect(screen.getAllByRole('menu')).toHaveLength(1);
+    expect(triggers[0]).toHaveAttribute('aria-expanded', 'false');
+    expect(triggers[1]).toHaveAttribute('aria-expanded', 'true');
+  });
+});


### PR DESCRIPTION
Closes KAN-112.

## The defect

With one group's overflow menu open, hovering the group row **below** it revealed that row's action strip **on top of** the menu.

## Root cause

KAN-110 gave every action strip a `z-index` so the menu could escape the strip's own stacking context — the strip is centred with `transform: translateY(-50%)`, which creates one. That fixed the menu against the *tab rows*, but left every strip on the **same** z-index. Among siblings with equal z-index, **DOM order decides**, and the lower group's strip is later in the DOM.

Reproduced in a browser, two groups, upper menu open:

```
stripZIndexes: ["1", "1"]
stripDomOrder: ["Learn", "Create"]
overlap:       96 x 13 px
topmostOwner:  "lower strip (BUG)"
```

## Fix

The row owning the open menu outranks its siblings. `OverflowMenu` gained `onOpenChange`; `WindowEntryContainer` tracks `openMenuGroupId` and gives that row `z-index: 3`.

The menu can't fix this itself — it's confined to its host strip's stacking context, so the **host** must lift. That's now documented on the component beside the existing note that the strip needs a z-index at all.

The callback is applied guardedly, not assigned:

```js
setOpenMenuGroupId((prev) => (open ? groupId : prev === groupId ? null : prev));
```

Opening a second menu closes the first, and that close can land *after* the second open — clearing unconditionally would blank the row that just opened.

## Not a defect: one menu at a time

Asked in the same report. It already held: the outside-click listener is on `mousedown`, which fires before the second trigger's `click`.

Worth recording **how** that was checked, because the obvious probe lies. A synthetic `dispatchEvent(new MouseEvent('click'))` fires no `mousedown`, so it leaves both menus open and looks like a bug. Only a real CDP click showed the truth: `openMenuCount: 1`, `expandedStates: ["false","true"]`.

It was untested, so it's now pinned as an invariant.

## Verification

After the fix, same scenario, then clicking the second trigger:

```
stripZIndexes: ["3", "1"]     topmostOwner: "menu (FIXED)"
then:  openMenuCount 1, expandedStates ["false","true"], stripZIndexes ["1","3"]
```

The lift transfers with the open menu.

**842 tests pass.** `tsc` clean, lint 0 errors / 25 warnings unchanged, prettier clean.

### Mutation testing

| mutation | result |
|---|---|
| constant z-index (the original bug) | 1 fail |
| lift **every** strip permanently | 1 fail — only the control catches this |
| `onOpenChange` never fires | 1 fail |
| outside-click listener removed | 2 fail |

The second row is the one that matters: a test asserting only "the open row has a high z-index" would pass against a component that lifted everything, which reintroduces the tie. The control asserts that with nothing open, neither row outranks the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)