### PR TITLE
Fill the group rename field to its row (KAN-114)

### DIFF
--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -634,9 +634,26 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                           color: ${COLORS.TEXT_COLOR};
                           background-color: ${COLORS.PRIMARY_COLOR};
                           border: 1px solid ${COLORS.BORDER_COLOR};
+                          /* Same four declarations the window title editor
+                             carries. Without height and padding the field
+                             collapsed to the intrinsic height of its text and
+                             sat 2px short of its own row, with the browser's
+                             default 2px padding rather than a chosen one --
+                             which read as a thinner, tighter box than the
+                             editor one level above it. */
+                          display: flex;
+                          align-items: center;
                           font-family: ${FONT_FAMILY};
                           font-size: 0.8rem;
-                          margin-left: 4px;
+                          padding-left: 8px;
+                          /* align-self, NOT height: 100%. The strip is a flex
+                             container with align-items: center and only a
+                             min-height, so it has no definite height for a
+                             percentage to resolve against and the child is not
+                             stretched -- height: 100% computed, rendered
+                             nothing, and left the field 2px short of its row.
+                             Stretching the item is what actually fills it. */
+                          align-self: stretch;
                           width: 100%;
                           min-width: 0;
                           &:focus {

--- a/src/tests/components/chromeGroupRename.test.tsx
+++ b/src/tests/components/chromeGroupRename.test.tsx
@@ -368,3 +368,40 @@ describe('the confirm tick does not blur the field it commits', () => {
     }
   );
 });
+
+// The editor collapsed to the intrinsic height of its 0.8rem text -- 20px in a
+// 22px row -- and carried the browser's default 2px padding rather than a
+// chosen one. Beside the window title editor one level up, which fills its row
+// exactly and pads to 8px, it read as a thinner, tighter box.
+//
+// Asserted as "fills its own row" rather than a pixel count: the group row is
+// deliberately smaller than the window row, so matching absolute heights would
+// be wrong. What has to match is the treatment.
+describe('the group rename editor fills its row', () => {
+  const openEditor = async () => {
+    const user = userEvent.setup();
+    await renderWindow([{ groupId: 'g1', title: 'Research', color: 'blue' }]);
+    await user.click(
+      screen.getByRole('button', { name: 'Rename group: Research' })
+    );
+    return screen.getByRole('textbox', { name: 'Rename group: Research' });
+  };
+
+  // Asserts align-self, not height. A previous version of this test checked
+  // `height: 100%` -- which was set, computed, and rendered NOTHING: the strip
+  // is a flex container with only a min-height, so there is no definite height
+  // for the percentage to resolve against. The declaration was present and the
+  // field was still 2px short. jsdom does no layout, so it cannot catch that;
+  // the rendered height is verified in a browser instead.
+  test('stretches to its row rather than sizing to its text', async () => {
+    const input = await openEditor();
+
+    expect(getComputedStyle(input).alignSelf).toBe('stretch');
+  });
+
+  test('pads its text like the window editor does, not the browser default', async () => {
+    const input = await openEditor();
+
+    expect(getComputedStyle(input).paddingLeft).toBe('8px');
+  });
+});


### PR DESCRIPTION
Closes KAN-114.

## The defect

The Chrome group rename field reads as a thinner, tighter box than the window title editor above it. Measured against the built artifact:

| | height | its row | fills it? | padding-left | font |
|---|---|---|---|---|---|
| Window title editor | 32px | 32px | yes | 8px | 14.4px |
| Group title editor | **20px** | 22px | **no — 2px short** | **2px** | 12.8px |

That 2px was the browser's default, not a chosen value. The editor added in KAN-107 never got the height and padding declarations its sibling carries.

## The obvious fix computes correctly and renders nothing

Copying `height: 100%` from the window editor left the field at **20px**.

The group header strip is a flex container with `align-items: center` and only a `min-height`. A percentage height needs a definite parent height to resolve against — there is none — and `align-items: center` means the item isn't stretched either. So the declaration was present, computed, and inert.

`align-self: stretch` is what actually fills the row.

### The first test asserted the inert declaration and passed

```js
expect(getComputedStyle(input).height).toBe('100%');   // true, and meaningless
```

jsdom does no layout, so it could not see that the rendered box was still 2px short. The test now asserts `align-self`, and the rendered height is verified in a browser.

This is the third instance of the same blind spot in this feature: **KAN-112** (paint order), **KAN-111** (`:hover` state), and now layout. jsdom can confirm a declaration exists; it can never confirm the declaration did anything.

## Deliberately not matched: absolute height

The group editor is 22px and the window editor 32px, and that stays. The group row is genuinely smaller (0.8rem vs 0.9rem text), so equalising them would mean growing the row while editing and jumping the layout. What has to match is the **treatment** — fills its own row, padded deliberately — not the pixel count.

## Verification

```
before:  height 20, stripHeight 22, fillsItsRow false, paddingLeft "2px"
after:   height 22, stripHeight 22, fillsItsRow true,  paddingLeft "8px", alignSelf "stretch"
```

**854 tests pass.** `tsc` clean, lint 0 errors / 25 warnings unchanged, prettier clean.

| mutation | result |
|---|---|
| drop the fill | 1 fail |
| drop `padding-left` | 1 fail |

🤖 Generated with [Claude Code](https://claude.com/claude-code)