### PR TITLE
Fill the Chrome group row on hover, like every row around it (KAN-115)

### DIFF
--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -614,6 +614,23 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                       display: flex;
                       align-items: center;
                       min-height: 22px;
+                      /* Fills like the window row above and the tab rows
+                         below, which both paint HOVER_COLOR under the pointer.
+                         Without it this row revealed its actions while giving
+                         no sign of being hovered at all.
+
+                         Both triggers, because the actions appear on both:
+                         reveal and fill are one visual state with one trigger
+                         (KAN-100), and filling on only one is how they came
+                         apart last time.
+
+                         No transition on the fill, also KAN-100 -- easing it
+                         lets the row reach the colour in two halves with a
+                         visible edge between them. */
+                      &:hover,
+                      &:focus-within {
+                        background-color: ${COLORS.HOVER_COLOR};
+                      }
                       &:hover .group-rename-reveal,
                       &:focus-within .group-rename-reveal {
                         opacity: 1;

--- a/src/tests/components/chromeGroupRowActions.test.tsx
+++ b/src/tests/components/chromeGroupRowActions.test.tsx
@@ -308,3 +308,76 @@ describe('two group rows in one window', () => {
     expect(triggers[1]).toHaveAttribute('aria-expanded', 'true');
   });
 });
+
+// The window row and every tab row fill with HOVER_COLOR under the pointer.
+// The group header row, added in KAN-107, filled with nothing -- so hovering it
+// revealed its actions on a row that gave no sign of being hovered.
+//
+// Both triggers, not just hover: this strip reveals its actions on :hover AND
+// :focus-within, and KAN-100's rule is that reveal and fill are ONE visual
+// state with one trigger. Filling on only one of them is exactly how they
+// drifted apart before.
+//
+// No transition on the fill, for KAN-100's reason: the fill has to land in the
+// same frame as anything painted over it, or the row fills in two halves with a
+// visible edge between them.
+describe('the group row fills like the rows around it', () => {
+  const stripRules = (groupName: string) => {
+    const group = screen.getByRole('group', { name: groupName });
+    const strip = group.querySelector('.group-rename-reveal')
+      ?.parentElement as HTMLElement;
+    const classes = [...strip.classList].map((c) => `.${c}`);
+    const out: string[] = [];
+    for (const sheet of [...document.styleSheets]) {
+      let rules: CSSRuleList;
+      try {
+        rules = sheet.cssRules;
+      } catch {
+        continue;
+      }
+      for (const rule of [...rules]) {
+        if (classes.some((c) => rule.cssText.includes(c)))
+          out.push(rule.cssText);
+      }
+    }
+    return out.join('\n');
+  };
+
+  const HOVER = /#E4E7EB|rgb\(228, ?231, ?235\)/i;
+
+  test('fills under the pointer', async () => {
+    await renderRow();
+    const rules = stripRules('Research');
+
+    const hoverBlock = rules
+      .split('}')
+      .find((b) => b.includes(':hover') && !b.includes('.group-rename-reveal'));
+
+    expect(hoverBlock).toBeDefined();
+    expect(hoverBlock).toMatch(HOVER);
+  });
+
+  test('fills when the keyboard reveals its actions', async () => {
+    await renderRow();
+    const rules = stripRules('Research');
+
+    const focusBlock = rules
+      .split('}')
+      .find(
+        (b) =>
+          b.includes(':focus-within') && !b.includes('.group-rename-reveal')
+      );
+
+    expect(focusBlock).toBeDefined();
+    expect(focusBlock).toMatch(HOVER);
+  });
+
+  // KAN-100: easing the fill lets the row arrive at the colour in two halves.
+  test('does not ease the fill', async () => {
+    await renderRow();
+
+    expect(stripRules('Research')).not.toMatch(
+      /transition[^;]*background-color/i
+    );
+  });
+});


### PR DESCRIPTION
Closes KAN-115.

## The defect

Hovering the window title row fills it. Hovering any tab row fills it. Hovering a **Chrome group** row filled nothing — it revealed its three action icons while giving no sign of being hovered.

```
parentStyle   (window row)  →  &:hover { background-color: HOVER_COLOR }
childrenStyle (tab rows)    →  &:hover { background-color: HOVER_COLOR }
group header strip          →  only  &:hover .group-rename-reveal { opacity: 1 }
```

The row was added in KAN-107 and never got a fill.

## Fix

Fills with `HOVER_COLOR` on **both** `:hover` and `:focus-within`, with **no transition**. Both details are inherited from KAN-100, not chosen fresh.

**Both triggers.** The strip reveals its actions on hover *and* focus-within, and KAN-100's rule is that reveal and fill are one visual state with one trigger — filling on only one is precisely how they drifted apart before.

**No transition.** KAN-100 measured that easing the fill lets the row arrive at the colour in two halves with a visible vertical edge, at 17 frames of 52. This row has no opaque mask over it — the title reserves the icon block's width, so nothing overlaps — but the rule is kept so the row can't drift from its neighbours if a mask is added later.

## Noted, not fixed

The window row is arguably still inconsistent: `parentStyle` fills only on `:hover`, while `parentRightStyle` fills its mask on `:focus-within` too. Pre-existing and out of scope here.

## Verification

Real browser, one group hovered and its sibling not:

```
hoveredGroupRowFill:   rgb(228, 231, 235)   // #E4E7EB, HOVER_COLOR
unhoveredGroupRowFill: rgba(0, 0, 0, 0)
```

**857 tests pass.** `tsc` clean, lint 0 errors / 25 warnings unchanged, prettier clean.

| mutation | result |
|---|---|
| hover-only fill (drops focus parity) | 1 fail |
| eased fill (KAN-100 violation) | 1 fail |

🤖 Generated with [Claude Code](https://claude.com/claude-code)