### PR TITLE
Stand the Chrome group row as tall as its neighbours (KAN-116)

### DIFF
--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -613,7 +613,13 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                       position: relative;
                       display: flex;
                       align-items: center;
-                      min-height: 22px;
+                      /* 32px, the height the window row and every tab row
+                         already stand at -- measured, not guessed. At 22px the
+                         hover fill read as a short band wedged between
+                         full-height ones. It is also exactly the action icons'
+                         height, so they now fit the row rather than
+                         overflowing a shorter one. */
+                      min-height: 32px;
                       /* Fills like the window row above and the tab rows
                          below, which both paint HOVER_COLOR under the pointer.
                          Without it this row revealed its actions while giving

--- a/src/tests/components/chromeGroupRowActions.test.tsx
+++ b/src/tests/components/chromeGroupRowActions.test.tsx
@@ -381,3 +381,22 @@ describe('the group row fills like the rows around it', () => {
     );
   });
 });
+
+// The group header row stood 22px tall while the window row above it and every
+// tab row below it are 32px, so its hover fill read as a short band wedged
+// between full-height ones. Measured in a browser before the change: window 32,
+// tab 32, group 22.
+//
+// 32px is also exactly the action icons' height, so they now fit the row
+// instead of overflowing a shorter one and relying on absolute centring.
+describe('the group row stands as tall as the rows around it', () => {
+  test('reserves the same row height the window and tab rows use', async () => {
+    await renderRow();
+
+    const strip = screen
+      .getByRole('group', { name: 'Research' })
+      .querySelector('.group-rename-reveal')?.parentElement as HTMLElement;
+
+    expect(getComputedStyle(strip).minHeight).toBe('32px');
+  });
+});


### PR DESCRIPTION
Closes KAN-116.

## The defect

Giving the group row a hover fill in KAN-115 exposed that the **row itself** is shorter than everything around it, so the fill read as a short band wedged between full-height ones.

Measured by hovering each row and reading the height of whatever element actually painted `HOVER_COLOR`:

| row | filled height |
|---|---|
| Window row | 32px |
| Tab row | 32px |
| **Chrome group row** | **22px** |

The 22px came from KAN-107 — chosen to fit the 0.8rem title, never checked against the rows it sits between.

## Fix

`min-height: 32px`.

That is also exactly the action icons' own height, so they now fit the row rather than overflowing a shorter one and relying on absolute centring to look right.

## This supersedes a decision from KAN-114

KAN-114 fixed the rename field to fill its row and explicitly stated that absolute heights were **not** being matched to the window editor: the group row was smaller by design, so equalising them would mean growing the row while editing and jumping the layout.

The reasoning was sound. The premise was wrong. **The row was not smaller by design — it was smaller by oversight.** With the row at 32px the field stretches to 32px on its own, matching the window editor exactly, with no layout jump and no special-casing.

That is worth noting as a pattern: I reasoned carefully from a measurement I had taken (22px) without asking whether the measured value was itself correct.

## Verification

```
before:  window 32, tab 32, group 22
after:   filledHeightsWhileHoveringGroup [32]
         allGroupStripHeights [32, 32]      matchesTheOtherRows true
         groupRenameFieldHeight 32          (22 after KAN-114, 20 before it)
```

**858 tests pass.** `tsc` clean, lint 0 errors / 25 warnings unchanged, prettier clean.

Mutation: reverting to `min-height: 22px` fails the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)