### PR TITLE
Show the window editor's tick, and run its field to the row edge (KAN-117)

### DIFF
--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -141,9 +141,20 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
        (KAN-100). They are glyphs over a background that is already uniform, so
        fading them cannot produce an edge -- which is what separates them from
        the mask they sit on. */
-    background-color: ${isParentHovered ? COLORS.HOVER_COLOR : 'transparent'};
+    /* No mask while editing: the field is beneath this block, so painting
+       HOVER_COLOR here would drop a grey box onto a white input. */
+    background-color: ${isParentHovered && !isEditing
+      ? COLORS.HOVER_COLOR
+      : 'transparent'};
     & > * {
-      opacity: ${isParentHovered ? 1 : 0};
+      /* isEditing, because the confirm tick is not a hover affordance -- it is
+         the editor's own control and has to be there whether or not the
+         pointer is. Focus is in the INPUT while editing, which is outside this
+         block, so neither isParentHovered nor :focus-within below ever fires
+         and the tick was invisible unless the pointer happened to be over the
+         row. The group editor avoids this by keying its reveal off the strip
+         that CONTAINS its input. */
+      opacity: ${isParentHovered || isEditing ? 1 : 0};
       transition: opacity 0.1s ease-out;
     }
     /* The keyboard's equivalent of the hover reveal (KAN-68). */
@@ -439,7 +450,11 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
 
               Otherwise: a real button. */}
           {isEditing && !isSearchPanel ? (
-            <div css={css(parentLinkStyle)}>
+            // padding-right: 0 overrides parentLinkStyle's 9px, which exists
+            // to keep the RESTING title clear of the action icons. While
+            // editing there is no title to keep clear, and the reserved gap
+            // left the field stopping 9px short of the row's edge.
+            <div css={css(parentLinkStyle + 'padding-right: 0;')}>
               <input
                 value={newTitle}
                 onBlur={handleBlur}

--- a/src/tests/components/WindowEntryContainer.test.tsx
+++ b/src/tests/components/WindowEntryContainer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { screen, within } from '@testing-library/react';
+import { screen, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import WindowEntryContainer from '../../components/home/rightpane/WindowEntryContainer';
@@ -258,5 +258,104 @@ describe('finishing a window rename', () => {
       screen.getByRole('button', { name: 'Rename window group' })
     ).toBeInTheDocument();
     expect(store).toBeDefined();
+  });
+});
+
+// Two faults in the window title editor, both visible once the group editor
+// beside it was made right.
+//
+// The tick lives inside the row's action block, whose opacity is driven by
+// isParentHovered. While editing, focus is in the INPUT -- outside that block
+// -- so neither the hover flag nor :focus-within applies and the tick was
+// invisible unless the pointer happened to be over the row. The group editor
+// does not have this problem because its reveal is keyed off the strip that
+// CONTAINS the input.
+//
+// And parentLinkStyle reserves padding-right: 9px to keep the resting title
+// clear of the action icons. While editing there is no title to keep clear,
+// so the field stopped 9px short of the row's edge -- measured in a browser.
+describe('the window title editor', () => {
+  const openEditor = async () => {
+    const user = userEvent.setup();
+    await renderWindow({
+      tabs: [
+        { tabId: 't1', favicon: '', title: 'Inbox', url: 'https://a.test' },
+      ],
+    });
+    await user.click(
+      screen.getByRole('button', { name: 'Rename window group' })
+    );
+    return screen.getByRole('textbox');
+  };
+
+  // Asserted against the generated CSS, not getComputedStyle. The reveal is a
+  // `& > *` rule, and jsdom does not resolve child combinators for computed
+  // style -- it reports opacity 1 for the tick whatever the state, which is how
+  // three earlier versions of this test passed against the bug. The browser
+  // reports 0. Verified there too.
+  test('shows its confirm tick without needing the pointer', async () => {
+    await openEditor();
+
+    // Load-bearing. userEvent.click moves the virtual pointer onto the row, so
+    // onMouseEnter fires and isParentHovered stays TRUE -- which made two
+    // earlier versions of this test pass by exercising the hover path and
+    // never touching isEditing at all. mouseLeave is fired directly rather
+    // than via unhover(), because the element the pointer was last over has
+    // since unmounted.
+    let row: HTMLElement | null = screen.getByRole('textbox');
+    while (row && getComputedStyle(row).position !== 'relative') {
+      row = row.parentElement;
+    }
+    fireEvent.mouseLeave(row as HTMLElement);
+
+    const tick = screen.getByRole('button', { name: 'Save changes' });
+
+    let block: HTMLElement | null = tick;
+    while (block && getComputedStyle(block).position !== 'absolute') {
+      block = block.parentElement;
+    }
+    const classes = [...(block as HTMLElement).classList].map((c) => `.${c}`);
+
+    const childRules: string[] = [];
+    for (const sheet of [...document.styleSheets]) {
+      let rules: CSSRuleList;
+      try {
+        rules = sheet.cssRules;
+      } catch {
+        continue;
+      }
+      for (const rule of [...rules]) {
+        const text = rule.cssText;
+        if (
+          classes.some((c) => text.includes(`${c}>`) || text.includes(`${c} >`))
+        )
+          childRules.push(text);
+      }
+    }
+
+    expect(childRules.join('\n')).toMatch(/opacity:\s*1/);
+  });
+
+  test('runs the field to the edge of its row', async () => {
+    const input = await openEditor();
+
+    expect(
+      getComputedStyle(input.parentElement as HTMLElement).paddingRight
+    ).toBe('0px');
+  });
+
+  // THE CONTROL for the padding. The 9px exists for a reason -- it keeps the
+  // resting title clear of the action icons -- so it must survive when the row
+  // is NOT being edited.
+  test('CONTROL: the resting title still reserves room for the actions', async () => {
+    await renderWindow({
+      tabs: [
+        { tabId: 't1', favicon: '', title: 'Inbox', url: 'https://a.test' },
+      ],
+    });
+
+    const title = screen.getByRole('button', { name: 'Window 1' });
+
+    expect(getComputedStyle(title).paddingRight).toBe('9px');
   });
 });


### PR DESCRIPTION
Closes KAN-117.

## The defect

Two faults in the window title editor, both obvious once the Chrome group editor beside it was fixed. Measured against the built artifact:

```
gapToRowEdge: 9        // field stops 9px short of the row's right edge
tickOpacity:  0        // confirm tick invisible unless the row is hovered
```

**The tick is a hover affordance and shouldn't be.** It lives in the row's action block, whose reveal is `& > * { opacity: isParentHovered ? 1 : 0 }`. While editing, focus is in the **input** — outside that block — so neither `isParentHovered` nor the block's `:focus-within` fires. A confirm tick isn't a hover affordance; it's the editor's own control and belongs on screen whenever the editor is.

The group editor avoids this by keying its reveal off the strip that *contains* its input.

**The field stops short.** `parentLinkStyle` reserves `padding-right: 9px` to keep the *resting* title clear of the action icons. While editing there's no title to keep clear, so that reservation just left a band of pane background.

## Fix

- Reveal is `isParentHovered || isEditing`.
- No mask while editing — the field is beneath the block, so `HOVER_COLOR` there would drop a grey box onto a white input.
- The editing branch overrides padding to `0`; the resting branch keeps its 9px.

## Three versions of the test passed against the bug

Each failure was a *test* problem, and each is worth knowing:

1. **`closest('span')`** found the glyph span inside `Icon`, not the reveal wrapper.
2. **`getComputedStyle` can't see the reveal at all.** It's a `& > *` rule, and **jsdom does not resolve child combinators for computed style** — it reported `opacity: 1` for the tick in every state, where the browser reports `0`. The assertion had to move to the generated CSS text.
3. **`userEvent.click` moves the virtual pointer onto the row**, firing `onMouseEnter`, so `isParentHovered` stayed true and the test exercised the hover path while never touching `isEditing`. The row's `mouseLeave` is now fired directly — `unhover()` can't help, because the element the pointer was last over has since unmounted.

Only after the third fix did the mutation (drop `isEditing`) actually fail.

## Verification

Opened with a synthetic click, which fires no `mouseenter`, so the row is genuinely unhovered:

```
before:  gapToRowEdge 9,  tickOpacityWhileNotHovered 0
after:   gapToRowEdge 0,  tickOpacityWhileNotHovered 1,  maskWhileEditing rgba(0,0,0,0)
```

**861 tests pass.** `tsc` clean, lint 0 errors / 25 warnings unchanged, prettier clean.

| mutation | result |
|---|---|
| drop `isEditing` from the reveal | 1 fail |
| restore the 9px padding | 1 fail |

Plus a control asserting the **resting** title still reserves its 9px, so the fix can't be "delete the padding everywhere".

🤖 Generated with [Claude Code](https://claude.com/claude-code)