### PR TITLE
Inset settings sections evenly, not just on the left (KAN-118)

### DIFF
--- a/src/components/settings/rightpane/SettingsDetailsContainer.tsx
+++ b/src/components/settings/rightpane/SettingsDetailsContainer.tsx
@@ -275,7 +275,13 @@ const SettingsDetailsContainer: React.FC = () => {
             display: flex;
             flex-direction: column;
             align-items: flex-start;
+            /* Matched on both sides. The inset used to be left-only, so every
+               settings section sat off-centre in its pane -- measured on the
+               Language grid, 50px of gutter on the left and 9px on the right.
+               The content inside is flexible, so reserving the right simply
+               narrows it; nothing needed resizing by hand. */
             padding-left: clamp(16px, 8%, 72px);
+            padding-right: clamp(16px, 8%, 72px);
             width: 100%;
             margin-top: 20px;
           `}
@@ -412,6 +418,7 @@ const SettingsDetailsContainer: React.FC = () => {
             flex-direction: column;
             align-items: flex-start;
             padding-left: clamp(16px, 8%, 72px);
+            padding-right: clamp(16px, 8%, 72px);
             width: 100%;
             margin-top: 20px;
           `}
@@ -471,6 +478,7 @@ const SettingsDetailsContainer: React.FC = () => {
             flex-direction: column;
             align-items: flex-start;
             padding-left: clamp(16px, 8%, 72px);
+            padding-right: clamp(16px, 8%, 72px);
             width: 100%;
             margin-top: 20px;
           `}
@@ -511,6 +519,7 @@ const SettingsDetailsContainer: React.FC = () => {
             flex-direction: column;
             align-items: flex-start;
             padding-left: clamp(16px, 8%, 72px);
+            padding-right: clamp(16px, 8%, 72px);
             width: 100%;
             margin-top: 20px;
           `}
@@ -567,6 +576,7 @@ const SettingsDetailsContainer: React.FC = () => {
         <div
           css={css`
             padding-left: clamp(16px, 8%, 72px);
+            padding-right: clamp(16px, 8%, 72px);
             width: 100%;
             margin-top: 20px;
           `}
@@ -626,6 +636,7 @@ const SettingsDetailsContainer: React.FC = () => {
             flex-direction: column;
             align-items: flex-start;
             padding-left: clamp(16px, 8%, 72px);
+            padding-right: clamp(16px, 8%, 72px);
             width: 100%;
             margin-top: 20px;
           `}
@@ -691,6 +702,7 @@ const SettingsDetailsContainer: React.FC = () => {
             flex-direction: column;
             align-items: flex-start;
             padding-left: clamp(16px, 8%, 72px);
+            padding-right: clamp(16px, 8%, 72px);
             width: 100%;
             margin-top: 20px;
           `}

--- a/src/tests/components/settingsPaneGutters.test.tsx
+++ b/src/tests/components/settingsPaneGutters.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'vitest';
+
+import SettingsDetailsContainer from '../../components/settings/rightpane/SettingsDetailsContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  selectCategory,
+  SettingsCategory,
+} from '../../redux/slices/settingsCategoryStateSlice';
+
+// Every settings section insets its content with
+// `padding-left: clamp(16px, 8%, 72px)` and reserved nothing on the right, so
+// the pane's content sat off-centre: measured in a browser on the Language
+// section, the left gutter was 50px and the right 9px.
+//
+// Asserted as left === right rather than a pixel value, because the inset is a
+// clamp against the pane's own width -- pinning a number would pin the viewport
+// the test happened to run at.
+describe('the settings pane insets its content evenly', () => {
+  const sectionsUnderTest = [
+    ['Display', SettingsCategory.DISPLAY],
+    ['Sync & Privacy', SettingsCategory.SYNC],
+    ['Data Management', SettingsCategory.DATA_MANAGEMENT],
+    ['Language', SettingsCategory.LANGUAGE],
+    // About is deliberately absent: it centres its content with
+    // `align-items: center` and carries no inset at all, so it has no gutters
+    // to balance. Asserting one here demanded an element that should not exist.
+  ] as const;
+
+  test.each(sectionsUnderTest)(
+    'the %s section reserves the same gutter on both sides',
+    async (_name, category) => {
+      const { container } = await renderWithProviders(
+        <SettingsDetailsContainer />,
+        { seedStore: (store) => store.dispatch(selectCategory(category)) }
+      );
+
+      // Identified by the clamp's own floor (16px), not by the literal string
+      // "clamp" -- jsdom resolves the function, so a substring match finds
+      // nothing and an earlier version of this fell back to EVERY padded div,
+      // catching a 4px/8px button that is asymmetric for its own good reasons.
+      const isInset = (d: Element) => {
+        const pl = getComputedStyle(d).paddingLeft;
+        // jsdom returns the literal clamp() string; a browser resolves it to
+        // px. Accept both, so this test does not depend on which one runs it.
+        return pl.includes('clamp') || parseFloat(pl) >= 16;
+      };
+      const targets = [...container.querySelectorAll('div')].filter(isInset);
+
+      expect(targets.length).toBeGreaterThan(0);
+      for (const el of targets) {
+        const cs = getComputedStyle(el);
+        expect(cs.paddingRight).toBe(cs.paddingLeft);
+      }
+    }
+  );
+
+  // THE CONTROL. Equal padding would also be satisfied by zero padding on both
+  // sides, which would put the content flush against the pane's edges. The
+  // inset has to survive.
+  test('CONTROL: the inset is still an inset, not zero', async () => {
+    const { container } = await renderWithProviders(
+      <SettingsDetailsContainer />,
+      {
+        seedStore: (store) =>
+          store.dispatch(selectCategory(SettingsCategory.LANGUAGE)),
+      }
+    );
+
+    const inset = [...container.querySelectorAll('div')].filter((d) => {
+      const pl = getComputedStyle(d).paddingLeft;
+      return pl.includes('clamp') || parseFloat(pl) >= 16;
+    });
+
+    expect(inset.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes KAN-118.

## The defect

Every settings section insets its content with `padding-left: clamp(16px, 8%, 72px)` and reserves **nothing** on the right — seven occurrences of the padding, and `padding-right` appearing **nowhere** in the file. So the content sits off-centre in its pane.

Measured on the Language grid:

```
gutterLeft: 50px    gutterRight: 9px
```

## Fix

A matching `padding-right` on all seven sections.

**No button resizing was needed** — the question you asked. The content is flexible, so reserving the right gutter narrows it on its own: the language buttons went from **232px to 211px** by themselves.

`About` is deliberately untouched: it centres its content with `align-items: center` and carries no inset, so it has no gutters to balance. An early version of the test demanded one there and was wrong.

## Verification

```
Language grid:     gutterLeft 41, gutterRight 41, equal true
Sync Status card:  gutterLeft 41, gutterRight 41, equal true
```

**866 tests pass.** `tsc` clean, lint 0 errors / 25 warnings unchanged, prettier clean.

Mutation: removing `padding-right` from any one section fails its test. A control asserts the inset is still an inset, so "delete the padding everywhere" doesn't pass.

## A stale-artifact near miss

Worth recording, because it nearly produced a wrong conclusion. The first measurement after the fix reported `paddingRight: 0px` — the change looked like it hadn't worked. It had:

```
src/tests/components/settingsPaneGutters.test.tsx(2,1): error TS6133: 'screen' is declared but its value is never read.
```

`npm run build` is `tsc && vite build`, so **a type error in a test file stops the artifact being rebuilt**, silently — leaving the old bundle in place for me to measure. 866 passing vitest tests said nothing about it, because vitest does not typecheck.

Caught by counting `clamp(16px` in the bundle: **7** where the source had **14**. That count, plus the hashed filename changing (`index-D6Exb4NM` → `index-C67dnwVd`), is what proves a fresh artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)