### PR TITLE
Add a tab to the front of its group, not the end (KAN-119)

### DIFF
--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -836,16 +836,21 @@ export const tabContainerDataStateSlice = createSlice({
       if (!located) return;
       const { container, window } = located;
 
-      // NOT unshift, which is what addCurrTabToWindowInternal does. A group
-      // renders at the position of its FIRST member (partitionTabsIntoRuns),
-      // so putting a grouped tab at the front of the window would drag the
-      // whole group up there with it. It goes after the group's last existing
-      // member, which is also the contiguous shape applyTabGroups wants.
-      const lastMemberIndex = window.tabs.reduce(
-        (last, tab, index) => (tab.chromeGroupId === groupId ? index : last),
-        -1
+      // At the front of the GROUP, which is where the window-level add puts a
+      // tab too -- addCurrTabToWindowInternal unshifts.
+      //
+      // NOT the front of the window, which is the distinction that matters. A
+      // group renders at the position of its FIRST member
+      // (partitionTabsIntoRuns), so unshifting a grouped tab to index 0 would
+      // drag the whole group up there with it. Inserting at the group's own
+      // start does not: the new tab becomes the first member at the index the
+      // group already began on, so the runs come out in the same order. It
+      // also keeps the members contiguous, which is what applyTabGroups needs
+      // to hand chrome.tabs.group a single block of ids on restore.
+      const firstMemberIndex = window.tabs.findIndex(
+        (tab) => tab.chromeGroupId === groupId
       );
-      window.tabs.splice(lastMemberIndex + 1, 0, {
+      window.tabs.splice(firstMemberIndex, 0, {
         ...currentTabData,
         // The deliberate exception to KAN-11's rule that a tab added from
         // another window is stored ungrouped. Inheriting a group silently

--- a/src/tests/components/chromeGroupRowActions.test.tsx
+++ b/src/tests/components/chromeGroupRowActions.test.tsx
@@ -142,7 +142,7 @@ describe('the group row action set', () => {
     expect(win(store).tabs.map((t) => t.tabId)).toEqual(['loose']);
   });
 
-  test('add current tab puts it in the group, beside its members', async () => {
+  test('add current tab puts it at the front of the group', async () => {
     const user = userEvent.setup();
     const { store } = await renderRow();
 
@@ -152,8 +152,9 @@ describe('the group row action set', () => {
 
     const tabs = win(store).tabs;
     expect(tabs).toHaveLength(4);
-    expect(tabs[3].chromeGroupId).toBe('grp');
-    expect(tabs.map((t) => t.title)).toEqual(['Loose', 'One', 'Two', 'Added']);
+    // First member of the group, matching the window-level add, which unshifts
+    expect(tabs.map((t) => t.title)).toEqual(['Loose', 'Added', 'One', 'Two']);
+    expect(tabs[1].chromeGroupId).toBe('grp');
   });
 
   // A control that cannot act must not be focusable and inert (KAN-62).

--- a/src/tests/redux/chromeGroupActions.test.ts
+++ b/src/tests/redux/chromeGroupActions.test.ts
@@ -22,6 +22,7 @@ import type {
   tabContainerData,
   TabMasterContainer,
 } from '../../redux/slices/tabContainerDataStateSlice';
+import { partitionTabsIntoRuns } from '../../utils/functions/tabGroups';
 
 // The three actions that finish the Chrome tab group row, beside the rename
 // added in KAN-107.
@@ -119,17 +120,52 @@ describe('adding the current tab to a Chrome group', () => {
     ).toBe('grp');
   });
 
-  // The headline trap. addCurrTabToWindowInternal unshifts, which for a
-  // grouped tab would move the group's whole run to the top of the window.
-  it('lands beside the group members, not at the front of the window', () => {
+  // First in the group, matching the window-level add, which unshifts. An
+  // earlier version put it after the group's LAST member out of a misplaced
+  // worry about moving the group -- see the control below for what that worry
+  // was actually about.
+  it('lands at the front of its group', () => {
     const after = add(seed());
     expect(tabIds(after)).toEqual([
       'loose-1',
+      'added',
       'g-1',
       'g-2',
-      'added',
       'loose-2',
     ]);
+  });
+
+  // THE CONTROL, and the real constraint. partitionTabsIntoRuns emits a group
+  // at the position of its FIRST member, so a tab unshifted to the front of the
+  // WINDOW would drag the whole group up there with it. Inserting at the
+  // group's own start does not: the new tab becomes the first member at the
+  // index the group already began on, so the runs come out in the same order.
+  it('CONTROL: the group does not move within the window', () => {
+    const after = add(seed());
+    const tabs = after.tabGroups[0].windows[0].tabs;
+    const runs = partitionTabsIntoRuns(
+      tabs,
+      after.tabGroups[0].windows[0].chromeTabGroups
+    );
+
+    expect(runs.map((r) => r.kind)).toEqual([
+      'ungrouped',
+      'group',
+      'ungrouped',
+    ]);
+    expect(runs[0].tabs.map((t) => t.tabId)).toEqual(['loose-1']);
+    expect(runs[2].tabs.map((t) => t.tabId)).toEqual(['loose-2']);
+  });
+
+  // Contiguity is what applyTabGroups needs on restore: chrome.tabs.group is
+  // called with the members' ids, and they must not be interleaved with others.
+  it('keeps the group contiguous', () => {
+    const tabs = add(seed()).tabGroups[0].windows[0].tabs;
+    const memberIndexes = tabs
+      .map((t, i) => (t.chromeGroupId === 'grp' ? i : -1))
+      .filter((i) => i !== -1);
+
+    expect(memberIndexes).toEqual([1, 2, 3]);
   });
 
   it('increments both tab counts', () => {


### PR DESCRIPTION
Closes KAN-119.

## The defect

**Add current tab to group** appended. The window-level **Add current tab** unshifts, so the app's convention is that a newly added tab goes first — and the group action disagreed with it.

## Root cause: a real constraint applied one level too broadly

KAN-110 deliberately avoided `unshift`, with this reasoning:

> A group renders at the position of its FIRST member (`partitionTabsIntoRuns`), so putting a grouped tab at the front of the window would drag the whole group up there with it.

That's true, and still is. The mistake was conflating **the front of the window** with **the front of the group**, then retreating all the way to "after the last member" to be safe.

Inserting at the group's own first-member index has none of that problem: the new tab becomes the first member *at the index the group already began on*, so the runs come out in the same order and the group doesn't move. It stays contiguous too, which is what `applyTabGroups` needs to hand `chrome.tabs.group` a single block of ids on restore.

## Fix

`splice(firstMemberIndex, 0, tab)` rather than `splice(lastMemberIndex + 1, 0, tab)`.

## Tests

The position expectation flipped, and **two invariants were added that the old code also satisfied** — they guard the constraint, not the change:

- **the group does not move within the window** — asserted through `partitionTabsIntoRuns`: the runs still come out `ungrouped, group, ungrouped` with the same outer members.
- **the group stays contiguous** — member indices form a single unbroken block.

| mutation | result |
|---|---|
| back to after-last | 2 fail |
| `unshift` to the front of the window (the original trap) | **4 fail**, including both invariants |

That second row is why the invariants earn their place: they're what stops a future *"just unshift it"* from looking correct.

**868 tests pass.** `tsc` clean, lint 0 errors / 25 warnings unchanged, prettier clean.

## Verification

Real browser, group `Booked` with an ungrouped tab above it:

```
tabOrder: [ Loose first (-), <added> (g1), Flights to Osaka (g1),
            Machiya stays (g1), Japan Rail Pass (g1), Kyoto saved places (g2) ]
groupRunOrderOnScreen: ["Booked", "Explore"]
```

New tab first in its group, members contiguous, group unmoved. Bundle hash changed (`C67dnwVd` → `Cwb7mODH`), confirming a fresh artifact rather than a stale one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)