### PR TITLE
Raise the Chrome group title to 0.85rem (KAN-120)

### DIFF
--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -283,7 +283,12 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     <NormalLabel
       value={groupDisplayName(group)}
       color={group.title ? COLORS.LABEL_L2_COLOR : COLORS.LABEL_L3_COLOR}
-      size="0.8rem"
+      // 0.85rem, not the 0.9rem the window title and tab titles share. At
+      // 0.8rem this was the smallest content text in the pane and smaller than
+      // the tabs the group contains, which reads as a caption rather than a
+      // header. Matching 0.9 would instead make a group as prominent as the
+      // window holding it. Compared in a browser before choosing.
+      size="0.85rem"
       style={`padding-left: 4px;${group.title ? '' : ' font-style: italic;'}`}
     />
   );
@@ -682,7 +687,9 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                           display: flex;
                           align-items: center;
                           font-family: ${FONT_FAMILY};
-                          font-size: 0.8rem;
+                          /* Matches the label this replaces, or the text
+                             visibly jumps size on entering edit mode. */
+                          font-size: 0.85rem;
                           padding-left: 8px;
                           /* align-self, NOT height: 100%. The strip is a flex
                              container with align-items: center and only a

--- a/src/tests/components/chromeGroupRename.test.tsx
+++ b/src/tests/components/chromeGroupRename.test.tsx
@@ -405,3 +405,52 @@ describe('the group rename editor fills its row', () => {
     expect(getComputedStyle(input).paddingLeft).toBe('8px');
   });
 });
+
+// The group title shipped at 0.8rem -- the smallest content text in the pane,
+// and smaller than the tabs the group contains, which inverts the hierarchy: a
+// container reading as subordinate to its own children.
+//
+// 0.85rem rather than 0.9rem, chosen after comparing all three in a browser.
+// 0.9rem is what the WINDOW title uses, so matching it would make a group as
+// loud as the window that holds it, and a heavier 0.9 louder still.
+//
+// This narrows the inversion without removing it: tab titles are also 0.9rem,
+// so no value is both smaller than the window and not smaller than the tabs.
+// The real flatness is that window and tab share a size, leaving no step for a
+// group to occupy. Deliberately not addressed here.
+describe('the group title size', () => {
+  test('is larger than the 0.8rem it shipped at', async () => {
+    await renderWindow([{ groupId: 'g1', title: 'Research', color: 'blue' }]);
+
+    // 0.85rem at the 16px root
+    expect(getComputedStyle(screen.getByText('Research')).fontSize).toBe(
+      '13.6px'
+    );
+  });
+
+  // THE CONTROL. The point of the change is the gap to the tabs, so the tab
+  // title must stay where it is -- shrinking the tabs would also "fix" the
+  // ratio and would be the wrong fix entirely.
+  test('CONTROL: the tab titles are unchanged at 0.9rem', async () => {
+    await renderWindow([{ groupId: 'g1', title: 'Research', color: 'blue' }]);
+
+    expect(getComputedStyle(screen.getByText('Inbox')).fontSize).toBe('14.4px');
+  });
+
+  // The editor replaces the label in place, so a different size there would
+  // make the text visibly jump on entering and leaving edit mode.
+  test('the editor matches the label it replaces', async () => {
+    const user = userEvent.setup();
+    await renderWindow([{ groupId: 'g1', title: 'Research', color: 'blue' }]);
+
+    const labelSize = getComputedStyle(screen.getByText('Research')).fontSize;
+    await user.click(
+      screen.getByRole('button', { name: 'Rename group: Research' })
+    );
+    const input = screen.getByRole('textbox', {
+      name: 'Rename group: Research',
+    });
+
+    expect(getComputedStyle(input).fontSize).toBe(labelSize);
+  });
+});


### PR DESCRIPTION
Closes KAN-120.

## The defect

The Chrome group title shipped at `0.8rem` (12.8px) — the smallest content text in the right pane, and **smaller than the tabs the group contains**.

| role | size |
|---|---|
| Session title | 1.125rem / 18px |
| Window title | 0.9rem / 14.4px |
| Tab title | 0.9rem / 14.4px |
| **Group title** | **0.8rem / 12.8px** |
| Hero metadata | 0.75 / 0.7rem |

A group is a *container* of tabs, so rendering it below them inverts the hierarchy — it reads as a caption on the row above rather than a header for the rows below.

## Why 0.85rem and not 0.9rem

Four options were injected into the running popup and compared in context — `0.8/400`, `0.85/400`, `0.9/400`, `0.9/500` — each shown above its own tabs.

`0.9rem` was rejected for a reason I'd initially under-weighted: **that is what the window title uses.** Matching it makes a group as prominent as the window holding it, and the 500-weight variant louder still.

**0.85rem is a compromise, not a clean fix**, and that's worth stating rather than glossing:

Tab titles are *also* `0.9rem`, so no value is both smaller than the window and not smaller than the tabs — those two constraints ask for opposite things. The underlying flatness is that **the window title and the tab title share a size**, leaving no step for a group to occupy. This narrows the inversion (12.8 → 13.6px) without removing it. Fixing it properly means raising the window title, which is a larger change and deliberately not made here.

## Also fixed

The rename editor's input was still `0.8rem` while the label moved to `0.85rem`, so the text would have **visibly jumped size** on entering and leaving edit mode. A test now pins the two together rather than pinning each to a number.

## Tests

- label is `13.6px`
- **CONTROL**: tab titles unchanged at `14.4px` — the point of the change is the *gap*, and shrinking the tabs would equalise the ratio just as well while being the wrong fix
- the editor matches the label it replaces

| mutation | result |
|---|---|
| label back to `0.8rem` | 2 fail |
| shrink the **tabs** instead | 1 fail (the control) |
| editor size drifts from the label | 1 fail |

**871 tests pass.** `tsc` clean, lint 0 errors / 25 warnings unchanged, prettier clean.

## Verification

Real browser, against the built artifact (`0.85rem` present ×3 in the bundle):

```
groupTitle  13.6px / 400
tabTitle    14.4px / 400
windowTitle 14.4px / 400
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)