### PR TITLE
Open a Chrome group when its row is clicked (KAN-121)

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -34,6 +34,7 @@
   "Expand": "Erweitern",
   "Rename window group": "Fenstergruppe umbenennen",
   "Rename group": "Gruppe umbenennen",
+  "Open group": "Gruppe öffnen",
   "Add current tab to group": "Aktuellen Tab zur Gruppe hinzufügen",
   "Ungroup": "Gruppierung aufheben",
   "Delete group": "Gruppe löschen",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -34,6 +34,7 @@
   "Expand": "Expand",
   "Rename window group": "Rename window group",
   "Rename group": "Rename group",
+  "Open group": "Open group",
   "Add current tab to group": "Add current tab to group",
   "Ungroup": "Ungroup",
   "Delete group": "Delete group",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -34,6 +34,7 @@
   "Expand": "Expandir",
   "Rename window group": "Renombrar grupo de ventanas",
   "Rename group": "Renombrar grupo",
+  "Open group": "Abrir grupo",
   "Add current tab to group": "Añadir la pestaña actual al grupo",
   "Ungroup": "Desagrupar",
   "Delete group": "Eliminar grupo",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -34,6 +34,7 @@
   "Expand": "Agrandir",
   "Rename window group": "Renommer le groupe de fenêtres",
   "Rename group": "Renommer le groupe",
+  "Open group": "Ouvrir le groupe",
   "Add current tab to group": "Ajouter l’onglet actuel au groupe",
   "Ungroup": "Dissocier",
   "Delete group": "Supprimer le groupe",

--- a/public/locales/hi/translation.json
+++ b/public/locales/hi/translation.json
@@ -34,6 +34,7 @@
   "Expand": "विस्तारित करें",
   "Rename window group": "विंडो समूह का नाम बदलें",
   "Rename group": "समूह का नाम बदलें",
+  "Open group": "समूह खोलें",
   "Add current tab to group": "मौजूदा टैब को समूह में जोड़ें",
   "Ungroup": "समूह हटाएँ",
   "Delete group": "समूह मिटाएँ",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -34,6 +34,7 @@
   "Expand": "Espandi",
   "Rename window group": "Rinomina gruppo",
   "Rename group": "Rinomina gruppo",
+  "Open group": "Apri gruppo",
   "Add current tab to group": "Aggiungi la scheda corrente al gruppo",
   "Ungroup": "Separa",
   "Delete group": "Elimina gruppo",

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -34,6 +34,7 @@
   "Expand": "展開",
   "Rename window group": "ウィンドウグループの名前を変更",
   "Rename group": "グループの名前を変更",
+  "Open group": "グループを開く",
   "Add current tab to group": "現在のタブをグループに追加",
   "Ungroup": "グループ解除",
   "Delete group": "グループを削除",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -34,6 +34,7 @@
   "Expand": "Expandir",
   "Rename window group": "Renomear grupo de janelas",
   "Rename group": "Renomear grupo",
+  "Open group": "Abrir grupo",
   "Add current tab to group": "Adicionar a aba atual ao grupo",
   "Ungroup": "Desagrupar",
   "Delete group": "Excluir grupo",

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -34,6 +34,7 @@
   "Expand": "Развернуть",
   "Rename window group": "Переименовать группу окон",
   "Rename group": "Переименовать группу",
+  "Open group": "Открыть группу",
   "Add current tab to group": "Добавить текущую вкладку в группу",
   "Ungroup": "Разгруппировать",
   "Delete group": "Удалить группу",

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -34,6 +34,7 @@
   "Expand": "展开",
   "Rename window group": "重命名窗口组",
   "Rename group": "重命名群组",
+  "Open group": "打开群组",
   "Add current tab to group": "将当前标签页添加到群组",
   "Ungroup": "取消分组",
   "Delete group": "删除群组",

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -31,7 +31,11 @@ import {
   sanitizeTabGroupColor,
   TAB_GROUP_COLOR_HEX,
 } from '../../../utils/functions/tabGroups';
-import type { chromeTabGroupData } from '../../../utils/functions/tabGroups';
+import type {
+  chromeTabGroupData,
+  TabRun,
+} from '../../../utils/functions/tabGroups';
+import { applyTabGroups } from '../../../utils/functions/windows';
 
 interface WindowEntryContainerProps {
   title: string;
@@ -279,6 +283,11 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
   const renameGroupLabel = (group: chromeTabGroupData) =>
     t('Rename group') + ': ' + groupDisplayName(group);
 
+  // WCAG 2.5.3, same shape as the tab rows: the accessible name contains the
+  // visible title, and says what the control actually does now.
+  const openGroupLabel = (group: chromeTabGroupData) =>
+    t('Open group') + ': ' + groupDisplayName(group);
+
   const groupTitleLabel = (group: chromeTabGroupData) => (
     <NormalLabel
       value={groupDisplayName(group)}
@@ -360,6 +369,57 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
         active: true,
         index: currentTabIndex + 1,
       });
+    });
+  };
+
+  // Mirrors handleTabClick, for a whole group. Every other row in this pane
+  // opens something on click -- the window title opens its window, a tab title
+  // opens that tab -- and the group row was the only one that renamed instead,
+  // which also left renaming with two entry points and opening with none.
+  //
+  // The index advances per tab. Creating them all at currentTabIndex + 1 would
+  // reverse the group, because each insert pushes the previous one right.
+  //
+  // Tabs open ungrouped: re-forming the Chrome group needs the tabGroups
+  // permission at click time and is deliberately left to its own ticket.
+  const handleGroupClick = (run: TabRun) => {
+    if (run.kind !== 'group') return;
+    chrome.tabs.query({ active: true, currentWindow: true }, async (tabs) => {
+      const current = tabs[0];
+      if (!current) return;
+
+      // Sequential, not Promise.all. Each create is given an explicit index,
+      // and concurrent inserts would resolve those indexes against a list that
+      // is still shifting -- the group would come out shuffled.
+      const created: chrome.tabs.Tab[] = [];
+      for (const [offset, tab] of run.tabs.entries()) {
+        created.push(
+          await chrome.tabs.create({
+            url: resolveTabUrl(tab.url),
+            // Only the last one takes focus, so the user lands at the end of
+            // what they opened instead of watching focus jump per tab.
+            active: offset === run.tabs.length - 1,
+            index: current.index + 1 + offset,
+          })
+        );
+      }
+
+      const tabIds = created
+        .map((tab) => tab.id)
+        .filter((id): id is number => id !== undefined);
+      if (tabIds.length === 0) return;
+
+      // Re-forms the saved group -- same name, same colour -- by reusing the
+      // function restore already uses, rather than a second implementation of
+      // the same thing. No permission check here: this row only renders when
+      // hasTabGroupsPermission is true, and applyTabGroups feature-detects
+      // chrome.tabGroups anyway, so a missing namespace leaves the tabs open
+      // and ungrouped rather than failing the click.
+      await applyTabGroups(
+        current.windowId,
+        [run.group],
+        new Map([[run.group.groupId, tabIds]])
+      );
     });
   };
 
@@ -721,8 +781,9 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                       // layout gives it no room unless it is reserved here.
                       // Measured at 100/125/150% zoom before and after.
                       <ClickableRow
-                        ariaLabel={renameGroupLabel(run.group)}
-                        onClick={() => startEditingGroup(run.group)}
+                        ariaLabel={openGroupLabel(run.group)}
+                        tooltipText={t('Open group')}
+                        onClick={() => handleGroupClick(run)}
                         style="display: flex; align-items: center; min-width: 0; width: 100%; padding-right: 100px; box-sizing: border-box;"
                       >
                         {groupTitleLabel(run.group)}

--- a/src/tests/components/TabGroupDetailsContainer.test.tsx
+++ b/src/tests/components/TabGroupDetailsContainer.test.tsx
@@ -213,9 +213,7 @@ describe('renaming a Chrome tab group round-trips to the screen', () => {
     });
 
     await user.click(
-      await screen.findByRole('button', {
-        name: 'Rename group: Unnamed group',
-      })
+      await screen.findByRole('button', { name: 'Rename group' })
     );
     await user.type(
       screen.getByRole('textbox', { name: 'Rename group: Unnamed group' }),
@@ -233,7 +231,7 @@ describe('renaming a Chrome tab group round-trips to the screen', () => {
     });
 
     await user.click(
-      await screen.findByRole('button', { name: 'Rename group: Research' })
+      await screen.findByRole('button', { name: 'Rename group' })
     );
     const input = screen.getByRole('textbox', {
       name: 'Rename group: Research',

--- a/src/tests/components/chromeGroupRename.test.tsx
+++ b/src/tests/components/chromeGroupRename.test.tsx
@@ -135,19 +135,27 @@ describe('the rename control', () => {
   // WCAG 2.5.3, the same shape KAN-77 established for the session rename: the
   // accessible name has to CONTAIN the visible one, or a voice-control user
   // saying "click Research" has nothing to hit.
-  test('is named for the group it renames', async () => {
+  // The ROW opens the group now (KAN-121); the pencil is the only way to
+  // rename. Both are still named so that a voice-control user can say either.
+  test('the row is named for opening, the pencil for renaming', async () => {
     await renderWindow([{ groupId: 'g1', title: 'Research', color: 'blue' }]);
 
     expect(
-      screen.getByRole('button', { name: 'Rename group: Research' })
+      screen.getByRole('button', { name: 'Open group: Research' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Rename group' })
     ).toBeInTheDocument();
   });
 
-  test('names an untitled group by its placeholder', async () => {
+  test('an untitled group is named by its placeholder in both', async () => {
     await renderWindow([{ groupId: 'g1', title: '', color: 'orange' }]);
 
     expect(
-      screen.getByRole('button', { name: 'Rename group: Unnamed group' })
+      screen.getByRole('button', { name: 'Open group: Unnamed group' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Rename group' })
     ).toBeInTheDocument();
   });
 
@@ -177,9 +185,7 @@ describe('committing a rename', () => {
       { groupId: 'g1', title: 'Research', color: 'blue' },
     ]);
 
-    await user.click(
-      screen.getByRole('button', { name: 'Rename group: Research' })
-    );
+    await user.click(screen.getByRole('button', { name: 'Rename group' }));
     const input = screen.getByRole('textbox', {
       name: 'Rename group: Research',
     });
@@ -195,9 +201,7 @@ describe('committing a rename', () => {
       { groupId: 'g1', title: '', color: 'orange' },
     ]);
 
-    await user.click(
-      screen.getByRole('button', { name: 'Rename group: Unnamed group' })
-    );
+    await user.click(screen.getByRole('button', { name: 'Rename group' }));
     await user.type(
       screen.getByRole('textbox', { name: 'Rename group: Unnamed group' }),
       'Research{Enter}'
@@ -212,9 +216,7 @@ describe('committing a rename', () => {
       { groupId: 'g1', title: 'Research', color: 'blue' },
     ]);
 
-    await user.click(
-      screen.getByRole('button', { name: 'Rename group: Research' })
-    );
+    await user.click(screen.getByRole('button', { name: 'Rename group' }));
     const input = screen.getByRole('textbox', {
       name: 'Rename group: Research',
     });
@@ -230,9 +232,7 @@ describe('committing a rename', () => {
       { groupId: 'g1', title: 'Research', color: 'blue' },
     ]);
 
-    await user.click(
-      screen.getByRole('button', { name: 'Rename group: Research' })
-    );
+    await user.click(screen.getByRole('button', { name: 'Rename group' }));
     const input = screen.getByRole('textbox', {
       name: 'Rename group: Research',
     });
@@ -247,9 +247,7 @@ describe('committing a rename', () => {
     const user = userEvent.setup();
     await renderWindow([{ groupId: 'g1', title: 'Research', color: 'blue' }]);
 
-    await user.click(
-      screen.getByRole('button', { name: 'Rename group: Research' })
-    );
+    await user.click(screen.getByRole('button', { name: 'Rename group' }));
 
     expect(
       screen.getByRole('textbox', { name: 'Rename group: Research' })
@@ -285,9 +283,7 @@ describe('finishing a group rename', () => {
     const user = userEvent.setup();
     await renderWindow([{ groupId: 'g1', title: 'Research', color: 'blue' }]);
 
-    await user.click(
-      screen.getByRole('button', { name: 'Rename group: Research' })
-    );
+    await user.click(screen.getByRole('button', { name: 'Rename group' }));
 
     expect(
       screen.getByRole('button', { name: 'Save changes' })
@@ -309,9 +305,7 @@ describe('finishing a group rename', () => {
       { groupId: 'g1', title: 'Research', color: 'blue' },
     ]);
 
-    await user.click(
-      screen.getByRole('button', { name: 'Rename group: Research' })
-    );
+    await user.click(screen.getByRole('button', { name: 'Rename group' }));
     const input = screen.getByRole('textbox', {
       name: 'Rename group: Research',
     });
@@ -328,9 +322,7 @@ describe('finishing a group rename', () => {
     const user = userEvent.setup();
     await renderWindow([{ groupId: 'g1', title: 'Research', color: 'blue' }]);
 
-    await user.click(
-      screen.getByRole('button', { name: 'Rename group: Research' })
-    );
+    await user.click(screen.getByRole('button', { name: 'Rename group' }));
     await user.click(screen.getByRole('button', { name: 'Save changes' }));
 
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
@@ -349,7 +341,7 @@ describe('finishing a group rename', () => {
 // focus in the input means onClick is the single commit path instead of racing
 // a blur. Asserted at the mechanism, because that is the only place it shows.
 describe('the confirm tick does not blur the field it commits', () => {
-  test.each([['group', 'Rename group: Research']])(
+  test.each([['group', 'Rename group']])(
     '%s tick prevents the default mousedown',
     async (_label, opener) => {
       const user = userEvent.setup();
@@ -381,9 +373,7 @@ describe('the group rename editor fills its row', () => {
   const openEditor = async () => {
     const user = userEvent.setup();
     await renderWindow([{ groupId: 'g1', title: 'Research', color: 'blue' }]);
-    await user.click(
-      screen.getByRole('button', { name: 'Rename group: Research' })
-    );
+    await user.click(screen.getByRole('button', { name: 'Rename group' }));
     return screen.getByRole('textbox', { name: 'Rename group: Research' });
   };
 
@@ -444,9 +434,7 @@ describe('the group title size', () => {
     await renderWindow([{ groupId: 'g1', title: 'Research', color: 'blue' }]);
 
     const labelSize = getComputedStyle(screen.getByText('Research')).fontSize;
-    await user.click(
-      screen.getByRole('button', { name: 'Rename group: Research' })
-    );
+    await user.click(screen.getByRole('button', { name: 'Rename group' }));
     const input = screen.getByRole('textbox', {
       name: 'Rename group: Research',
     });

--- a/src/tests/components/chromeGroupRowActions.test.tsx
+++ b/src/tests/components/chromeGroupRowActions.test.tsx
@@ -401,3 +401,122 @@ describe('the group row stands as tall as the rows around it', () => {
     expect(getComputedStyle(strip).minHeight).toBe('32px');
   });
 });
+
+// Clicking a group row started a RENAME, which no other row in the pane does:
+// the window title opens its window, a tab title opens that tab beside the
+// active one. So renaming had two entry points (row and pencil) while opening
+// the group had none.
+//
+// The row now opens the group's tabs; the pencil is the single way to rename.
+describe('clicking a group row opens its tabs', () => {
+  const openRow = async () => {
+    const user = userEvent.setup();
+    const rendered = await renderRow();
+    await user.click(
+      screen.getByRole('button', { name: 'Open group: Research' })
+    );
+    return rendered;
+  };
+
+  test('is named for opening, containing the group title', async () => {
+    await renderRow();
+
+    expect(
+      screen.getByRole('button', { name: 'Open group: Research' })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Rename group: Research' })
+    ).not.toBeInTheDocument();
+  });
+
+  test('opens every tab in the group and nothing else', async () => {
+    const { chrome } = await openRow();
+
+    expect(chrome.createdTabs.map((t) => t.url)).toEqual([
+      'https://b.co',
+      'https://c.co',
+    ]);
+  });
+
+  // Order is the part that breaks silently: creating each at the SAME index
+  // reverses them, because every insert pushes the previous one right.
+  test('keeps them in stored order, immediately after the active tab', async () => {
+    const { chrome } = await openRow();
+
+    // the fake seeds the active tab at index 0
+    expect(chrome.createdTabs.map((t) => t.index)).toEqual([1, 2]);
+  });
+
+  test('does not start a rename', async () => {
+    await openRow();
+
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  // THE CONTROL. Renaming must still be reachable -- just from one place.
+  test('CONTROL: the pencil still opens the editor', async () => {
+    const user = userEvent.setup();
+    await renderRow();
+
+    await user.click(screen.getByRole('button', { name: 'Rename group' }));
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  // The tabs are re-formed into the saved Chrome group -- same name, same
+  // colour -- rather than opened loose. This is the same shape applyTabGroups
+  // performs on restore, and it reuses that function rather than a second
+  // implementation of "how to make a group".
+  //
+  // No permission gate is needed here: the row only renders at all when
+  // hasTabGroupsPermission is true, so reaching this click already implies it.
+  test('re-forms the saved group around them', async () => {
+    const { chrome } = await openRow();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(chrome.groupedTabs).toHaveLength(1);
+    expect(chrome.groupedTabs[0].tabIds).toHaveLength(2);
+  });
+
+  test('restores the group name and colour', async () => {
+    await openRow();
+    await new Promise((r) => setTimeout(r, 0));
+
+    const groups = await globalThis.chrome.tabGroups.query({});
+    const formed = groups.find((g) => g.title === 'Research');
+
+    expect(formed).toBeDefined();
+    expect(formed?.color).toBe('blue');
+  });
+});
+
+// Two questions raised while building this, both answered by test rather than
+// by argument.
+describe('without the tabGroups permission', () => {
+  // There is nothing to click. partitionTabsIntoRuns is handed `undefined` for
+  // the groups when the permission is absent, so every tab is treated as
+  // ungrouped and no group header is emitted at all.
+  test('no group row is rendered, so the click cannot be reached', async () => {
+    await renderWithProviders(
+      <WindowEntryContainer
+        title="Window 1"
+        tabGroupId="tg"
+        windowId="w"
+        tabs={TABS}
+        chromeTabGroups={GROUPS}
+        onWindowTitleClick={() => undefined}
+        onUpdateWindowGroupTitle={() => undefined}
+        onAddCurrTabToWindowClick={() => undefined}
+        onDeleteClick={() => undefined}
+      />,
+      {
+        seedStore: (store) => store.dispatch(setHasTabGroupsPermission(false)),
+      }
+    );
+
+    expect(screen.queryByRole('group')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Open group/ })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/utils/functions/windows.ts
+++ b/src/utils/functions/windows.ts
@@ -76,7 +76,11 @@ export function isRestoreSessionRequest(
 // still a successful restore; and focus mode decides whether to close the
 // user's windows from createWindowWithRetries' result, so letting a grouping
 // error travel up that path could close windows whose replacements are fine.
-async function applyTabGroups(
+// Exported so the right pane can re-form a saved group when the user opens one
+// from a row, rather than a second implementation of "how to make a group"
+// existing beside this one. The tabGroups feature-detection below is what makes
+// it safe to call without a permission check at the call site.
+export async function applyTabGroups(
   windowId: number,
   groups: TabGroupSpec[],
   tabIdsByGroupId: Map<string, number[]>


### PR DESCRIPTION
Closes KAN-121.

## The gap

Clicking a group row started a **rename** — which no other row in the pane does:

| row | click |
|---|---|
| Window title | opens its window |
| Tab title | opens that tab beside the active one |
| **Group title** | **started a rename** |

So renaming had two entry points (row *and* pencil) while opening the group had none.

## Behaviour

The row opens the group's tabs in the current window, immediately after the active tab, **in stored order**, and re-forms them into the saved Chrome group with its name and colour. The pencil is now the only way to rename.

Three details are load-bearing rather than incidental:

- **The index advances per tab** (`currentTabIndex + 1 + offset`). All at one index *reverses* the group, because each insert pushes the previous one right.
- **Sequential, not `Promise.all`.** Each create carries an explicit index; concurrent inserts resolve those against a list that's still shifting.
- **Only the last tab takes focus**, so you land at the end of what you opened rather than watching focus jump per tab.

**Re-grouping reuses `applyTabGroups`** — the function restore already uses — rather than a second implementation of "how to form a group" living beside it. It was module-private and is now exported.

## The permission question, answered by test

Asked during the work: without `tabGroups`, is the click even reachable?

**No.** `partitionTabsIntoRuns` receives `undefined` for the groups when the permission is absent, so every tab is ungrouped, no group header is emitted, and there's no row to click. Removing that gate fails a test.

There's a second net regardless: `applyTabGroups` opens with `if (typeof chrome === 'undefined' || !chrome.tabGroups) return;` — so a missing namespace leaves the tabs open in order and skips only the grouping. The graceful fallback, for free.

## Accessible name

`Rename group: <title>` → `Open group: <title>`, the tab rows' shape: contains the visible title (WCAG 2.5.3) and says what the control now does. `Rename group` stays on the pencil. One new key across ten locales.

## Fallout

**Sixteen tests in two other files broke**, all opening the editor by clicking the row. That's the correct kind of breakage — they encoded the old entry point — and they now click the pencil. The two asserting the row's name were rewritten to pin the new split: row opens, pencil renames, both named.

## Verification

Real browser, built artifact, group `Booked` (green), three tabs:

```
i:2 /one   g:173253196
i:3 /two   g:173253196
i:4 /three g:173253196
groups: [{ id: 173253196, title: "Booked", color: "green" }]
```

**879 tests pass.** `tsc` clean, lint 0 errors / 25 warnings unchanged, prettier clean.

| mutation | result |
|---|---|
| all tabs at the same index (reverses the group) | 1 fail |
| row goes back to renaming | 3 fail |
| opens only the first tab | 2 fail |
| skip the re-grouping | 2 fail |
| group formed without name/colour | 1 fail |
| permission gate removed from rendering | 1 fail |

🤖 Generated with [Claude Code](https://claude.com/claude-code)