### PR TITLE
Form the group before stealing focus (KAN-122)

### DIFF
--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -396,9 +396,13 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
         created.push(
           await chrome.tabs.create({
             url: resolveTabUrl(tab.url),
-            // Only the last one takes focus, so the user lands at the end of
-            // what they opened instead of watching focus jump per tab.
-            active: offset === run.tabs.length - 1,
+            // Nothing is created focused. Activating a tab DESTROYS the popup,
+            // and everything below -- including the grouping -- is a
+            // continuation of this handler that would simply never run. The
+            // first version created the last tab active and the tabs opened
+            // ungrouped in the real popup, while looking correct when driven
+            // as a tab, which does not die.
+            active: false,
             index: current.index + 1 + offset,
           })
         );
@@ -420,6 +424,10 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
         [run.group],
         new Map([[run.group.groupId, tabIds]])
       );
+
+      // Focus LAST, once the group exists. This is the step that kills the
+      // popup, so nothing may depend on running after it.
+      await chrome.tabs.update(tabIds[tabIds.length - 1], { active: true });
     });
   };
 

--- a/src/tests/components/chromeGroupRowActions.test.tsx
+++ b/src/tests/components/chromeGroupRowActions.test.tsx
@@ -520,3 +520,77 @@ describe('without the tabGroups permission', () => {
     ).not.toBeInTheDocument();
   });
 });
+
+// The real popup is DESTROYED the moment a tab takes focus. The first version
+// of this handler created the last tab with active: true and then awaited
+// applyTabGroups -- so in the real popup the continuation never ran and the
+// tabs opened ungrouped. It looked correct when verified, because the popup was
+// being driven as a TAB, which does not die; e2e/README.md says outright that
+// defects depending on the popup being destroyed are invisible that way.
+//
+// The fix is ordering: nothing may steal focus until the group exists. These
+// assert that ordering rather than the death itself, which jsdom cannot stage.
+describe('opening a group survives the popup closing', () => {
+  test('no tab is created focused', async () => {
+    const user = userEvent.setup();
+    const { chrome } = await renderRow();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Open group: Research' })
+    );
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(chrome.createdTabs.every((t) => t.active !== true)).toBe(true);
+  });
+
+  test('the group is formed before anything is focused', async () => {
+    const user = userEvent.setup();
+    await renderRow();
+
+    const order: string[] = [];
+    const api = globalThis.chrome as unknown as {
+      tabs: {
+        group: (...a: unknown[]) => unknown;
+        update: (...a: unknown[]) => unknown;
+      };
+    };
+    const realGroup = api.tabs.group.bind(api.tabs);
+    const realUpdate = api.tabs.update.bind(api.tabs);
+    api.tabs.group = (...a: unknown[]) => {
+      order.push('group');
+      return realGroup(...a);
+    };
+    api.tabs.update = (...a: unknown[]) => {
+      const props = a[1] as { active?: boolean } | undefined;
+      if (props?.active) order.push('activate');
+      return realUpdate(...a);
+    };
+
+    await user.click(
+      screen.getByRole('button', { name: 'Open group: Research' })
+    );
+    await new Promise((r) => setTimeout(r, 0));
+
+    api.tabs.group = realGroup;
+    api.tabs.update = realUpdate;
+
+    expect(order).toEqual(['group', 'activate']);
+  });
+
+  // THE CONTROL. Never focusing anything would satisfy both assertions above
+  // and would silently drop the behaviour the user asked for -- landing on the
+  // tabs they just opened.
+  test('CONTROL: the last opened tab still ends up focused', async () => {
+    const user = userEvent.setup();
+    await renderRow();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Open group: Research' })
+    );
+    await new Promise((r) => setTimeout(r, 0));
+
+    const tabs = await globalThis.chrome.tabs.query({ currentWindow: true });
+    const opened = tabs.filter((t) => (t.url || '').startsWith('https://'));
+    expect(opened[opened.length - 1].active).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes KAN-122.

## The defect

Clicking a group row opened its tabs but left them **ungrouped** — no colour, no name.

## Root cause: the popup dies mid-handler

The handler created the last tab with `active: true`. **Activating a tab destroys the action popup**, and everything after that point — including `applyTabGroups` — is a continuation of the same async handler. It never runs.

```
create t1 (active:false)  →  ok
create t2 (active:false)  →  ok
create t3 (active:TRUE)   →  popup destroyed here
applyTabGroups(...)       →  never runs
```

## Why my verification missed it

This is the part worth keeping. KAN-121 was verified by driving the popup **as a tab**, the standard recipe here. A tab doesn't die when another tab takes focus, so the continuation ran and the grouping appeared to work.

`e2e/README.md` says so explicitly, under **What this cannot catch**:

> **Popup lifetime.** The popup is driven as a tab, because the real action popup closes the moment focus moves and cannot be automated. Defects that depend on the popup being destroyed are invisible here.

The harness was *documented* as blind to exactly this class of defect, and I still read the result as proof. The general rule: **any handler that activates a tab, focuses a window, or requests a permission must finish its work before that step.**

## Fix

Ordering — nothing steals focus until the group exists:

1. create every tab with `active: false`
2. `applyTabGroups` — the group is formed
3. `chrome.tabs.update(lastId, { active: true })` — the step that kills the popup, with nothing depending on running after it

Routing through the service worker (as restore does) would also work and is more robust, but the reorder suffices because nothing follows the activation.

## Tests

The popup's death can't be staged in jsdom, so the tests pin the **ordering** that makes it survivable:

- no tab is created focused
- the group is formed before anything is focused — call order recorded through the chrome fake
- **CONTROL**: the last opened tab still ends up focused, so "never focus anything" can't pass

| mutation | result |
|---|---|
| focus on create again (the original bug) | 1 fail |
| focus **before** grouping | 1 fail |
| never focus anything | 2 fail (the control) |

**882 tests pass.** `tsc` clean, lint 0 errors / 25 warnings unchanged, prettier clean.

## Verification

Real browser, built artifact:

```
i:2 /one   g:1535296466  active:false
i:3 /two   g:1535296466  active:false
i:4 /three g:1535296466  active:true
groups: [{ title: "Booked", color: "green" }]
```

Grouped, named, coloured, only the last tab focused. This confirms the **outcome** — the popup's destruction still can't be reproduced in this harness, which is precisely the gap that let the original bug through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)