### PR TITLE
Make the whole Chrome group row clickable (KAN-123)

### DIFF
--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -792,7 +792,13 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                         ariaLabel={openGroupLabel(run.group)}
                         tooltipText={t('Open group')}
                         onClick={() => handleGroupClick(run)}
-                        style="display: flex; align-items: center; min-width: 0; width: 100%; padding-right: 100px; box-sizing: border-box;"
+                        // align-self, because the strip centres its children
+                        // -- without it the clickable is only as tall as its
+                        // text and the row has 8px of dead zone above and
+                        // below, while the hover fill paints the full 32px.
+                        // The tab rows get this from their parent's
+                        // align-items: stretch; this strip has to ask.
+                        style="display: flex; align-items: center; align-self: stretch; min-width: 0; width: 100%; padding-right: 100px; box-sizing: border-box;"
                       >
                         {groupTitleLabel(run.group)}
                       </ClickableRow>

--- a/src/tests/components/chromeGroupRowActions.test.tsx
+++ b/src/tests/components/chromeGroupRowActions.test.tsx
@@ -594,3 +594,34 @@ describe('opening a group survives the popup closing', () => {
     expect(opened[opened.length - 1].active).toBe(true);
   });
 });
+
+// The row LOOKS 32px tall -- the hover fill paints the whole strip -- but the
+// clickable element was only as tall as its text. Measured in a browser:
+// strip 32px, clickable 17px, 8px of dead zone above and below. Aiming at the
+// grey band did nothing near its edges.
+//
+// The tab rows do not have this problem: their parent uses
+// `align-items: stretch`, so the clickable fills the row. The group strip
+// centres its children instead, so the row has to stretch itself.
+//
+// Asserted at the mechanism -- jsdom performs no layout, so every rect is 0
+// and the rendered height cannot be checked here. Verified in a browser.
+describe('the group row is clickable across its whole height', () => {
+  test('the clickable stretches to the row rather than to its text', async () => {
+    await renderRow();
+
+    const row = screen.getByRole('button', { name: 'Open group: Research' });
+
+    expect(getComputedStyle(row).alignSelf).toBe('stretch');
+  });
+
+  // THE CONTROL. Stretching the row must not come at the cost of the label
+  // still being centred within it -- otherwise the text would sit at the top.
+  test('CONTROL: the row still centres its label', async () => {
+    await renderRow();
+
+    const row = screen.getByRole('button', { name: 'Open group: Research' });
+
+    expect(getComputedStyle(row).alignItems).toBe('center');
+  });
+});


### PR DESCRIPTION
Closes KAN-123.

## The defect

The row paints a hover fill across its full height, but clicking near the top or bottom of that band did nothing.

```
groupStripHeight:     32
groupClickableHeight: 17     ← barely half
deadTop: 8   deadBottom: 8
```

The row advertised a target it didn't have. It only became noticeable once KAN-115 gave the row a fill and KAN-116 raised it to 32px — before that, the gap between what was painted and what was clickable was small enough to miss.

## Root cause

The group strip centres its children (`align-items: center`), so the `ClickableRow` sizes to its text.

The tab rows don't have this problem, and the difference is one line: their parent uses `align-items: stretch`, so their clickable fills the row for free. Measured on the same page — `tabClickableHeight: 32`, `tabFillsItsRow: true`.

## Fix

`align-self: stretch` on the row's `ClickableRow`. Same fix and same reason as **KAN-114**, which stretched the rename input in this identical strip.

## Tests

jsdom performs no layout — every rect is 0 — so the rendered height can't be asserted there. The test pins the mechanism, and the hit area is verified in a browser.

A control asserts the row still **centres its label**, so stretching can't be achieved by letting the text ride to the top.

| mutation | result |
|---|---|
| drop `align-self` from the row | 1 fail |
| stretch but stop centring the label | 1 fail (the control) |

**A mutation that appeared to pass, and hadn't landed.** My first attempt removed the string `align-self: stretch` with a single replace — and hit the **rename input's** copy from KAN-114, which appears earlier in the file, leaving the row untouched. The test rightly still passed. Retargeting at the row's own style string made it fail.

Worth stating: when a mutation "survives", check it reached what it was aimed at before concluding the test is weak.

**884 tests pass.** `tsc` clean, lint 0 errors / 25 warnings unchanged, prettier clean.

## Verification

Real browser, hit-testing the band at three heights:

```
stripHeight 32, clickableHeight 32, deadTop 0, deadBottom 0
hitsAtTopEdge true, hitsAtMiddle true, hitsAtBottomEdge true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)