### PR TITLE
Release 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,22 @@ Your sessions are stored locally on your device. When device sync is enabled, sa
 
 ## Changelog
 
-### v.1.6.1 (Latest)
+### v.1.7.0 (Latest)
+
+#### Features
+
+- Rename a saved Chrome tab group, and clear its name again, without opening the session
+- Change a saved tab group's color from the colored bar beside it
+- Click a saved tab group to open its tabs next to the current one, re-formed in Chrome as the group you saved
+- Add the current tab to a saved tab group, ungroup it, or delete the group and its tabs
+
+#### Fixes
+
+- Renaming a session now has a visible tick to finish with, like renaming a window already did
+- The window rename box now shows its tick without hovering, and runs to the edge of its row
+- Settings sections now have even space on both sides instead of sitting off-center
+
+### v.1.6.1
 
 #### Fixes
 
@@ -81,36 +96,6 @@ Your sessions are stored locally on your device. When device sync is enabled, sa
 #### Improvements
 
 - The app no longer makes failing cloud requests while it is still signing in
-
-### v.1.5.0
-
-#### Features
-
-- Save just the current window as a session, instead of always saving every open window
-- Every button, list row and menu item can now be reached with Tab and used with Enter or Space
-- Screen readers now announce every control correctly, and in your own language rather than in English
-- Disabled controls are no longer focusable, and are announced as disabled instead of as ordinary buttons
-
-#### Fixes
-
-- Renaming a session no longer loses what you have typed when a sync or an undo arrives while you are editing
-- An undone rename no longer reappears on the next sync
-- Redo now works on macOS, where the Cmd+Shift+Z shortcut previously did nothing at all
-- Cmd+Z inside a text field now undoes your typing instead of the app's last action
-- Typing in the search box no longer clears the redo history or floods the undo history
-- Search results now report how many matches were found, instead of repeating the session's own window and tab counts
-- Sessions are now ordered and dated by the instant they were created, so their order no longer depends on the device's clock
-- The focus-mode confirmation no longer says your windows are "already saved" when there was nothing to save
-- Focus mode no longer saves popup windows that it cannot reopen later
-- A session too large to sync is now refused with an explanation, instead of leaving sync stuck for good
-- Selecting or searching a session no longer changes when that session was last modified, which could let an older copy win a sync
-- The message shown when a sync fails now appears in your own language
-- The area around the app now follows your chosen theme instead of staying grey
-- Icon spacing inside buttons now renders as intended
-
-#### Improvements
-
-- Selecting or searching a session no longer triggers a cloud sync
 
 [View All Changelog →](https://github.com/justine-george/tab-keeper-react-chrome-extension/wiki/Changelog)
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -61,7 +61,7 @@ the manual chrome-devtools loop repeatable.
 All measured, not assumed — each cost a debugging cycle to find:
 
 - **`channel: 'chromium'` is required.** Plain `headless: true` uses the
-  headless *shell*, which never loads the extension: the service worker never
+  headless _shell_, which never loads the extension: the service worker never
   registers and `waitForEvent('serviceworker')` times out.
 - **`context.serviceWorkers()` is empty immediately after launch**, in every
   mode. Always await the `serviceworker` event; a bare `[0]` throws every run.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tab-keeper-react-chrome-extension",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tab-keeper-react-chrome-extension",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.11.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Justine George",
   "description": "Efficiently save and synchronize tabs across devices without the need for personal logins.",
   "private": true,
-  "version": "1.6.1",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "1.6.1",
+  "version": "1.7.0",
   "name": "Tab Keeper - Chrome Tab Manager & Sync Tool",
   "description": "Efficiently save and synchronize tabs across devices without the need for personal logins.",
   "action": {


### PR DESCRIPTION
Cuts 1.7.0. Eighteen commits since `v1.6.1`, all of them tab-group work bar one settings fix.

## Why MINOR and not PATCH

Seventeen Jira tickets, and most are typed **Bug** — which makes a patch look right and isn't. Thirteen of them fix defects in features that are **themselves new in this release**: reported, filed and fixed inside the unreleased window, never seen by a user. What actually reaches a user is four new capabilities plus one changed behaviour.

| Reaches a user | |
|---|---|
| **Feature** | Rename a saved Chrome tab group (KAN-107) |
| **Feature** | Change a group's colour from its coloured bar (KAN-124) |
| **Feature** | Click a group row to open its tabs, re-formed in Chrome (KAN-121) |
| **Feature** | Add current tab / ungroup / delete group, behind a new overflow menu (KAN-110) |
| **Changed** | Clicking a group row used to start a rename; it now opens the group |
| **Fix** | Session rename had no visible way to finish (KAN-113) |
| **Fix** | Window rename box hid its tick and stopped short of its row (KAN-117) |
| **Fix** | Settings sections inset on the left only (KAN-118) |

Repo convention agrees: 1.4.0 / 1.5.0 / 1.6.0 for feature work, 1.4.1 / 1.6.1 for fix-only.

## Changelog scope, and what was deliberately left out

Only the three fixes above get a line, because only those three touch behaviour that shipped. **Verified against the tag rather than assumed** — each surface exists at `077acd3`:

```
KAN-113  session rename editor present at 1.6.1   (isEditing ×4)
KAN-117  window rename editor present at 1.6.1    (isEditing ×7)
KAN-118  clamp(16px inset present ×7, padding-right absent ×0
```

**KAN-125 gets no line, and that is worth stating explicitly.** It is a data-loss bug — an undone tab-group edit silently reversed by the next sync — so it looks like the headline fix. It isn't, because it was **unreachable in 1.6.1**: at that tag there were **zero** reducers that mutate `chromeTabGroups`, so no session could carry a group edit to undo. Checked, not assumed:

```
$ git show 077acd3:...tabContainerDataStateSlice.ts | grep -E '^    (updateChromeTabGroup|ungroup|delete...)'
NONE
```

It became reachable only via KAN-107/110/124, all shipping here. I'd earlier called it "a data-loss bug anyone on 1.6.1 still has" — that was wrong, and this is the correction.

The other twelve (KAN-111, 112, 114, 115, 116, 119, 120, 122, 123, and KAN-125) are all defects in this release's own new features. Same precedent as KAN-105/KAN-102 getting no line for being test-only: the changelog records what changed *for a user*.

## Changes

- `package.json`, `public/manifest.json`, `package-lock.json` → **1.7.0** (via `npm run bump-version minor`)
- README changelog gains `v.1.7.0 (Latest)`; 1.6.1 demoted, **1.5.0 drops off**, keeping the latest three

## Verification

Built artifact, checked after the build rather than assumed:

| Check | Result |
|---|---|
| `dist/manifest.json` version | **1.7.0** |
| `permissions` / `optional_permissions` | `["tabs","storage","favicon"]` / `["tabGroups"]` — unchanged |
| Service worker declared | `{"service_worker":"background.js","type":"module"}` |
| Locales in artifact | 10 (de en es fr hi it ja pt ru zh) |
| New features present in bundle | `Change group color` ✓ `Rename group` ✓ `Open group` ✓ `Ungroup` ✓ |
| Remotely hosted script URLs | **none** — ran the workflow's own grep |
| Unit / component | **917 passed** (95 files) |
| E2E | **64 passed** |
| `tsc` | clean |
| `eslint src e2e` | 0 errors, 25 warnings — baseline unchanged |
| `prettier --check` | clean |

One note on that remote-code row: a broad `https?://[^"' ]*\.js` grep returns 2 hits, which are `redux.js.org/Errors` and `redux-toolkit.js.org/Errors` documentation URLs inside error messages — not script sources. The workflow's actual pattern (`apis\.google\.com|www\.google\.com/recaptcha`) returns nothing.

## Follow-ups, not in this PR

- **The wiki changelog needs the same 1.7.0 section** — the README must stay a byte-identical prefix of it.
- The Web Store listing changelog is written separately and deliberately plainer than this one.
- `pending-release` is currently on the 17 tickets in this release. It comes off when the Web Store **publishes**, not when it is submitted — review can reject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
