### PR TITLE
Name tab groups in the store description (KAN-126)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tab-keeper-react-chrome-extension",
   "author": "Justine George",
-  "description": "Efficiently save and synchronize tabs across devices without the need for personal logins.",
+  "description": "Save your Chrome windows, tabs and tab groups as sessions, then sync them across desktops. No account or email needed.",
   "private": true,
   "version": "1.7.0",
   "type": "module",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "version": "1.7.0",
   "name": "Tab Keeper - Chrome Tab Manager & Sync Tool",
-  "description": "Efficiently save and synchronize tabs across devices without the need for personal logins.",
+  "description": "Save your Chrome windows, tabs and tab groups as sessions, then sync them across desktops. No account or email needed.",
   "action": {
     "default_popup": "index.html",
     "default_icon": "icons/icon128.png",

--- a/src/tests/config/storeDescription.test.ts
+++ b/src/tests/config/storeDescription.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest';
+
+import manifest from '../../../public/manifest.json';
+import pkg from '../../../package.json';
+
+// The manifest's `description` is the extension's SHORT description: what the
+// Chrome Web Store prints under the name in search results, and what every link
+// preview card renders when the listing URL is shared. It is not a dashboard
+// field -- it ships inside the package, so a wrong one cannot be corrected on
+// the listing and has to wait for the next release and its review cycle.
+//
+// KAN-126: it went three releases describing the pre-1.6.0 product, never
+// mentioning tab groups, because nothing here looks at it.
+//
+// The copy itself is deliberately NOT pinned -- asserting an exact sentence
+// only restates it, and would fail on any future reword for no reason. What is
+// pinned are the two properties that make a wrong value expensive.
+describe('store short description', () => {
+  // Chrome rejects an over-long description at UPLOAD time, so the feedback
+  // arrives at submission -- after a version bump, a tagged release and a green
+  // build, at the one moment the cost of a round trip is highest.
+  test('is within the 132-character limit the Web Store enforces', () => {
+    expect(manifest.description.length).toBeLessThanOrEqual(132);
+  });
+
+  test('is not empty', () => {
+    expect(manifest.description.trim()).not.toBe('');
+  });
+
+  // The same sentence is duplicated in package.json, and nothing keeps the two
+  // in step. They agree today only because they have always been edited
+  // together; the failure mode is editing one and shipping the other.
+  test('is identical in package.json', () => {
+    expect(pkg.description).toBe(manifest.description);
+  });
+});


### PR DESCRIPTION
## What

`public/manifest.json`'s `description` is the extension's **short description** — what the Chrome Web Store prints under the name in search results, and what every link preview card renders when the listing URL is shared.

It read:

> Efficiently save and synchronize tabs across devices without the need for personal logins.

That describes the pre-1.6.0 product. Tab groups have been the headline of 1.6.0, 1.6.1 and 1.7.0 and got no mention. It surfaced from a link card sitting directly beneath a post announcing tab groups and saying nothing about them.

Now, **118 characters against a limit of 132**:

> Save your Chrome windows, tabs and tab groups as sessions, then sync them across desktops. No account or email needed.

`package.json` carries the same string and moves with it.

## Notes

- **Not a dashboard edit.** The short description ships inside the package, so it can't be fixed on the listing — it waits for the next release and its review cycle.
- **Not localized.** No `public/_locales`, no `default_locale`, no `__MSG_` in the manifest. One English string in two files, not eleven.
- **"No account or email needed" is a claim about Tab Keeper, not about Chrome.** Sync rides `chrome.storage.sync` and therefore the user's Chrome profile. That qualifier doesn't fit in 132 characters and belongs in the dashboard's long description, which is editable independently of any release and is not part of this change.

## Tests

`src/tests/config/storeDescription.test.ts`, 3 tests.

The copy itself is deliberately **not** pinned. Asserting the exact sentence only restates it and would fail on any future reword for no reason. What's pinned are the two properties that make a wrong value expensive:

| property | why it matters |
| --- | --- |
| length ≤ 132 | Chrome rejects an over-long description at **upload** time — feedback arrives after a version bump, a tag and a green build, when a round trip costs most |
| agrees with `package.json` | `sync-versions` copies only the *version* between the two files, never the description. Nothing kept these in step; they agreed only because they'd always been edited together |

Each assertion was checked against a mutation rather than assumed:

| mutation | result |
| --- | --- |
| description → 133 chars | `× is within the 132-character limit` |
| description → whitespace only | `× is not empty` |
| `package.json` description changed alone | `× is identical in package.json` |

All three return to green on revert.

## Gates

- **920 tests / 96 files** passed
- `tsc --noEmit` — 0
- `npm run lint` — 0 errors / 25 warnings (baseline)
- `prettier --check` — clean on all three changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)