### PR TITLE
Drag to reorder tabs within a saved window (KAN-10)

### DIFF
--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -1,4 +1,9 @@
-import React, { MouseEventHandler, useState } from 'react';
+import React, {
+  MouseEventHandler,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -25,6 +30,7 @@ import {
   ungroupChromeTabGroup,
   deleteChromeTabGroupInternal,
   updateChromeTabGroupColor,
+  moveTabInternal,
 } from '../../../redux/slices/tabContainerDataStateSlice';
 import { useTranslation } from 'react-i18next';
 import { v4 as uuidv4 } from 'uuid';
@@ -34,6 +40,7 @@ import type {
   TabRun,
 } from '../../../utils/functions/tabGroups';
 import { applyTabGroups } from '../../../utils/functions/windows';
+import { TabDragArea, DraggableTab } from './tabDrag/TabDragArea';
 
 interface WindowEntryContainerProps {
   title: string;
@@ -83,9 +90,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
   // equal z-indexes leave DOM order deciding -- and a LOWER group's strip then
   // painted over an open menu belonging to the group above it.
   const [openMenuGroupId, setOpenMenuGroupId] = useState<string | null>(null);
-  const [hoveredChildIndex, setHoveredChildIndex] = useState<number | null>(
-    null
-  );
+  const [hoveredTabId, setHoveredTabId] = useState<string | null>(null);
 
   const isSearchPanel = useSelector(
     (state: RootState) => state.globalState.isSearchPanel
@@ -102,6 +107,28 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
   // way, only the grouping UI disappears.
   const hasTabGroupsPermission = useSelector(
     (state: RootState) => state.globalState.hasTabGroupsPermission
+  );
+
+  const tabIds = useMemo(() => tabs.map((tab) => tab.tabId), [tabs]);
+  // Position by id, so the run rendering does not need indexOf per row.
+  const indexOfTab = useMemo(
+    () => new Map(tabs.map((tab, i) => [tab.tabId, i])),
+    [tabs]
+  );
+
+  const handleMove = useCallback(
+    (tabId: string, toIndex: number, toChromeGroupId?: string) => {
+      dispatch(
+        moveTabInternal({
+          tabGroupId,
+          windowId,
+          tabId,
+          toIndex,
+          toChromeGroupId,
+        })
+      );
+    },
+    [dispatch, tabGroupId, windowId]
   );
 
   const containerStyle = css`
@@ -196,17 +223,17 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     min-width: 0;
   `;
 
-  const childRightStyle = (index: number) => css`
+  const childRightStyle = (tabId: string) => css`
     position: absolute;
     top: 50%;
     right: 0;
     transform: translateY(-50%);
     /* Mask in one frame, icons ease -- see parentRightStyle (KAN-100). */
-    background-color: ${hoveredChildIndex === index
+    background-color: ${hoveredTabId === tabId
       ? COLORS.HOVER_COLOR
       : 'transparent'};
     & > * {
-      opacity: ${hoveredChildIndex === index ? 1 : 0};
+      opacity: ${hoveredTabId === tabId ? 1 : 0};
       transition: opacity 0.1s ease-out;
     }
     /* The keyboard's equivalent of the hover reveal (KAN-68). Delete tab has
@@ -439,18 +466,19 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     }
   }
 
-  // `index` is hover bookkeeping against hoveredChildIndex, which is this
-  // component's own state -- it is not an identity for the row and must not
-  // be used as the key. Callers pass tabs.indexOf(tabItem) so the count runs
-  // across the whole window rather than restarting inside each group's run;
-  // getting that wrong makes hovering one tab highlight another.
-  function renderTab({ tabId, favicon, title, url }: tabData, index: number) {
+  // Hover is tracked by tabId, not by position (KAN-127). A position-keyed
+  // flag points at whichever tab has since moved into that slot, so anything
+  // that reorders the list -- a sync adopting the other device's window, or a
+  // drag -- reveals the wrong row's actions. It also removes the cross-run
+  // index arithmetic this used to need, since a run's local index and the
+  // window-wide one no longer have to be reconciled.
+  function renderTab({ tabId, favicon, title, url }: tabData) {
     return (
       <div
         key={tabId}
         css={childrenStyle}
-        onMouseEnter={() => setHoveredChildIndex(index)}
-        onMouseLeave={() => setHoveredChildIndex(null)}
+        onMouseEnter={() => setHoveredTabId(tabId)}
+        onMouseLeave={() => setHoveredTabId(null)}
       >
         {/* The name reuses the string the tooltip already carried, so no new
             hardcoded English enters the app -- the 25 untranslated
@@ -476,7 +504,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
             />
           </div>
         </ClickableRow>
-        <div css={childRightStyle(index)}>
+        <div css={childRightStyle(tabId)}>
           <Icon
             tooltipText={t('Delete tab')}
             ariaLabel={t('Delete tab')}
@@ -631,28 +659,36 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
       </div>
       {windowOpenState && (
         <div css={childrenContainerStyle}>
-          {partitionTabsIntoRuns(
-            tabs,
-            hasTabGroupsPermission ? chromeTabGroups : undefined
-          ).map((run, runIndex) =>
-            run.kind === 'ungrouped' ? (
-              <React.Fragment key={`ungrouped-${runIndex}`}>
-                {run.tabs.map((tabItem) =>
-                  renderTab(tabItem, tabs.indexOf(tabItem))
-                )}
-              </React.Fragment>
-            ) : (
-              <div
-                key={run.group.groupId}
-                role="group"
-                aria-label={run.group.title || t('Unnamed group')}
-                css={css`
-                  display: flex;
-                  align-items: stretch;
-                  margin: 2px 0;
-                `}
-              >
-                {/* The colour is Chrome's own group identity, not app chrome
+          <TabDragArea tabIds={tabIds} onMove={handleMove}>
+            {partitionTabsIntoRuns(
+              tabs,
+              hasTabGroupsPermission ? chromeTabGroups : undefined
+            ).map((run, runIndex) =>
+              run.kind === 'ungrouped' ? (
+                <React.Fragment key={`ungrouped-${runIndex}`}>
+                  {run.tabs.map((tabItem) => (
+                    <DraggableTab
+                      key={tabItem.tabId}
+                      tabId={tabItem.tabId}
+                      index={indexOfTab.get(tabItem.tabId) ?? 0}
+                    >
+                      {renderTab(tabItem)}
+                    </DraggableTab>
+                  ))}
+                </React.Fragment>
+              ) : (
+                <div
+                  key={run.group.groupId}
+                  data-band-id={run.group.groupId}
+                  role="group"
+                  aria-label={run.group.title || t('Unnamed group')}
+                  css={css`
+                    display: flex;
+                    align-items: stretch;
+                    margin: 2px 0;
+                  `}
+                >
+                  {/* The colour is Chrome's own group identity, not app chrome
                     (BINDING CONSTRAINT 1) -- TAB_GROUP_COLOR_HEX is a fixed
                     map, not routed through useThemeColors, so it reads the
                     same in every theme as it does in the browser.
@@ -664,30 +700,32 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                     repeating the group name the role="group" boundary above
                     already announces. The band stays a sibling of the header
                     strip so it spans the whole group, as Chrome's does. */}
-                <GroupColorPicker
-                  color={run.group.color}
-                  decorative={isSearchPanel}
-                  ariaLabel={
-                    t('Change group color') + ': ' + groupDisplayName(run.group)
-                  }
-                  onSelect={(color) =>
-                    dispatch(
-                      updateChromeTabGroupColor({
-                        tabGroupId,
-                        windowId,
-                        groupId: run.group.groupId,
-                        color,
-                      })
-                    )
-                  }
-                />
-                <div
-                  css={css`
-                    flex: 1;
-                    min-width: 0;
-                  `}
-                >
-                  {/* The group's header strip.
+                  <GroupColorPicker
+                    color={run.group.color}
+                    decorative={isSearchPanel}
+                    ariaLabel={
+                      t('Change group color') +
+                      ': ' +
+                      groupDisplayName(run.group)
+                    }
+                    onSelect={(color) =>
+                      dispatch(
+                        updateChromeTabGroupColor({
+                          tabGroupId,
+                          windowId,
+                          groupId: run.group.groupId,
+                          color,
+                        })
+                      )
+                    }
+                  />
+                  <div
+                    css={css`
+                      flex: 1;
+                      min-width: 0;
+                    `}
+                  >
+                    {/* The group's header strip.
 
                       This REPLACES the older rule that an untitled group
                       renders as the band alone (BINDING CONSTRAINT 2). That
@@ -703,19 +741,19 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                       The placeholder is italic and one label tier dimmer than
                       a real name so it does not read as content -- the group
                       is not called "Unnamed group", it has no name. */}
-                  <div
-                    css={css`
-                      position: relative;
-                      display: flex;
-                      align-items: center;
-                      /* 32px, the height the window row and every tab row
+                    <div
+                      css={css`
+                        position: relative;
+                        display: flex;
+                        align-items: center;
+                        /* 32px, the height the window row and every tab row
                          already stand at -- measured, not guessed. At 22px the
                          hover fill read as a short band wedged between
                          full-height ones. It is also exactly the action icons'
                          height, so they now fit the row rather than
                          overflowing a shorter one. */
-                      min-height: 32px;
-                      /* Fills like the window row above and the tab rows
+                        min-height: 32px;
+                        /* Fills like the window row above and the tab rows
                          below, which both paint HOVER_COLOR under the pointer.
                          Without it this row revealed its actions while giving
                          no sign of being hovered at all.
@@ -728,222 +766,232 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                          No transition on the fill, also KAN-100 -- easing it
                          lets the row reach the colour in two halves with a
                          visible edge between them. */
-                      &:hover,
-                      &:focus-within {
-                        background-color: ${COLORS.HOVER_COLOR};
-                      }
-                      &:hover .group-rename-reveal,
-                      &:focus-within .group-rename-reveal {
-                        opacity: 1;
-                      }
-                    `}
-                  >
-                    {editingGroupId === run.group.groupId && !isSearchPanel ? (
-                      <input
-                        value={groupDraft}
-                        aria-label={renameGroupLabel(run.group)}
-                        onBlur={() => commitGroupRename(run.group)}
-                        onChange={(e) => setGroupDraft(e.target.value)}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter') commitGroupRename(run.group);
-                        }}
-                        autoFocus
-                        css={css`
-                          color: ${COLORS.TEXT_COLOR};
-                          background-color: ${COLORS.PRIMARY_COLOR};
-                          border: 1px solid ${COLORS.BORDER_COLOR};
-                          /* Same four declarations the window title editor
+                        &:hover,
+                        &:focus-within {
+                          background-color: ${COLORS.HOVER_COLOR};
+                        }
+                        &:hover .group-rename-reveal,
+                        &:focus-within .group-rename-reveal {
+                          opacity: 1;
+                        }
+                      `}
+                    >
+                      {editingGroupId === run.group.groupId &&
+                      !isSearchPanel ? (
+                        <input
+                          value={groupDraft}
+                          aria-label={renameGroupLabel(run.group)}
+                          onBlur={() => commitGroupRename(run.group)}
+                          onChange={(e) => setGroupDraft(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') commitGroupRename(run.group);
+                          }}
+                          autoFocus
+                          css={css`
+                            color: ${COLORS.TEXT_COLOR};
+                            background-color: ${COLORS.PRIMARY_COLOR};
+                            border: 1px solid ${COLORS.BORDER_COLOR};
+                            /* Same four declarations the window title editor
                              carries. Without height and padding the field
                              collapsed to the intrinsic height of its text and
                              sat 2px short of its own row, with the browser's
                              default 2px padding rather than a chosen one --
                              which read as a thinner, tighter box than the
                              editor one level above it. */
-                          display: flex;
-                          align-items: center;
-                          font-family: ${FONT_FAMILY};
-                          /* Matches the label this replaces, or the text
+                            display: flex;
+                            align-items: center;
+                            font-family: ${FONT_FAMILY};
+                            /* Matches the label this replaces, or the text
                              visibly jumps size on entering edit mode. */
-                          font-size: 0.85rem;
-                          padding-left: 8px;
-                          /* align-self, NOT height: 100%. The strip is a flex
+                            font-size: 0.85rem;
+                            padding-left: 8px;
+                            /* align-self, NOT height: 100%. The strip is a flex
                              container with align-items: center and only a
                              min-height, so it has no definite height for a
                              percentage to resolve against and the child is not
                              stretched -- height: 100% computed, rendered
                              nothing, and left the field 2px short of its row.
                              Stretching the item is what actually fills it. */
-                          align-self: stretch;
-                          width: 100%;
-                          min-width: 0;
-                          &:focus {
-                            outline: none;
-                          }
-                        `}
-                      />
-                    ) : isSearchPanel ? (
-                      // A control that cannot act must not be focusable and
-                      // inert (KAN-62), so searching gets static text.
-                      groupTitleLabel(run.group)
-                    ) : (
-                      // WCAG 2.5.3, same shape as KAN-77: the accessible name
-                      // CONTAINS the visible one, so "click Research" works.
-                      // padding-right reserves the action block's width so a
-                      // long title ellipsizes instead of rendering UNDER the
-                      // icons. The block is absolutely positioned -- kept that
-                      // way deliberately, so the title does not reflow and
-                      // jump when the icons appear on hover -- which means
-                      // layout gives it no room unless it is reserved here.
-                      // Measured at 100/125/150% zoom before and after.
-                      <ClickableRow
-                        ariaLabel={openGroupLabel(run.group)}
-                        tooltipText={t('Open group')}
-                        onClick={() => handleGroupClick(run)}
-                        // align-self, because the strip centres its children
-                        // -- without it the clickable is only as tall as its
-                        // text and the row has 8px of dead zone above and
-                        // below, while the hover fill paints the full 32px.
-                        // The tab rows get this from their parent's
-                        // align-items: stretch; this strip has to ask.
-                        style="display: flex; align-items: center; align-self: stretch; min-width: 0; width: 100%; padding-right: 100px; box-sizing: border-box;"
-                      >
-                        {groupTitleLabel(run.group)}
-                      </ClickableRow>
-                    )}
-                    {editingGroupId === run.group.groupId && !isSearchPanel && (
-                      // Same shape as the other two ticks: the wrapper stops
-                      // the post-commit click retargeting onto the pencil, and
-                      // preventDefault keeps focus in the input so onClick is
-                      // the single commit path.
-                      <span
-                        className="group-rename-reveal"
-                        css={css`
-                          position: absolute;
-                          top: 50%;
-                          right: 0;
-                          transform: translateY(-50%);
-                          opacity: 1;
-                          display: flex;
-                          align-items: center;
-                          z-index: 1;
-                        `}
-                        onMouseDown={(e) => e.preventDefault()}
-                      >
-                        <Icon
-                          tooltipText={t('Save changes')}
-                          ariaLabel={t('Save changes')}
-                          type="done"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            commitGroupRename(run.group);
-                          }}
+                            align-self: stretch;
+                            width: 100%;
+                            min-width: 0;
+                            &:focus {
+                              outline: none;
+                            }
+                          `}
                         />
-                      </span>
-                    )}
-                    {editingGroupId !== run.group.groupId && !isSearchPanel && (
-                      <div
-                        className="group-rename-reveal"
-                        css={css`
-                          position: absolute;
-                          top: 50%;
-                          right: 0;
-                          transform: translateY(-50%);
-                          opacity: 0;
-                          transition: opacity 0.1s ease-out;
-                          display: flex;
-                          align-items: center;
-                          /* Load-bearing, and only visible in a real browser.
+                      ) : isSearchPanel ? (
+                        // A control that cannot act must not be focusable and
+                        // inert (KAN-62), so searching gets static text.
+                        groupTitleLabel(run.group)
+                      ) : (
+                        // WCAG 2.5.3, same shape as KAN-77: the accessible name
+                        // CONTAINS the visible one, so "click Research" works.
+                        // padding-right reserves the action block's width so a
+                        // long title ellipsizes instead of rendering UNDER the
+                        // icons. The block is absolutely positioned -- kept that
+                        // way deliberately, so the title does not reflow and
+                        // jump when the icons appear on hover -- which means
+                        // layout gives it no room unless it is reserved here.
+                        // Measured at 100/125/150% zoom before and after.
+                        <ClickableRow
+                          ariaLabel={openGroupLabel(run.group)}
+                          tooltipText={t('Open group')}
+                          onClick={() => handleGroupClick(run)}
+                          // align-self, because the strip centres its children
+                          // -- without it the clickable is only as tall as its
+                          // text and the row has 8px of dead zone above and
+                          // below, while the hover fill paints the full 32px.
+                          // The tab rows get this from their parent's
+                          // align-items: stretch; this strip has to ask.
+                          style="display: flex; align-items: center; align-self: stretch; min-width: 0; width: 100%; padding-right: 100px; box-sizing: border-box;"
+                        >
+                          {groupTitleLabel(run.group)}
+                        </ClickableRow>
+                      )}
+                      {editingGroupId === run.group.groupId &&
+                        !isSearchPanel && (
+                          // Same shape as the other two ticks: the wrapper stops
+                          // the post-commit click retargeting onto the pencil, and
+                          // preventDefault keeps focus in the input so onClick is
+                          // the single commit path.
+                          <span
+                            className="group-rename-reveal"
+                            css={css`
+                              position: absolute;
+                              top: 50%;
+                              right: 0;
+                              transform: translateY(-50%);
+                              opacity: 1;
+                              display: flex;
+                              align-items: center;
+                              z-index: 1;
+                            `}
+                            onMouseDown={(e) => e.preventDefault()}
+                          >
+                            <Icon
+                              tooltipText={t('Save changes')}
+                              ariaLabel={t('Save changes')}
+                              type="done"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                commitGroupRename(run.group);
+                              }}
+                            />
+                          </span>
+                        )}
+                      {editingGroupId !== run.group.groupId &&
+                        !isSearchPanel && (
+                          <div
+                            className="group-rename-reveal"
+                            css={css`
+                              position: absolute;
+                              top: 50%;
+                              right: 0;
+                              transform: translateY(-50%);
+                              opacity: 0;
+                              transition: opacity 0.1s ease-out;
+                              display: flex;
+                              align-items: center;
+                              /* Load-bearing, and only visible in a real browser.
                              translateY above makes this element a STACKING
                              CONTEXT, which traps the overflow menu's own
                              z-index inside it -- the menu then painted behind
                              the tab rows below, which are later siblings with
                              position: relative. Lifting the context itself is
                              what puts the menu over them. */
-                          /* The row owning an open menu outranks its
+                              /* The row owning an open menu outranks its
                              siblings; see openMenuGroupId above. */
-                          z-index: ${openMenuGroupId === run.group.groupId
-                            ? 3
-                            : 1};
-                        `}
-                      >
-                        <Icon
-                          tooltipText={t('Rename group')}
-                          ariaLabel={t('Rename group')}
-                          type="edit"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            startEditingGroup(run.group);
-                          }}
-                        />
-                        <Icon
-                          tooltipText={t('Add current tab to group')}
-                          ariaLabel={t('Add current tab to group')}
-                          type="add"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            addCurrentTabToGroup(run.group);
-                          }}
-                        />
-                        {/* Ungroup and delete live behind the overflow rather
+                              z-index: ${openMenuGroupId === run.group.groupId
+                                ? 3
+                                : 1};
+                            `}
+                          >
+                            <Icon
+                              tooltipText={t('Rename group')}
+                              ariaLabel={t('Rename group')}
+                              type="edit"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                startEditingGroup(run.group);
+                              }}
+                            />
+                            <Icon
+                              tooltipText={t('Add current tab to group')}
+                              ariaLabel={t('Add current tab to group')}
+                              type="add"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                addCurrentTabToGroup(run.group);
+                              }}
+                            />
+                            {/* Ungroup and delete live behind the overflow rather
                             than as two more icons: four 32px icons overlap a
                             long title from 125% zoom, and "Ungroup" is not a
                             concept named anywhere else in this UI, so it needs
                             a word rather than a glyph. */}
-                        <OverflowMenu
-                          ariaLabel={t('More actions')}
-                          // Guarded on identity rather than assigning blindly:
-                          // opening a second menu closes the first, and the
-                          // close can land after the open, which would
-                          // otherwise clear the row that just opened.
-                          onOpenChange={(open) =>
-                            setOpenMenuGroupId((prev) =>
-                              open
-                                ? run.group.groupId
-                                : prev === run.group.groupId
-                                  ? null
-                                  : prev
-                            )
-                          }
-                          items={[
-                            {
-                              key: 'ungroup',
-                              label: t('Ungroup'),
-                              icon: 'label_off',
-                              onSelect: () =>
-                                dispatch(
-                                  ungroupChromeTabGroup({
-                                    tabGroupId,
-                                    windowId,
-                                    groupId: run.group.groupId,
-                                  })
-                                ),
-                            },
-                            {
-                              key: 'delete',
-                              label: t('Delete group'),
-                              icon: 'delete',
-                              danger: true,
-                              onSelect: () =>
-                                dispatch(
-                                  deleteChromeTabGroupInternal({
-                                    tabGroupId,
-                                    windowId,
-                                    groupId: run.group.groupId,
-                                  })
-                                ),
-                            },
-                          ]}
-                        />
-                      </div>
-                    )}
+                            <OverflowMenu
+                              ariaLabel={t('More actions')}
+                              // Guarded on identity rather than assigning blindly:
+                              // opening a second menu closes the first, and the
+                              // close can land after the open, which would
+                              // otherwise clear the row that just opened.
+                              onOpenChange={(open) =>
+                                setOpenMenuGroupId((prev) =>
+                                  open
+                                    ? run.group.groupId
+                                    : prev === run.group.groupId
+                                      ? null
+                                      : prev
+                                )
+                              }
+                              items={[
+                                {
+                                  key: 'ungroup',
+                                  label: t('Ungroup'),
+                                  icon: 'label_off',
+                                  onSelect: () =>
+                                    dispatch(
+                                      ungroupChromeTabGroup({
+                                        tabGroupId,
+                                        windowId,
+                                        groupId: run.group.groupId,
+                                      })
+                                    ),
+                                },
+                                {
+                                  key: 'delete',
+                                  label: t('Delete group'),
+                                  icon: 'delete',
+                                  danger: true,
+                                  onSelect: () =>
+                                    dispatch(
+                                      deleteChromeTabGroupInternal({
+                                        tabGroupId,
+                                        windowId,
+                                        groupId: run.group.groupId,
+                                      })
+                                    ),
+                                },
+                              ]}
+                            />
+                          </div>
+                        )}
+                    </div>
+                    {run.tabs.map((tabItem) => (
+                      <DraggableTab
+                        key={tabItem.tabId}
+                        tabId={tabItem.tabId}
+                        index={indexOfTab.get(tabItem.tabId) ?? 0}
+                      >
+                        {renderTab(tabItem)}
+                      </DraggableTab>
+                    ))}
                   </div>
-                  {run.tabs.map((tabItem) =>
-                    renderTab(tabItem, tabs.indexOf(tabItem))
-                  )}
                 </div>
-              </div>
-            )
-          )}
+              )
+            )}
+          </TabDragArea>
         </div>
       )}
     </div>

--- a/src/components/home/rightpane/tabDrag/TabDragArea.tsx
+++ b/src/components/home/rightpane/tabDrag/TabDragArea.tsx
@@ -1,0 +1,279 @@
+// Drag to reorder tabs within a saved window (KAN-10 part 1), driven directly
+// by pointer events.
+//
+// Chosen over @dnd-kit after building both and measuring: dnd-kit cost 14.91 kB
+// gzip against 1.47 kB here (a 10x difference, ~9% of the whole gzipped bundle),
+// its default `attributes` nested a button around every row and announced a
+// keyboard drag this feature does not ship, and owning the motion outright
+// keeps the reorder animation in the same system as the micro-animations
+// planned for these rows rather than composing around a library's.
+//
+// The keyboard is deliberately not a path here: ClickableRow already binds
+// Enter and Space to "open the tab", so a keyboard pick-up would need its own
+// affordance. Opening, deleting and renaming all remain keyboard-operable.
+//
+// TWO ELEMENTS, TWO JOBS. This node owns transform, transition, the lift shadow
+// and z-index; the row inside it keeps background-color for selection and the
+// inset shadow for hover, and its own transform stays free. Never move a row
+// state onto this node's transform, or the reorder motion and that state will
+// fight over one channel.
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import {
+  ACTIVATION_DISTANCE_PX,
+  bandAt,
+  setBodyGrabbing,
+  type DraggableTabProps,
+  type TabDragAreaProps,
+} from './dropRules';
+
+interface DragState {
+  tabId: string;
+  fromIndex: number;
+  toIndex: number;
+  // How far the held row has travelled from where it was picked up.
+  offset: number;
+  height: number;
+}
+
+interface Ctx {
+  register: (tabId: string, el: HTMLElement | null) => void;
+  begin: (tabId: string, clientX: number, clientY: number) => void;
+  drag: DragState | null;
+}
+
+const DragContext = React.createContext<Ctx | null>(null);
+
+interface Rect {
+  id: string;
+  index: number;
+  mid: number;
+  height: number;
+}
+
+export const TabDragArea: React.FC<TabDragAreaProps> = ({
+  tabIds,
+  onMove,
+  children,
+}) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const rows = useRef(new Map<string, HTMLElement>());
+  const [drag, setDrag] = useState<DragState | null>(null);
+
+  // Everything the live drag needs, kept in a ref so the window listeners are
+  // installed once rather than re-bound on every pointermove.
+  const live = useRef<{
+    tabId: string;
+    startX: number;
+    startY: number;
+    started: boolean;
+    rects: Rect[];
+    fromIndex: number;
+    height: number;
+    lastX: number;
+    lastY: number;
+  } | null>(null);
+
+  // Chrome synthesizes a `click` after `mouseup`, aimed at whatever the pointer
+  // released over -- which is the held row, because it tracks the pointer. Left
+  // alone it runs the row's onClick and opens the tab the user just dragged.
+  //
+  // A timestamp rather than an add/remove-listener dance: the click arrives in
+  // the same input sequence as the pointerup that arms this, and a listener
+  // removed on a timer can race that sequence in either direction. Spending the
+  // window on the first swallowed click is what stops the NEXT ordinary click
+  // being eaten too.
+  const suppressClickUntil = useRef(0);
+
+  const register = useCallback((tabId: string, el: HTMLElement | null) => {
+    if (el) rows.current.set(tabId, el);
+    else rows.current.delete(tabId);
+  }, []);
+
+  const begin = useCallback(
+    (tabId: string, clientX: number, clientY: number) => {
+      live.current = {
+        tabId,
+        startX: clientX,
+        startY: clientY,
+        started: false,
+        rects: [],
+        fromIndex: tabIds.indexOf(tabId),
+        height: 0,
+        lastX: clientX,
+        lastY: clientY,
+      };
+    },
+    [tabIds]
+  );
+
+  useEffect(() => {
+    const onMoveEvent = (e: PointerEvent) => {
+      const l = live.current;
+      if (!l) return;
+      l.lastX = e.clientX;
+      l.lastY = e.clientY;
+
+      if (!l.started) {
+        const travelled = Math.hypot(
+          e.clientX - l.startX,
+          e.clientY - l.startY
+        );
+        // Below the threshold this is still a click, and the row's own
+        // onClick must be allowed to fire untouched.
+        if (travelled < ACTIVATION_DISTANCE_PX) return;
+
+        // Measured once, at the moment the drag actually starts: reading rects
+        // on every move would report positions already displaced by the shifts
+        // this drag is applying.
+        l.rects = tabIds.map((id, index) => {
+          const el = rows.current.get(id);
+          const r = el?.getBoundingClientRect();
+          return {
+            id,
+            index,
+            mid: r ? r.top + r.height / 2 : 0,
+            height: r?.height ?? 0,
+          };
+        });
+        l.height = l.rects[l.fromIndex]?.height ?? 0;
+        l.started = true;
+        setBodyGrabbing(true);
+      }
+
+      const others = l.rects.filter((r) => r.id !== l.tabId);
+      // The count of rows whose midpoint the pointer has passed IS the index
+      // the tab lands at, because that count indexes the list with the held
+      // row already lifted out of it.
+      const toIndex = others.filter((r) => e.clientY > r.mid).length;
+
+      setDrag({
+        tabId: l.tabId,
+        fromIndex: l.fromIndex,
+        toIndex,
+        offset: e.clientY - l.startY,
+        height: l.height,
+      });
+    };
+
+    const finish = (commit: boolean) => {
+      const l = live.current;
+      live.current = null;
+      setDrag(null);
+      if (!l) return;
+      setBodyGrabbing(false);
+      // Below the threshold this was a click, not a drag, and the row's own
+      // handler must run untouched.
+      if (!l.started) return;
+
+      // Armed for a real drag whether it committed or was cancelled with Esc:
+      // in both cases the user was dragging, and in neither did they ask for
+      // the tab to open.
+      suppressClickUntil.current = performance.now() + 400;
+
+      if (commit) {
+        const others = l.rects.filter((r) => r.id !== l.tabId);
+        const toIndex = others.filter((r) => l.lastY > r.mid).length;
+        const group = bandAt(containerRef.current, l.lastX, l.lastY);
+        onMove(l.tabId, toIndex, group);
+      }
+    };
+
+    const onUp = () => finish(true);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') finish(false);
+    };
+    const onCancel = () => finish(false);
+    // Capture, on window: this has to run before React's root delegation gets
+    // the chance to dispatch the row's onClick.
+    const onClickCapture = (e: MouseEvent) => {
+      if (performance.now() >= suppressClickUntil.current) return;
+      suppressClickUntil.current = 0;
+      e.preventDefault();
+      e.stopPropagation();
+    };
+
+    window.addEventListener('pointermove', onMoveEvent);
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onCancel);
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('click', onClickCapture, true);
+    return () => {
+      window.removeEventListener('pointermove', onMoveEvent);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onCancel);
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('click', onClickCapture, true);
+      // A drag interrupted by unmount must not leave the document stuck in
+      // `grabbing`.
+      setBodyGrabbing(false);
+    };
+  }, [tabIds, onMove]);
+
+  const ctx = useMemo<Ctx>(
+    () => ({ register, begin, drag }),
+    [register, begin, drag]
+  );
+
+  return (
+    <div ref={containerRef}>
+      <DragContext.Provider value={ctx}>{children}</DragContext.Provider>
+    </div>
+  );
+};
+
+export const DraggableTab: React.FC<DraggableTabProps & { index: number }> = ({
+  tabId,
+  index,
+  children,
+}) => {
+  const ctx = useContext(DragContext);
+  const drag = ctx?.drag ?? null;
+
+  let translate = 0;
+  const held = drag?.tabId === tabId;
+
+  if (drag) {
+    if (held) {
+      translate = drag.offset;
+    } else if (drag.toIndex > drag.fromIndex) {
+      // Dragging down: everything it has passed moves up one slot.
+      if (index > drag.fromIndex && index <= drag.toIndex)
+        translate = -drag.height;
+    } else if (drag.toIndex < drag.fromIndex) {
+      if (index >= drag.toIndex && index < drag.fromIndex)
+        translate = drag.height;
+    }
+  }
+
+  return (
+    <div
+      ref={(el) => ctx?.register(tabId, el)}
+      onPointerDown={(e) => {
+        // Left button only, and never from inside the action strip -- the
+        // delete icon is a button, not a drag handle.
+        if (e.button !== 0) return;
+        ctx?.begin(tabId, e.clientX, e.clientY);
+      }}
+      style={{
+        transform: translate ? `translateY(${translate}px)` : undefined,
+        // The held row must track the pointer exactly; only the rows moving
+        // aside are animated.
+        transition: held ? 'none' : 'transform 0.18s ease',
+        boxShadow: held ? '0 2px 8px rgba(0,0,0,0.35)' : undefined,
+        zIndex: held ? 1 : undefined,
+        position: 'relative',
+        cursor: 'pointer',
+      }}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/components/home/rightpane/tabDrag/dropRules.ts
+++ b/src/components/home/rightpane/tabDrag/dropRules.ts
@@ -1,0 +1,54 @@
+// What a drag MEANS, kept apart from how it is driven.
+//
+// TabDragArea beside this file owns the pointer mechanics; this owns the rules
+// those mechanics apply, so each can be read and changed without the other.
+// `bandAt` in particular is the whole membership decision in one testable
+// function.
+import type { ReactNode } from 'react';
+
+export const ACTIVATION_DISTANCE_PX = 5;
+
+export interface TabDragAreaProps {
+  // Flat, in render order. Index into this is what onMove's toIndex means.
+  tabIds: string[];
+  onMove: (tabId: string, toIndex: number, toChromeGroupId?: string) => void;
+  children: ReactNode;
+}
+
+export interface DraggableTabProps {
+  tabId: string;
+  children: ReactNode;
+}
+
+// THE DROP RULE: the band decides. A tab released while the pointer is inside a
+// group's band -- padding included, since getBoundingClientRect covers it --
+// joins that group; anywhere else it lands ungrouped.
+//
+// Resolved from rects rather than from the engine's own collision result, so
+// both prototypes answer this question identically. Bands are marked with
+// data-band-id in WindowEntryContainer.
+export function bandAt(
+  container: HTMLElement | null,
+  x: number,
+  y: number
+): string | undefined {
+  if (!container) return undefined;
+  for (const band of container.querySelectorAll<HTMLElement>(
+    '[data-band-id]'
+  )) {
+    const r = band.getBoundingClientRect();
+    if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) {
+      return band.dataset.bandId;
+    }
+  }
+  return undefined;
+}
+
+// `grabbing` goes on the document, not on the row. During a drag the pointer
+// travels over other rows, gaps and bands, and a cursor scoped to the source
+// element reverts the moment it leaves -- which reads as the drag letting go.
+export function setBodyGrabbing(on: boolean): void {
+  document.body.style.cursor = on ? 'grabbing' : '';
+  // Without this the browser selects row text as the pointer sweeps the list.
+  document.body.style.userSelect = on ? 'none' : '';
+}

--- a/src/redux/middleware/customMiddleware.ts
+++ b/src/redux/middleware/customMiddleware.ts
@@ -26,6 +26,7 @@ import {
   UNGROUP_CHROME_GROUP_ACTION,
   RECOLOUR_CHROME_GROUP_ACTION,
   DELETE_CHROME_GROUP_ACTION,
+  MOVE_TAB_ACTION,
 } from '../../utils/constants/actionTypes';
 import type { RootState } from '../store';
 
@@ -50,6 +51,7 @@ const actionsToCapture = [
   DELETE_TAB_CONTAINER_ACTION,
   DELETE_WINDOW_ACTION,
   DELETE_TAB_ACTION,
+  MOVE_TAB_ACTION,
 
   // actions in globalStateSlice
   IS_DIRTY_ACTION,

--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -163,6 +163,27 @@ export interface openWindowParams {
   windowId: string;
 }
 
+// Move a tab to a position within its own window, and to whatever Chrome group
+// owns that position.
+//
+// Position and membership travel together because grouping is a property on the
+// tab rather than a nested collection: a group is a run of the flat array, so
+// "where it sits" and "what it belongs to" are one answer, not two.
+//
+// toChromeGroupId is RESOLVED BY THE CALLER, never inferred here. The drop knows
+// which band the pointer was over; recovering that from an index would mean
+// reconstructing band geometry inside a reducer.
+export interface moveTabParams {
+  tabGroupId: string;
+  windowId: string;
+  // Identity, not a position: the source index is looked up, so a stale index
+  // from a list that moved under the caller cannot move the wrong tab.
+  tabId: string;
+  toIndex: number;
+  // Absent means ungrouped.
+  toChromeGroupId?: string;
+}
+
 export const initialState: TabMasterContainer = {
   lastModified: Date.now(), // timestamp
   selectedTabGroupId: null,
@@ -1160,6 +1181,88 @@ export const tabContainerDataStateSlice = createSlice({
       saveToLocalStorage('tabContainerData', state);
     },
 
+    // move a tab within its window, and into whatever Chrome group owns the
+    // destination
+    moveTabInternal: (state, action: PayloadAction<moveTabParams>) => {
+      const { tabGroupId, windowId, tabId, toIndex, toChromeGroupId } =
+        action.payload;
+
+      const container = state.tabGroups.find(
+        (group) => group.tabGroupId === tabGroupId
+      );
+      if (!container) return;
+      const windowGroup = container.windows.find(
+        (w) => w.windowId === windowId
+      );
+      if (!windowGroup) return;
+      const fromIndex = windowGroup.tabs.findIndex((t) => t.tabId === tabId);
+      // Same shape as the sibling reducers: an id that does not resolve means
+      // the action arrived for data that is no longer there, and doing nothing
+      // is the correct outcome.
+      if (fromIndex === -1) return;
+
+      // toIndex is where the tab ends up in the RESULT, so it indexes the array
+      // with the tab lifted out -- whose last valid index is length - 1 here,
+      // before the removal below.
+      //
+      // Both bounds are resolved rather than left to splice, because this value
+      // is also compared against fromIndex just below, and a raw out-of-range
+      // toIndex would not equal the index it is going to land on.
+      const target = Math.min(
+        Math.max(0, toIndex),
+        windowGroup.tabs.length - 1
+      );
+
+      // A drop that lands the tab where it started, in the group it was already
+      // in, is not an edit. Without this it would stamp the session, write
+      // localStorage, dirty the container for a cloud write and push an undo
+      // step -- for something the user cannot see. Picking a tab up and putting
+      // it back is ordinary. BOTH axes have to match: dropping in place but
+      // inside a band is a real membership change.
+      const current = windowGroup.tabs[fromIndex];
+      if (target === fromIndex && current.chromeGroupId === toChromeGroupId) {
+        return;
+      }
+
+      const [moved] = windowGroup.tabs.splice(fromIndex, 1);
+      const fromChromeGroupId = moved.chromeGroupId;
+      windowGroup.tabs.splice(target, 0, moved);
+
+      // `delete`, not `= undefined`. Absent is the stored representation, and
+      // Firestore's setDoc rejects an explicit undefined outright (KAN-48).
+      if (toChromeGroupId === undefined) {
+        delete moved.chromeGroupId;
+      } else {
+        moved.chromeGroupId = toChromeGroupId;
+      }
+
+      // Only the group the tab LEFT can have emptied.
+      //
+      // ORDER IS LOAD-BEARING: this runs after the tab is back in the array
+      // carrying its NEW membership, so a tab reordered inside its own group
+      // still answers `some` and the group is never a prune candidate. That is
+      // what removes the need for an explicit "source is not the destination"
+      // case. Run this while the tab is spliced out and a single-member group
+      // deletes itself on every reorder.
+      if (
+        fromChromeGroupId !== undefined &&
+        !windowGroup.tabs.some((t) => t.chromeGroupId === fromChromeGroupId)
+      ) {
+        windowGroup.chromeTabGroups = (
+          windowGroup.chromeTabGroups ?? []
+        ).filter((group) => group.groupId !== fromChromeGroupId);
+      }
+
+      // touch, not stampCreated: a reorder is an edit, and stampCreated would
+      // reset createdAt, which is what the merge orders the session list by.
+      // Nudging a tab must not send its session to the top of the left pane.
+      touch(container);
+      state.lastModified = Date.now();
+
+      // update localstorage
+      saveToLocalStorage('tabContainerData', state);
+    },
+
     replaceState: (state, action: PayloadAction<typeof state>) => {
       // update localstorage
       saveToLocalStorage('tabContainerData', action.payload);
@@ -1425,6 +1528,7 @@ export const {
   deleteTabContainerInternal,
   deleteWindowInternal,
   deleteTabInternal,
+  moveTabInternal,
   replaceState,
   restoreContainer,
   applyUndoSnapshot,

--- a/src/tests/components/dragSuppressesClick.test.tsx
+++ b/src/tests/components/dragSuppressesClick.test.tsx
@@ -1,0 +1,130 @@
+import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+
+import WindowEntryContainer from '../../components/home/rightpane/WindowEntryContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import { setHasTabGroupsPermission } from '../../redux/slices/globalStateSlice';
+import type { tabData } from '../../redux/slices/tabContainerDataStateSlice';
+
+// A drag must not also open the tab it moved.
+//
+// Chrome synthesizes a `click` after `mouseup`, and the held row is translated
+// to follow the pointer, so the row is still the target at release. Measured in
+// the real popup: the click reaches the row's ClickableRow and opens the tab --
+// but ONLY when the drop commits no reorder. A committed move makes React move
+// the DOM node during the pointerup handler, before the click is dispatched,
+// which is what swallowed it and made the bug look intermittent. The drags that
+// move nothing are precisely the ones that open a tab.
+//
+// jsdom does not synthesize a click from a pointer sequence, so the click is
+// dispatched explicitly here -- which is exactly what the browser does, and
+// what the suppression has to intercept.
+
+const TABS: tabData[] = [
+  { tabId: 't1', favicon: '', title: 'One', url: 'https://one.test' },
+  { tabId: 't2', favicon: '', title: 'Two', url: 'https://two.test' },
+  { tabId: 't3', favicon: '', title: 'Three', url: 'https://three.test' },
+];
+
+const render = () =>
+  renderWithProviders(
+    <WindowEntryContainer
+      title="Window 1"
+      tabGroupId="tg1"
+      windowId="w1"
+      tabs={TABS}
+      onWindowTitleClick={() => undefined}
+      onUpdateWindowGroupTitle={() => undefined}
+      onAddCurrTabToWindowClick={() => undefined}
+      onDeleteClick={() => undefined}
+    />,
+    {
+      seedStore: (store) => {
+        store.dispatch(setHasTabGroupsPermission(false));
+      },
+    }
+  );
+
+// labelled element (ClickableRow) -> row div -> the draggable node
+const draggableFor = (title: string): HTMLElement => {
+  const el = screen.getByLabelText(`Open in new tab: ${title}`);
+  const node = el.parentElement?.parentElement;
+  if (!node) throw new Error(`no draggable node for ${title}`);
+  return node as HTMLElement;
+};
+
+describe('a drag does not also open the tab', () => {
+  let seen: number;
+  let spy: (e: Event) => void;
+
+  beforeEach(() => {
+    seen = 0;
+    spy = () => {
+      seen += 1;
+    };
+    // Bubble phase on document is where React's root delegation sits, so a
+    // click this listener never sees is a click no row handler runs on.
+    document.addEventListener('click', spy);
+  });
+
+  afterEach(() => {
+    document.removeEventListener('click', spy);
+    vi.useRealTimers();
+  });
+
+  // THE CONTROL. Without it, a suppression that swallowed EVERY click would
+  // pass the test below while breaking the pane's primary action.
+  test('CONTROL: a plain click with no drag still reaches the row', async () => {
+    await render();
+    const node = draggableFor('Two');
+
+    fireEvent.pointerDown(node, { clientX: 10, clientY: 20, button: 0 });
+    fireEvent.pointerUp(document, { clientX: 10, clientY: 20, button: 0 });
+    fireEvent.click(node, { clientX: 10, clientY: 20 });
+
+    expect(seen).toBe(1);
+  });
+
+  // A press that wanders below the activation distance is still a click, and
+  // must still open the tab.
+  test('CONTROL: a press that never crosses the threshold still clicks', async () => {
+    await render();
+    const node = draggableFor('Two');
+
+    fireEvent.pointerDown(node, { clientX: 10, clientY: 20, button: 0 });
+    fireEvent.pointerMove(document, { clientX: 11, clientY: 22, button: 0 });
+    fireEvent.pointerUp(document, { clientX: 11, clientY: 22, button: 0 });
+    fireEvent.click(node, { clientX: 11, clientY: 22 });
+
+    expect(seen).toBe(1);
+  });
+
+  test('the click that follows a real drag is swallowed', async () => {
+    await render();
+    const node = draggableFor('Two');
+
+    fireEvent.pointerDown(node, { clientX: 10, clientY: 20, button: 0 });
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 60, button: 0 });
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 100, button: 0 });
+    fireEvent.pointerUp(document, { clientX: 10, clientY: 100, button: 0 });
+    fireEvent.click(node, { clientX: 10, clientY: 100 });
+
+    expect(seen).toBe(0);
+  });
+
+  // The suppression must be spent by the drag it belongs to. Left armed, the
+  // NEXT ordinary click on any row would be eaten instead.
+  test('only the one click is swallowed, not the next one', async () => {
+    await render();
+    const node = draggableFor('Two');
+
+    fireEvent.pointerDown(node, { clientX: 10, clientY: 20, button: 0 });
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 100, button: 0 });
+    fireEvent.pointerUp(document, { clientX: 10, clientY: 100, button: 0 });
+    fireEvent.click(node, { clientX: 10, clientY: 100 });
+    expect(seen).toBe(0);
+
+    fireEvent.click(draggableFor('Three'), { clientX: 10, clientY: 140 });
+    expect(seen).toBe(1);
+  });
+});

--- a/src/tests/components/tabDragArea.test.tsx
+++ b/src/tests/components/tabDragArea.test.tsx
@@ -1,0 +1,252 @@
+import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import {
+  TabDragArea,
+  DraggableTab,
+} from '../../components/home/rightpane/tabDrag/TabDragArea';
+import { bandAt } from '../../components/home/rightpane/tabDrag/dropRules';
+
+// The drag layer on its own, without WindowEntryContainer around it. What is
+// pinned here is the BEHAVIOUR the pane relies on -- when a drag starts, where
+// it says the tab landed, which group it says the tab joined, and what happens
+// when it is abandoned.
+//
+// jsdom reports every rect as zero, so the midpoint arithmetic that decides the
+// landing index would be untestable as-is: every row would share a midpoint of
+// 0 and every drag would compute the same answer. The rows are given real boxes
+// below. Row n occupies [n*30, n*30+30), so the midpoints are 15, 45 and 75.
+const ROW_H = 30;
+
+const box = (top: number, height: number, left = 0, width = 200) =>
+  ({
+    top,
+    bottom: top + height,
+    left,
+    right: left + width,
+    height,
+    width,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+type OnMove = (tabId: string, toIndex: number, group?: string) => void;
+
+const Harness = ({ onMove }: { onMove: OnMove }) => (
+  <TabDragArea tabIds={['a', 'b', 'c']} onMove={onMove}>
+    {/* Row `a` sits inside a band; `b` and `c` do not. */}
+    <div data-band-id="grp" data-testid="band">
+      <DraggableTab tabId="a" index={0}>
+        <div>Row A</div>
+      </DraggableTab>
+    </div>
+    <DraggableTab tabId="b" index={1}>
+      <div>Row B</div>
+    </DraggableTab>
+    <DraggableTab tabId="c" index={2}>
+      <div>Row C</div>
+    </DraggableTab>
+  </TabDragArea>
+);
+
+// The draggable node is the parent of the row content.
+const nodeFor = (label: string) => screen.getByText(label).parentElement!;
+
+const layout = () => {
+  ['Row A', 'Row B', 'Row C'].forEach((label, i) => {
+    const el = nodeFor(label);
+    el.getBoundingClientRect = () => box(i * ROW_H, ROW_H);
+  });
+  // The band wraps row A and, per the drop rule, its padding counts as inside.
+  const band = screen.getByTestId('band');
+  band.getBoundingClientRect = () => box(-2, ROW_H + 4);
+};
+
+const press = (label: string, y: number) =>
+  fireEvent.pointerDown(nodeFor(label), { clientX: 10, clientY: y, button: 0 });
+const moveTo = (y: number) =>
+  fireEvent.pointerMove(document, { clientX: 10, clientY: y, button: 0 });
+const release = (y: number) =>
+  fireEvent.pointerUp(document, { clientX: 10, clientY: y, button: 0 });
+
+describe('what a drag reports when it lands', () => {
+  let onMove: ReturnType<typeof vi.fn<OnMove>>;
+
+  beforeEach(() => {
+    onMove = vi.fn<OnMove>();
+    render(<Harness onMove={onMove} />);
+    layout();
+  });
+
+  afterEach(() => {
+    document.body.style.cursor = '';
+  });
+
+  test('dragging to the top of the list lands at index 0', () => {
+    press('Row C', 75);
+    moveTo(40);
+    moveTo(5);
+    release(5);
+
+    expect(onMove).toHaveBeenCalledTimes(1);
+    expect(onMove.mock.calls[0][0]).toBe('c');
+    expect(onMove.mock.calls[0][1]).toBe(0);
+  });
+
+  test('dragging to the bottom lands at the last index', () => {
+    press('Row A', 15);
+    moveTo(50);
+    moveTo(85);
+    release(85);
+
+    expect(onMove.mock.calls[0][1]).toBe(2);
+  });
+
+  // The midpoint is the boundary, not the row's edge: a tab has to pass the
+  // middle of its neighbour before it is considered past it.
+  test('stopping short of the next midpoint does not advance the index', () => {
+    press('Row A', 15);
+    moveTo(40); // below Row B's midpoint of 45
+    release(40);
+
+    expect(onMove.mock.calls[0][1]).toBe(0);
+  });
+
+  test('releasing inside a band joins that group', () => {
+    press('Row C', 75);
+    moveTo(40);
+    moveTo(5); // inside the band's box
+    release(5);
+
+    expect(onMove.mock.calls[0][2]).toBe('grp');
+  });
+
+  test('releasing outside every band joins no group', () => {
+    press('Row A', 15);
+    moveTo(50);
+    moveTo(85);
+    release(85);
+
+    expect(onMove.mock.calls[0][2]).toBeUndefined();
+  });
+});
+
+describe('when a drag should not happen at all', () => {
+  let onMove: ReturnType<typeof vi.fn<OnMove>>;
+
+  beforeEach(() => {
+    onMove = vi.fn<OnMove>();
+    render(<Harness onMove={onMove} />);
+    layout();
+  });
+
+  afterEach(() => {
+    document.body.style.cursor = '';
+  });
+
+  test('a press that never crosses the threshold reports no move', () => {
+    press('Row A', 15);
+    moveTo(17); // 2px, under the 5px activation distance
+    release(17);
+
+    expect(onMove).not.toHaveBeenCalled();
+  });
+
+  test('Escape abandons the drag without moving anything', () => {
+    press('Row A', 15);
+    moveTo(85);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    release(85);
+
+    expect(onMove).not.toHaveBeenCalled();
+  });
+
+  test('a right-button press does not begin a drag', () => {
+    fireEvent.pointerDown(nodeFor('Row A'), {
+      clientX: 10,
+      clientY: 15,
+      button: 2,
+    });
+    moveTo(85);
+    release(85);
+
+    expect(onMove).not.toHaveBeenCalled();
+  });
+});
+
+describe('the cursor while dragging', () => {
+  let onMove: ReturnType<typeof vi.fn<OnMove>>;
+
+  beforeEach(() => {
+    onMove = vi.fn<OnMove>();
+    render(<Harness onMove={onMove} />);
+    layout();
+  });
+
+  afterEach(() => {
+    document.body.style.cursor = '';
+  });
+
+  // On the document, not the row: during a drag the pointer travels over other
+  // rows and gaps, and a cursor scoped to the source element reverts as soon as
+  // it leaves, which reads as the drag letting go.
+  test('the document shows grabbing during the drag and clears after', () => {
+    press('Row A', 15);
+    moveTo(50);
+    expect(document.body.style.cursor).toBe('grabbing');
+
+    release(50);
+    expect(document.body.style.cursor).toBe('');
+  });
+
+  test('Escape also clears it', () => {
+    press('Row A', 15);
+    moveTo(50);
+    expect(document.body.style.cursor).toBe('grabbing');
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(document.body.style.cursor).toBe('');
+  });
+
+  test('a press below the threshold never sets it', () => {
+    press('Row A', 15);
+    moveTo(17);
+    expect(document.body.style.cursor).toBe('');
+    release(17);
+  });
+});
+
+// bandAt is the whole membership decision, so it is worth pinning on its own
+// rather than only through a drag.
+describe('bandAt', () => {
+  const container = () => {
+    const root = document.createElement('div');
+    const band = document.createElement('div');
+    band.dataset.bandId = 'grp';
+    band.getBoundingClientRect = () => box(10, 40, 0, 100);
+    root.appendChild(band);
+    return root;
+  };
+
+  test('a point inside the band resolves to its group', () => {
+    expect(bandAt(container(), 50, 30)).toBe('grp');
+  });
+
+  test('a point above the band resolves to no group', () => {
+    expect(bandAt(container(), 50, 5)).toBeUndefined();
+  });
+
+  test('a point beside the band resolves to no group', () => {
+    expect(bandAt(container(), 150, 30)).toBeUndefined();
+  });
+
+  test('the boundary counts as inside, so the padding is part of the band', () => {
+    expect(bandAt(container(), 50, 10)).toBe('grp');
+    expect(bandAt(container(), 50, 50)).toBe('grp');
+  });
+
+  test('no container resolves to no group rather than throwing', () => {
+    expect(bandAt(null, 50, 30)).toBeUndefined();
+  });
+});

--- a/src/tests/components/tabHoverSurvivesReorder.test.tsx
+++ b/src/tests/components/tabHoverSurvivesReorder.test.tsx
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+
+import WindowEntryContainer from '../../components/home/rightpane/WindowEntryContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import { setHasTabGroupsPermission } from '../../redux/slices/globalStateSlice';
+import type { tabData } from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-127. The row's hover reveal was keyed by POSITION
+// (`hoveredChildIndex === index`), so anything that reordered the tab list left
+// the wrong row's delete icon showing. Reachable today through a sync adopting
+// the other device's window under a stationary pointer, and routine once
+// drag-to-reorder ships.
+//
+// Probed on the action block's own `background-color`, which is a direct
+// property on that element, rather than on the `& > *` opacity rule beside it:
+// jsdom does not resolve child combinators for computed style, which is how
+// three earlier versions of a sibling test passed against the bug it was
+// written for.
+
+const TABS: tabData[] = [
+  { tabId: 't1', favicon: '', title: 'One', url: 'https://one.test' },
+  { tabId: 't2', favicon: '', title: 'Two', url: 'https://two.test' },
+  { tabId: 't3', favicon: '', title: 'Three', url: 'https://three.test' },
+];
+
+const render = (tabs: tabData[]) =>
+  renderWithProviders(
+    <WindowEntryContainer
+      title="Window 1"
+      tabGroupId="tg1"
+      windowId="w1"
+      tabs={tabs}
+      onWindowTitleClick={() => undefined}
+      onUpdateWindowGroupTitle={() => undefined}
+      onAddCurrTabToWindowClick={() => undefined}
+      onDeleteClick={() => undefined}
+    />,
+    {
+      seedStore: (store) => {
+        store.dispatch(setHasTabGroupsPermission(false));
+      },
+    }
+  );
+
+// The row is the nearest ancestor of the tab's link that also contains an
+// absolutely positioned action block.
+const rowFor = (title: string): HTMLElement => {
+  let node: HTMLElement | null = screen.getByLabelText(
+    `Open in new tab: ${title}`
+  );
+  while (node && getComputedStyle(node).position !== 'relative') {
+    node = node.parentElement;
+  }
+  if (!node) throw new Error(`no row found for ${title}`);
+  return node;
+};
+
+const actionBlockFor = (title: string): HTMLElement => {
+  const row = rowFor(title);
+  const block = [...row.children].find(
+    (child) => getComputedStyle(child as HTMLElement).position === 'absolute'
+  );
+  if (!block) throw new Error(`no action block found for ${title}`);
+  return block as HTMLElement;
+};
+
+const TRANSPARENT = 'rgba(0, 0, 0, 0)';
+const isRevealed = (title: string) =>
+  getComputedStyle(actionBlockFor(title)).backgroundColor !== TRANSPARENT;
+
+describe('a tab row keeps its hover state when the list reorders', () => {
+  test('CONTROL: hovering a row reveals that row and no other', async () => {
+    await render(TABS);
+
+    expect(isRevealed('Two')).toBe(false);
+
+    fireEvent.mouseEnter(rowFor('Two'));
+
+    expect(isRevealed('Two')).toBe(true);
+    expect(isRevealed('One')).toBe(false);
+    expect(isRevealed('Three')).toBe(false);
+  });
+
+  test('the reveal follows the tab, not the position it used to sit at', async () => {
+    const { rerender } = await render(TABS);
+
+    fireEvent.mouseEnter(rowFor('Two'));
+    expect(isRevealed('Two')).toBe(true);
+
+    // Two moves to the front. Nothing about the pointer changed, so no
+    // mouseleave fires -- which is exactly the sync case.
+    const reordered = [TABS[1], TABS[0], TABS[2]];
+    rerender(
+      <WindowEntryContainer
+        title="Window 1"
+        tabGroupId="tg1"
+        windowId="w1"
+        tabs={reordered}
+        onWindowTitleClick={() => undefined}
+        onUpdateWindowGroupTitle={() => undefined}
+        onAddCurrTabToWindowClick={() => undefined}
+        onDeleteClick={() => undefined}
+      />
+    );
+
+    expect(isRevealed('Two')).toBe(true);
+    expect(isRevealed('One')).toBe(false);
+  });
+});

--- a/src/tests/redux/moveTab.test.ts
+++ b/src/tests/redux/moveTab.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(async () => undefined),
+  saveToFirestore: vi.fn(async () => undefined),
+  displayToast: vi.fn(),
+}));
+
+import reducer, {
+  saveToTabContainerInternal,
+  moveTabInternal,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import type {
+  tabContainerData,
+  TabMasterContainer,
+} from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-10 part 1: drag to reorder tabs within a saved window.
+//
+// Grouping is a PROPERTY on the tab, not a nested collection, so every move --
+// within a run, into a band, out of a band -- is one splice on the flat array
+// plus one field write. These tests are the shared layer under both drag
+// prototypes; neither prototype's pointer handling is exercised here.
+//
+// The window deliberately mixes loose tabs with a two-member group AND a
+// single-member group. The single-member group is what separates a correct
+// prune ("the group I just left is now empty") from the tempting wrong one
+// ("some group lost a tab"), which deletes a group a tab was only reordered
+// inside.
+const session = (): tabContainerData => ({
+  tabGroupId: 'tg',
+  title: 'Session',
+  createdTime: '2026-09-07 00:00:00',
+  createdAt: 1757203200000,
+  windowCount: 1,
+  tabCount: 5,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: 'w',
+      windowHeight: 100,
+      windowWidth: 100,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 5,
+      title: 'Window',
+      tabs: [
+        {
+          tabId: 'loose-1',
+          favicon: '',
+          title: 'Loose 1',
+          url: 'https://a.co',
+        },
+        {
+          tabId: 'a-1',
+          favicon: '',
+          title: 'A one',
+          url: 'https://b.co',
+          chromeGroupId: 'grp-a',
+        },
+        {
+          tabId: 'a-2',
+          favicon: '',
+          title: 'A two',
+          url: 'https://c.co',
+          chromeGroupId: 'grp-a',
+        },
+        {
+          tabId: 'loose-2',
+          favicon: '',
+          title: 'Loose 2',
+          url: 'https://d.co',
+        },
+        {
+          tabId: 'b-1',
+          favicon: '',
+          title: 'B one',
+          url: 'https://e.co',
+          chromeGroupId: 'grp-b',
+        },
+      ],
+      chromeTabGroups: [
+        { groupId: 'grp-a', title: 'Research', color: 'blue' },
+        { groupId: 'grp-b', title: 'Solo', color: 'red' },
+      ],
+    },
+  ],
+});
+
+const base = (): TabMasterContainer => ({
+  lastModified: 1,
+  selectedTabGroupId: null,
+  tabGroups: [],
+});
+
+const seed = () => reducer(base(), saveToTabContainerInternal(session()));
+const win = (s: TabMasterContainer) => s.tabGroups[0].windows[0];
+const tabIds = (s: TabMasterContainer) => win(s).tabs.map((t) => t.tabId);
+const groupIds = (s: TabMasterContainer) =>
+  (win(s).chromeTabGroups ?? []).map((g) => g.groupId);
+const tab = (s: TabMasterContainer, id: string) =>
+  win(s).tabs.find((t) => t.tabId === id)!;
+
+const move = (
+  state: TabMasterContainer,
+  tabId: string,
+  toIndex: number,
+  toChromeGroupId?: string
+) =>
+  reducer(
+    state,
+    moveTabInternal({
+      tabGroupId: 'tg',
+      windowId: 'w',
+      tabId,
+      toIndex,
+      toChromeGroupId,
+    })
+  );
+
+// THE INDEX CONTRACT, pinned because it is the one thing about a reorder API
+// that is silently ambiguous: toIndex is where the tab ENDS UP in the resulting
+// array, which is what dnd-kit's arrayMove means by `to`. The alternative --
+// an index into the list as it stood before the tab was lifted out -- differs
+// by exactly one on every downward move, and a prototype built against the
+// other reading would be subtly wrong in a way no type can catch.
+describe('the toIndex contract', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('places the tab AT toIndex in the result, moving down', () => {
+    const after = move(seed(), 'loose-1', 3);
+    expect(tabIds(after)[3]).toBe('loose-1');
+  });
+
+  it('places the tab AT toIndex in the result, moving up', () => {
+    const after = move(seed(), 'b-1', 1, 'grp-b');
+    expect(tabIds(after)[1]).toBe('b-1');
+  });
+
+  it('puts an index past the end at the end, keeping every tab', () => {
+    const after = move(seed(), 'loose-1', 99);
+    expect(tabIds(after)).toHaveLength(5);
+    expect(tabIds(after)[4]).toBe('loose-1');
+  });
+
+  // splice reads a negative start as an offset from the END, so an unguarded
+  // -1 lands the tab second-from-last instead of first -- a wrong position
+  // rather than an error, which is the kind that ships.
+  it('puts a negative index at the front, not near the back', () => {
+    const after = move(seed(), 'loose-2', -1);
+    expect(tabIds(after)).toHaveLength(5);
+    expect(tabIds(after)[0]).toBe('loose-2');
+  });
+});
+
+describe('moving a tab within a saved window', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('reorders within an ungrouped stretch', () => {
+    const after = move(seed(), 'loose-2', 0);
+    expect(tabIds(after)).toEqual(['loose-2', 'loose-1', 'a-1', 'a-2', 'b-1']);
+  });
+
+  it('leaves an ungrouped tab ungrouped', () => {
+    const after = move(seed(), 'loose-2', 0);
+    expect('chromeGroupId' in tab(after, 'loose-2')).toBe(false);
+  });
+
+  it('reorders within a band without changing membership', () => {
+    const after = move(seed(), 'a-2', 1, 'grp-a');
+    expect(tabIds(after)).toEqual(['loose-1', 'a-2', 'a-1', 'loose-2', 'b-1']);
+    expect(tab(after, 'a-2').chromeGroupId).toBe('grp-a');
+  });
+
+  it('joins the group when dropped into a band', () => {
+    const after = move(seed(), 'loose-1', 1, 'grp-a');
+    expect(tab(after, 'loose-1').chromeGroupId).toBe('grp-a');
+  });
+
+  it('leaves the group when dropped outside every band', () => {
+    const after = move(seed(), 'a-1', 4);
+    expect(tab(after, 'a-1').chromeGroupId).toBeUndefined();
+  });
+
+  // Firestore's setDoc rejects an explicit `undefined` outright -- that is
+  // KAN-48. Absent is the stored representation, and a deep-equal assertion
+  // cannot tell the two apart, so this checks the key itself.
+  it('DELETES the group key rather than setting it undefined', () => {
+    const after = move(seed(), 'a-1', 4);
+    expect('chromeGroupId' in tab(after, 'a-1')).toBe(false);
+  });
+});
+
+describe('what a move does to the group list', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('prunes a group whose last member was dragged out', () => {
+    const after = move(seed(), 'b-1', 0);
+    expect(groupIds(after)).toEqual(['grp-a']);
+  });
+
+  it('keeps a group that still has members', () => {
+    const after = move(seed(), 'a-1', 4);
+    expect(groupIds(after)).toEqual(['grp-a', 'grp-b']);
+  });
+
+  // The case a "did any group just lose a tab" implementation deletes: the
+  // group neither gained nor lost a member, because source and destination are
+  // the same group.
+  it('keeps a single-member group reordered within itself', () => {
+    const after = move(seed(), 'b-1', 4, 'grp-b');
+    expect(groupIds(after)).toEqual(['grp-a', 'grp-b']);
+    expect(tab(after, 'b-1').chromeGroupId).toBe('grp-b');
+  });
+
+  it('prunes only the group that emptied, when a tab moves between groups', () => {
+    const after = move(seed(), 'b-1', 1, 'grp-a');
+    expect(groupIds(after)).toEqual(['grp-a']);
+    expect(tab(after, 'b-1').chromeGroupId).toBe('grp-a');
+  });
+});
+
+describe('what a move must not disturb', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('changes no counts', () => {
+    const before = seed();
+    const after = move(before, 'a-1', 4);
+    expect(after.tabGroups[0].tabCount).toBe(before.tabGroups[0].tabCount);
+    expect(after.tabGroups[0].windowCount).toBe(
+      before.tabGroups[0].windowCount
+    );
+    expect(win(after).tabCount).toBe(win(before).tabCount);
+  });
+
+  // touch, not stampCreated. stampCreated resets createdAt, and the merge
+  // orders the session list by createdInstant -- so calling it here would send
+  // a session to the top of the left pane because a tab inside it was nudged.
+  it('advances lastModified without restamping creation', () => {
+    const before = seed();
+    const after = move(before, 'a-1', 4);
+    expect(after.tabGroups[0].createdAt).toBe(before.tabGroups[0].createdAt);
+    expect(after.tabGroups[0].createdTime).toBe(
+      before.tabGroups[0].createdTime
+    );
+    expect(after.tabGroups[0].lastModified).toBeGreaterThanOrEqual(
+      before.tabGroups[0].lastModified ?? 0
+    );
+  });
+
+  it('leaves every other tab in its original relative order', () => {
+    const after = move(seed(), 'a-1', 4);
+    expect(tabIds(after)).toEqual(['loose-1', 'a-2', 'loose-2', 'b-1', 'a-1']);
+  });
+});
+
+// A drop that lands the tab exactly where it started is not an edit. Left
+// unguarded it still stamps lastModified, writes localStorage, dirties the
+// container for a cloud write and pushes an undo step -- for a change the user
+// cannot see. Picking a tab up and putting it back is a normal thing to do.
+describe('a move that changes nothing', () => {
+  // The clock is driven, not read. Date.now() returns the same millisecond for
+  // a seed and a move in the same tick, so lastModified cannot tell "stamped"
+  // from "not stamped" on a real clock -- an earlier version of these tests
+  // passed for exactly that reason while proving nothing.
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-07T12:00:00Z'));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  const later = <T>(fn: () => T): T => {
+    vi.advanceTimersByTime(5000);
+    return fn();
+  };
+
+  it('does not stamp the session when index and group are unchanged', () => {
+    const before = seed();
+    const after = later(() => move(before, 'a-1', 1, 'grp-a'));
+    expect(after.tabGroups[0].lastModified).toBe(
+      before.tabGroups[0].lastModified
+    );
+  });
+
+  it('leaves the order alone', () => {
+    const before = seed();
+    const after = later(() => move(before, 'a-1', 1, 'grp-a'));
+    expect(tabIds(after)).toEqual(tabIds(before));
+  });
+
+  // The guard must compare BOTH axes. Dropping a tab in place but inside a band
+  // changes its membership and is a real edit.
+  it('CONTROL: dropping in place INTO a group is still applied', () => {
+    const before = seed();
+    const after = later(() => move(before, 'loose-1', 0, 'grp-a'));
+    expect(tab(after, 'loose-1').chromeGroupId).toBe('grp-a');
+    expect(after.tabGroups[0].lastModified).not.toBe(
+      before.tabGroups[0].lastModified
+    );
+  });
+
+  it('CONTROL: dropping in place OUT of a group is still applied', () => {
+    const before = seed();
+    const after = later(() => move(before, 'a-1', 1));
+    expect('chromeGroupId' in tab(after, 'a-1')).toBe(false);
+    expect(after.tabGroups[0].lastModified).not.toBe(
+      before.tabGroups[0].lastModified
+    );
+  });
+});
+
+describe('a move for data that is no longer there', () => {
+  beforeEach(() => localStorage.clear());
+
+  const unknown = (
+    state: TabMasterContainer,
+    params: { tabGroupId?: string; windowId?: string; tabId?: string }
+  ) =>
+    reducer(
+      state,
+      moveTabInternal({
+        tabGroupId: params.tabGroupId ?? 'tg',
+        windowId: params.windowId ?? 'w',
+        tabId: params.tabId ?? 'loose-1',
+        toIndex: 0,
+      })
+    );
+
+  it('is a no-op for an unknown session', () => {
+    const before = seed();
+    expect(tabIds(unknown(before, { tabGroupId: 'nope' }))).toEqual(
+      tabIds(before)
+    );
+  });
+
+  it('is a no-op for an unknown window', () => {
+    const before = seed();
+    expect(tabIds(unknown(before, { windowId: 'nope' }))).toEqual(
+      tabIds(before)
+    );
+  });
+
+  it('is a no-op for an unknown tab', () => {
+    const before = seed();
+    expect(tabIds(unknown(before, { tabId: 'nope' }))).toEqual(tabIds(before));
+  });
+});

--- a/src/tests/redux/moveTabIsCaptured.test.ts
+++ b/src/tests/redux/moveTabIsCaptured.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test, vi } from 'vitest';
+
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+import { makeTestStore } from '../setup/makeStore';
+import {
+  saveToTabContainerInternal,
+  moveTabInternal,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import { undo } from '../../redux/slices/undoRedoSlice';
+import { setIsNotDirty } from '../../redux/slices/globalStateSlice';
+
+// The same trap KAN-107 and the Chrome group actions hit: an action missing
+// from actionsToCapture still renders and still reaches localStorage, so it
+// looks correct everywhere except the two places that matter -- it loses its
+// undo step, and it never dirties the container, so the reorder is never
+// synced. Asserted as those two consequences rather than as membership of a
+// list, because the list is the implementation of the rule, not the rule.
+
+const build = () => ({
+  tabGroupId: 'tg',
+  title: 'Session',
+  createdTime: '2026-09-07 00:00:00',
+  windowCount: 1,
+  tabCount: 3,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: 'w',
+      windowHeight: 100,
+      windowWidth: 100,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 3,
+      title: 'Window',
+      tabs: [
+        { tabId: 'one', favicon: '', title: 'One', url: 'https://a.co' },
+        { tabId: 'two', favicon: '', title: 'Two', url: 'https://b.co' },
+        {
+          tabId: 'three',
+          favicon: '',
+          title: 'Three',
+          url: 'https://c.co',
+          chromeGroupId: 'grp',
+        },
+      ],
+      chromeTabGroups: [{ groupId: 'grp', title: 'Research', color: 'blue' }],
+    },
+  ],
+});
+
+type Store = ReturnType<typeof makeTestStore>['store'];
+
+const seeded = () => {
+  const { store } = makeTestStore();
+  store.dispatch(saveToTabContainerInternal(build()));
+  store.dispatch(setIsNotDirty());
+  return store;
+};
+const ids = (s: Store) =>
+  s
+    .getState()
+    .tabContainerDataState.tabGroups[0].windows[0].tabs.map((t) => t.tabId);
+
+describe('moving a tab is a captured action', () => {
+  test('a reorder is undoable and dirties the container', () => {
+    const store = seeded();
+    store.dispatch(
+      moveTabInternal({
+        tabGroupId: 'tg',
+        windowId: 'w',
+        tabId: 'one',
+        toIndex: 2,
+      })
+    );
+    expect(ids(store)).toEqual(['two', 'three', 'one']);
+    expect(store.getState().globalState.isDirty).toBe(true);
+
+    store.dispatch(undo());
+    expect(ids(store)).toEqual(['one', 'two', 'three']);
+  });
+
+  test('a move that changes group membership is undoable', () => {
+    const store = seeded();
+    store.dispatch(
+      moveTabInternal({
+        tabGroupId: 'tg',
+        windowId: 'w',
+        tabId: 'one',
+        toIndex: 2,
+        toChromeGroupId: 'grp',
+      })
+    );
+    const grouped = (s: Store) =>
+      s
+        .getState()
+        .tabContainerDataState.tabGroups[0].windows[0].tabs.find(
+          (t) => t.tabId === 'one'
+        )?.chromeGroupId;
+    expect(grouped(store)).toBe('grp');
+
+    store.dispatch(undo());
+    expect(grouped(store)).toBeUndefined();
+  });
+
+  // THE CONTROL. Both assertions above would also pass if the middleware
+  // captured every action indiscriminately. A move aimed at a tab that is not
+  // there changes nothing, so it must not become an undo step or dirty the
+  // container.
+  test('CONTROL: a move of an unknown tab neither dirties nor pushes undo', () => {
+    const store = seeded();
+    const pastBefore = store.getState().undoRedo.past.length;
+
+    store.dispatch(
+      moveTabInternal({
+        tabGroupId: 'tg',
+        windowId: 'w',
+        tabId: 'nope',
+        toIndex: 0,
+      })
+    );
+
+    expect(ids(store)).toEqual(['one', 'two', 'three']);
+    expect(store.getState().globalState.isDirty).toBe(false);
+    expect(store.getState().undoRedo.past.length).toBe(pastBefore);
+  });
+});

--- a/src/utils/constants/actionTypes.ts
+++ b/src/utils/constants/actionTypes.ts
@@ -44,6 +44,7 @@ export const DELETE_TAB_CONTAINER_ACTION =
 export const DELETE_WINDOW_ACTION =
   'tabContainerDataState/deleteWindowInternal';
 export const DELETE_TAB_ACTION = 'tabContainerDataState/deleteTabInternal';
+export const MOVE_TAB_ACTION = 'tabContainerDataState/moveTabInternal';
 
 // global actions
 export const IS_DIRTY_ACTION = 'globalState/setIsDirty';


### PR DESCRIPTION
## What

Tabs inside a saved window can be dragged into a new order. Dropping a tab inside a Chrome group's coloured band moves it into that group; dropping it anywhere else leaves it ungrouped.

Scoped to **tabs within one window**. KAN-10 lists three scopes as one feature; they are not one feature.

## Why sessions are not in scope

`mergeTabContainers` derives the session order on every sync (`src/utils/functions/mergeTabData.ts:199`):

```ts
survivors.sort(
  (a, b) =>
    createdInstant(b) - createdInstant(a) ||
    compareAsc(a.tabGroupId, b.tabGroupId)
);
```

A session's position in `tabGroups[]` therefore carries no information that survives a merge — drag one to the top and the next sync puts it back. That needs an explicit order field plus a change to the merge's ordering contract and a two-device concurrent-reorder story, in the module with three reversal regressions behind it.

A window's contents pass through the merge untouched, so reordering *inside* a window is an ordinary content edit the existing dirty/sync flow already carries. Windows-within-a-session is the same shape and is the natural follow-up.

## No schema change

Grouping is a property on the tab, not a nested collection, so every drop — within a run, into a band, out of a band — is one splice on the flat array plus one field write.

`sameWindowContent` already compares tabs **positionally** and already includes `chromeGroupId`, so the sync whitelist needed no edit. Its existing comment anticipated this feature: *"a comparator that ignores it is one refactor away from missing a move between groups."*

Two judgment calls worth naming:

| call | reason |
| --- | --- |
| `touch`, not `stampCreated` | `stampCreated` resets `createdAt`, and the merge orders the session list by it — nudging a tab would send its session to the top of the left pane |
| a no-op drop mutates nothing | dropping a tab where it started would otherwise stamp the session, dirty it for a cloud write and push an undo step for a change nobody can see |

`MOVE_TAB_ACTION` is in `actionsToCapture`, or the move would be silently un-undoable.

## Why no drag library

`@dnd-kit` was built as a competing prototype behind a runtime toggle and compared in the real popup. Three builds off this branch isolate the cost:

| build | raw | gzip |
| --- | --- | --- |
| pre-feature baseline | 522.13 kB | 160.72 kB |
| this implementation | 525.51 kB | **161.93 kB** |
| dnd-kit prototype linked | 569.97 kB | 177.10 kB |

**+1.21 kB gzip** for the feature, against **+14.91 kB** for dnd-kit — roughly 10x, or ~9% of the whole gzipped bundle.

Cost was not the only reason. dnd-kit's default `attributes` put `role="button"`, a tabIndex and `aria-roledescription="sortable"` on the sortable node, which nested a button around each row's existing `ClickableRow`, swallowed the row's accessible name into the outer one, and announced *"press the space bar to pick up a draggable item"* — for a keyboard path this feature does not ship. Seen in the real popup's accessibility tree.

**Pointer-only by design.** `ClickableRow` already binds Enter and Space to "open the tab", so a keyboard pick-up would collide with it and needs its own affordance. Opening, deleting and renaming a tab all remain keyboard-operable; only reordering is pointer-driven.

## Interaction

Activation at 5px of travel, so a click still opens the tab. Cursor is `pointer` at rest and `grabbing` once a drag is under way — sequenced rather than simultaneous, so the two never compete for one channel. `grabbing` is set on the document, not the row, because the pointer leaves the source element during a drag.

Two elements, two jobs: the new outer node owns `transform`, `transition`, the lift shadow and `z-index`; the row inside keeps `background-color` for selection and the inset shadow for hover, and its own `transform` stays free for the micro-animations planned for these rows.

## Also fixes KAN-127

The row's hover reveal was keyed by **position** (`hoveredChildIndex === index`), so any reorder lit up the wrong row's delete icon. Reachable before this change too — a sync adopting the other device's window re-renders under a stationary pointer with no `mouseleave` to clear the stale index. Now keyed by `tabId`, which also deletes both `tabs.indexOf(tabItem)` lookups and the cross-run index arithmetic the old comment warned about. No data risk either way: the delete handler closes over the row's own `tabId`.

## Tests

49 new tests across 5 files. Every assertion was checked against a mutation rather than assumed.

| mutation | result |
| --- | --- |
| `delete` → `= undefined` on the group key | 2 tests fail (the KAN-48 Firestore shape) |
| `touch` → `stampCreated` | `advances lastModified without restamping creation` fails |
| prune the group before the tab is spliced back in | `keeps a single-member group reordered within itself` fails |
| drop the negative-index guard | `puts a negative index at the front` fails |
| unregister `MOVE_TAB_ACTION` | 2 undo/dirty tests fail |
| drop the no-op guard | `does not stamp the session when index and group are unchanged` fails |
| guard the no-op on index only, ignoring membership | both in-place-membership controls fail |
| activation distance 5 → 0 | 2 tests fail |
| midpoint → row top | 2 tests fail |
| band boundary inclusive → exclusive | 1 fails |
| Escape no longer cancels | 2 fail |
| cursor never cleared | 2 fail |
| remove the `bandAt` call from the commit path | `releasing inside a band joins that group` fails |
| never arm the click suppression | 2 fail |
| never spend the suppression | `only the one click is swallowed` fails |
| revert KAN-127 to index keying | `the reveal follows the tab` fails |

Two findings came out of that pass and changed the code rather than the tests. A guard I had argued was essential — "source group is not the destination group" before pruning — turned out to be **dead code**: the emptiness check runs after the tab is spliced back in with its new membership, so a same-group reorder can never make its group a prune candidate. What is real is the ordering, and there is a test for it. `Math.min` in the index clamp was dead too, since `splice` already clamps a too-large start index; the negative half is not, and now has its own test.

One test also passed for the wrong reason at first: `Date.now()` returns the same millisecond for a seed and a move, so `lastModified` could not distinguish "stamped" from "not stamped". Those tests drive a fake clock now.

## Verified in the real extension

Loaded from `dist` and driven through the browser's own input pipeline, not synthetic events:

- a drag commits — a tab moved index 0 → 3, `lastModified` advanced, Undo became enabled
- no drag opens a tab — `chrome.tabs.create` stubbed and recorded; zero calls across every drag
- a plain click still opens the tab — `opened: ["https://c.example"]`, so the click suppression is not over-broad
- a no-op drop changes nothing — order, `lastModified` and Undo all unchanged
- the accessibility tree is unchanged from before this PR: each row is still its `ClickableRow` plus its delete button, with no wrapper

**Not verified live:** the band rule, because the test browser has not granted the optional `tabGroups` permission and the pane correctly renders flat without it. It has unit coverage (`bandAt` directly, and the drag-area tests with stubbed rects) but no real-popup confirmation.

## Gates

- **969 tests / 101 files** passed (from 920 / 96)
- `tsc --noEmit` — 0
- `npm run lint` — 0 errors / 25 warnings (baseline)
- `prettier --check` — clean on all changed files
- `npm audit --omit=dev` — 0 vulnerabilities; the runtime dependency list is back to its original 13

🤖 Generated with [Claude Code](https://claude.com/claude-code)