### PR TITLE
Make the drag cursor and the hidden row actions actually render (KAN-134, KAN-135)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -21,6 +21,38 @@ body {
   transition: none !important;
 }
 
+/* A drag is in flight (KAN-134). RowDragArea publishes this attribute on <html>
+   for the duration of one.
+
+   `*` rather than a single ancestor is the entire point. `cursor` inherits, but
+   an explicit declaration on a descendant beats an inherited value whatever its
+   importance -- and every row here declares one: the draggable node itself,
+   ClickableRow, and three more in WindowEntryContainer. Setting the cursor on
+   <body>, which is what this replaces, was therefore set-and-inert: measured in
+   the popup, `document.body.style.cursor` read `grabbing` while the element
+   under the pointer computed `pointer`, for the whole gesture.
+
+   `!important` is load-bearing for the same reason as the rule above -- these
+   have to beat emotion classes, which are injected later and would otherwise
+   win on order alone. */
+[data-dragging] * {
+  cursor: grabbing !important;
+  user-select: none !important;
+}
+
+/* A row's own actions must not ride the pointer while it is being dragged
+   (KAN-135). The held row is translated to follow the pointer, so it never
+   stops being the hovered element and keeps its strip revealed; rows shifting
+   aside pass under the pointer and reveal theirs too. That leaves a DESTRUCTIVE
+   control sitting under the cursor at the moment of release.
+
+   Selected by attribute because the reveal itself is an emotion class keyed on
+   React state, which no stylesheet can name. */
+[data-dragging] [data-row-actions] {
+  opacity: 0 !important;
+  background-color: transparent !important;
+}
+
 ::-webkit-scrollbar {
   width: 10px;
 }

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -522,7 +522,10 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
             />
           </div>
         </ClickableRow>
-        <div css={childRightStyle(tabId)}>
+        {/* data-row-actions is the stylesheet's hook for hiding this strip
+            during a drag (KAN-135). The reveal above is an emotion class keyed
+            on React state, which App.css cannot name. */}
+        <div data-row-actions css={childRightStyle(tabId)}>
           <Icon
             tooltipText={t('Delete tab')}
             ariaLabel={t('Delete tab')}
@@ -630,7 +633,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
             </ClickableRow>
           )}
         </div>
-        <div css={parentRightStyle}>
+        <div data-row-actions css={parentRightStyle}>
           {isEditing && !isSearchPanel ? (
             // Same shape as the session tick: the wrapper carries the
             // onMouseDown that Icon does not expose, preventDefault keeps focus

--- a/src/components/home/rightpane/rowDrag/RowDragArea.tsx
+++ b/src/components/home/rightpane/rowDrag/RowDragArea.tsx
@@ -34,7 +34,7 @@ import React, {
 import {
   ACTIVATION_DISTANCE_PX,
   isInsideList,
-  setBodyGrabbing,
+  setDragging,
   type DraggableRowProps,
   type RowDragAreaProps,
 } from './dropRules';
@@ -178,7 +178,7 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
         });
         l.height = l.rects[l.fromIndex]?.height ?? 0;
         l.started = true;
-        setBodyGrabbing(true);
+        setDragging(true);
       }
 
       const others = l.rects.filter((r) => r.id !== l.rowId);
@@ -206,7 +206,7 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
       live.current = null;
       setDrag(null);
       if (!l) return;
-      setBodyGrabbing(false);
+      setDragging(false);
       // Below the threshold this was a click, not a drag, and the row's own
       // handler must run untouched.
       if (!l.started) return;
@@ -257,7 +257,7 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
       window.removeEventListener('click', onClickCapture, true);
       // A drag interrupted by unmount must not leave the document stuck in
       // `grabbing`.
-      setBodyGrabbing(false);
+      setDragging(false);
     };
   }, [rowIds, onMove, resolveDrop]);
 

--- a/src/components/home/rightpane/rowDrag/dropRules.ts
+++ b/src/components/home/rightpane/rowDrag/dropRules.ts
@@ -109,11 +109,26 @@ export function isInsideList(
   return y >= top - slack && y <= bottom + slack;
 }
 
-// `grabbing` goes on the document, not on the row. During a drag the pointer
-// travels over other rows, gaps and bands, and a cursor scoped to the source
-// element reverts the moment it leaves -- which reads as the drag letting go.
-export function setBodyGrabbing(on: boolean): void {
-  document.body.style.cursor = on ? 'grabbing' : '';
-  // Without this the browser selects row text as the pointer sweeps the list.
-  document.body.style.userSelect = on ? 'none' : '';
+// Publish "a drag is in flight" on the document, for App.css to react to.
+//
+// It goes on the document rather than the row because during a drag the pointer
+// travels over other rows, gaps and bands, and anything scoped to the source
+// element stops applying the moment it leaves -- which reads as the drag
+// letting go.
+//
+// A FLAG, not a style. This used to set `document.body.style.cursor` directly,
+// and that was set-and-inert (KAN-134): `cursor` inherits, but an explicit
+// declaration on a descendant beats an inherited value whatever its importance,
+// and every row in this pane declares `cursor: pointer`. Measured in the popup,
+// the body read `grabbing` while the element under the pointer computed
+// `pointer` for the entire gesture -- and the test asserting the body's own
+// style passed throughout.
+//
+// So the rule has to apply to the elements themselves, which means a selector
+// (`[data-dragging] *`) rather than a property set on one node. The styles live
+// in App.css; this only says when they apply. It also carries `user-select`,
+// which had the same shape and is now in the same rule.
+export function setDragging(on: boolean): void {
+  if (on) document.documentElement.setAttribute('data-dragging', '');
+  else document.documentElement.removeAttribute('data-dragging');
 }

--- a/src/tests/components/dragIsDisabledWhileSearching.test.tsx
+++ b/src/tests/components/dragIsDisabledWhileSearching.test.tsx
@@ -126,7 +126,7 @@ const storedTabIds = (store: RenderWithProvidersResult['store']) =>
     .tabContainerDataState.tabGroups[0].windows[0].tabs.map((t) => t.tabId);
 
 afterEach(() => {
-  document.body.style.cursor = '';
+  document.documentElement.removeAttribute('data-dragging');
 });
 
 describe('a tab drag inside a filtered list', () => {

--- a/src/tests/components/dragOutsideItsListIsNoOp.test.tsx
+++ b/src/tests/components/dragOutsideItsListIsNoOp.test.tsx
@@ -117,7 +117,7 @@ const tabsOf = (store: RenderWithProvidersResult['store'], i: number) =>
     .tabContainerDataState.tabGroups[0].windows[i].tabs.map((t) => t.tabId);
 
 afterEach(() => {
-  document.body.style.cursor = '';
+  document.documentElement.removeAttribute('data-dragging');
 });
 
 describe('a tab released outside its own window', () => {

--- a/src/tests/components/dragSetsDocumentFlag.test.tsx
+++ b/src/tests/components/dragSetsDocumentFlag.test.tsx
@@ -1,0 +1,177 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+
+import {
+  RowDragArea,
+  DraggableRow,
+} from '../../components/home/rightpane/rowDrag/RowDragArea';
+import WindowEntryContainer from '../../components/home/rightpane/WindowEntryContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import { setHasTabGroupsPermission } from '../../redux/slices/globalStateSlice';
+import type { tabData } from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-134 / KAN-135. What a drag publishes to the document, so CSS can react.
+//
+// The previous mechanism set `document.body.style.cursor` directly, and the
+// test asserted exactly that -- and passed while the user saw no change at all,
+// because `cursor` inherits and every row declares its own. jsdom resolves no
+// cascade, so this layer can only pin that the FLAG is published and cleared
+// correctly; that the flag then does anything is `dragStyles.test.ts` (the rule
+// exists) plus a browser pass (the rule renders).
+//
+// Splitting it that way is deliberate: an assertion this layer *can* make
+// honestly, rather than one that looks stronger and proves nothing.
+
+const ROW_H = 30;
+
+const box = (top: number, height: number) =>
+  ({
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 200,
+    height,
+    width: 200,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+const Harness = () => (
+  <RowDragArea rowIds={['a', 'b', 'c']} onMove={() => undefined}>
+    {['a', 'b', 'c'].map((id, index) => (
+      <DraggableRow key={id} rowId={id} index={index}>
+        <div>Row {id}</div>
+      </DraggableRow>
+    ))}
+  </RowDragArea>
+);
+
+const nodeFor = (id: string) =>
+  document.querySelector<HTMLElement>(`[data-drag-row-id="${id}"]`)!;
+
+const layout = () =>
+  ['a', 'b', 'c'].forEach((id, i) => {
+    nodeFor(id).getBoundingClientRect = () => box(i * ROW_H, ROW_H);
+  });
+
+const press = (id: string, y: number) =>
+  fireEvent.pointerDown(nodeFor(id), { clientX: 10, clientY: y, button: 0 });
+const moveTo = (y: number) =>
+  fireEvent.pointerMove(document, { clientX: 10, clientY: y });
+const release = (y: number) =>
+  fireEvent.pointerUp(document, { clientX: 10, clientY: y });
+
+const isDragging = () => document.documentElement.hasAttribute('data-dragging');
+
+afterEach(() => {
+  document.documentElement.removeAttribute('data-dragging');
+});
+
+describe('a drag publishes a flag on the document', () => {
+  beforeEach(() => {
+    render(<Harness />);
+    layout();
+  });
+
+  test('set while dragging, cleared on drop', () => {
+    expect(isDragging()).toBe(false);
+
+    press('a', 15);
+    moveTo(50);
+    expect(isDragging()).toBe(true);
+
+    release(50);
+    expect(isDragging()).toBe(false);
+  });
+
+  test('Escape clears it too', () => {
+    press('a', 15);
+    moveTo(50);
+    expect(isDragging()).toBe(true);
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(isDragging()).toBe(false);
+  });
+
+  // THE CONTROL. A press that never crosses the activation distance is a
+  // click, not a drag -- flagging it would force the grabbing cursor and hide
+  // every row's actions on an ordinary click.
+  test('CONTROL: a press below the threshold never sets it', () => {
+    press('a', 15);
+    moveTo(17);
+
+    expect(isDragging()).toBe(false);
+    release(17);
+    expect(isDragging()).toBe(false);
+  });
+});
+
+describe('a drag interrupted by unmount', () => {
+  test('does not leave the document flagged', () => {
+    const { unmount } = render(<Harness />);
+    layout();
+
+    press('a', 15);
+    moveTo(50);
+    expect(isDragging()).toBe(true);
+
+    unmount();
+
+    expect(isDragging()).toBe(false);
+  });
+});
+
+// KAN-135. The stylesheet hides the strips during a drag, so it needs a stable
+// hook to find them by -- the reveal itself is an emotion class keyed on React
+// state, which no stylesheet can select.
+describe('a tab row marks its action strip for the stylesheet', () => {
+  const TABS: tabData[] = [
+    { tabId: 't1', favicon: '', title: 'One', url: 'https://one.test' },
+    { tabId: 't2', favicon: '', title: 'Two', url: 'https://two.test' },
+  ];
+
+  test('every tab row carries data-row-actions', async () => {
+    const { container } = await renderWithProviders(
+      <WindowEntryContainer
+        title="Window 1"
+        tabGroupId="tg1"
+        windowId="w1"
+        tabs={TABS}
+        onWindowTitleClick={() => undefined}
+        onUpdateWindowGroupTitle={() => undefined}
+        onAddCurrTabToWindowClick={() => undefined}
+        onDeleteClick={() => undefined}
+      />,
+      { seedStore: (store) => store.dispatch(setHasTabGroupsPermission(false)) }
+    );
+
+    const strips = container.querySelectorAll('[data-row-actions]');
+    // One per tab row, plus the window header's own strip.
+    expect(strips.length).toBeGreaterThanOrEqual(TABS.length);
+  });
+
+  test('the marked strip is the one holding the delete control', async () => {
+    const { container } = await renderWithProviders(
+      <WindowEntryContainer
+        title="Window 1"
+        tabGroupId="tg1"
+        windowId="w1"
+        tabs={TABS}
+        onWindowTitleClick={() => undefined}
+        onUpdateWindowGroupTitle={() => undefined}
+        onAddCurrTabToWindowClick={() => undefined}
+        onDeleteClick={() => undefined}
+      />,
+      { seedStore: (store) => store.dispatch(setHasTabGroupsPermission(false)) }
+    );
+
+    const deleteControls = [
+      ...container.querySelectorAll('[aria-label="Delete tab"]'),
+    ];
+    expect(deleteControls.length).toBe(TABS.length);
+    deleteControls.forEach((control) => {
+      expect(control.closest('[data-row-actions]')).not.toBeNull();
+    });
+  });
+});

--- a/src/tests/components/rowDragArea.test.tsx
+++ b/src/tests/components/rowDragArea.test.tsx
@@ -119,7 +119,7 @@ describe('handleSelector decides which press starts a drag', () => {
   });
 
   afterEach(() => {
-    document.body.style.cursor = '';
+    document.documentElement.removeAttribute('data-dragging');
   });
 
   test('a press on the handle starts a drag', () => {
@@ -181,7 +181,7 @@ describe('what a drag reports when it lands', () => {
   });
 
   afterEach(() => {
-    document.body.style.cursor = '';
+    document.documentElement.removeAttribute('data-dragging');
   });
 
   test('dragging to the top of the list lands at index 0', () => {
@@ -243,7 +243,7 @@ describe('when a drag should not happen at all', () => {
   });
 
   afterEach(() => {
-    document.body.style.cursor = '';
+    document.documentElement.removeAttribute('data-dragging');
   });
 
   test('a press that never crosses the threshold reports no move', () => {
@@ -276,8 +276,20 @@ describe('when a drag should not happen at all', () => {
   });
 });
 
-describe('the cursor while dragging', () => {
+// MOVED, and the move is the point. These three used to assert
+// `document.body.style.cursor === 'grabbing'` -- an assertion that was true
+// throughout, while the pointer rendered `pointer` for the whole gesture
+// (KAN-134). jsdom resolves no cascade, so the body's own style says nothing
+// about what any element shows.
+//
+// The flag those tests should have been checking is now pinned in
+// dragSetsDocumentFlag.test.tsx, the rule it triggers in dragStyles.test.ts,
+// and the rendered cursor in a browser. Nothing here asserts a cursor, because
+// nothing here can.
+describe('the drag flag while dragging', () => {
   let onMove: ReturnType<typeof vi.fn<OnMove>>;
+
+  const dragging = () => document.documentElement.hasAttribute('data-dragging');
 
   beforeEach(() => {
     onMove = vi.fn<OnMove>();
@@ -286,34 +298,34 @@ describe('the cursor while dragging', () => {
   });
 
   afterEach(() => {
-    document.body.style.cursor = '';
+    document.documentElement.removeAttribute('data-dragging');
   });
 
   // On the document, not the row: during a drag the pointer travels over other
-  // rows and gaps, and a cursor scoped to the source element reverts as soon as
-  // it leaves, which reads as the drag letting go.
-  test('the document shows grabbing during the drag and clears after', () => {
+  // rows and gaps, and anything scoped to the source element stops applying as
+  // soon as it leaves, which reads as the drag letting go.
+  test('the document is flagged during the drag and cleared after', () => {
     press('Row A', 15);
     moveTo(50);
-    expect(document.body.style.cursor).toBe('grabbing');
+    expect(dragging()).toBe(true);
 
     release(50);
-    expect(document.body.style.cursor).toBe('');
+    expect(dragging()).toBe(false);
   });
 
   test('Escape also clears it', () => {
     press('Row A', 15);
     moveTo(50);
-    expect(document.body.style.cursor).toBe('grabbing');
+    expect(dragging()).toBe(true);
 
     fireEvent.keyDown(window, { key: 'Escape' });
-    expect(document.body.style.cursor).toBe('');
+    expect(dragging()).toBe(false);
   });
 
   test('a press below the threshold never sets it', () => {
     press('Row A', 15);
     moveTo(17);
-    expect(document.body.style.cursor).toBe('');
+    expect(dragging()).toBe(false);
     release(17);
   });
 });

--- a/src/tests/components/windowDragReorder.test.tsx
+++ b/src/tests/components/windowDragReorder.test.tsx
@@ -142,7 +142,7 @@ const windowIds = (store: RenderWithProvidersResult['store']) =>
     .tabContainerDataState.tabGroups[0].windows.map((w) => w.windowId);
 
 afterEach(() => {
-  document.body.style.cursor = '';
+  document.documentElement.removeAttribute('data-dragging');
 });
 
 describe('dragging a window inside a session', () => {

--- a/src/tests/config/dragStyles.test.ts
+++ b/src/tests/config/dragStyles.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'vitest';
+
+// `?raw` rather than node:fs. tsconfig's `types` array omits "node"
+// deliberately -- its comment says so -- to stop src/ reaching for APIs that do
+// not exist in a browser, and a readFileSync here fails `tsc` for exactly that
+// reason. This resolves through the same bundler the app uses, so the file
+// asserted on is provably the file that ships.
+import appCss from '../../App.css?raw';
+
+// KAN-134 / KAN-135. The drag's two visual rules live in App.css rather than in
+// an emotion style, and that is deliberate — see the comments in the file.
+//
+// Asserted against the STYLESHEET TEXT, which is unusual and is the whole point.
+// The bug being guarded against is a declaration that is set and inert:
+// `setBodyGrabbing` really did set `document.body.style.cursor = 'grabbing'`,
+// the old test asserted exactly that and passed, and the user still saw
+// `pointer` — because `cursor` inherits and every row declares its own. jsdom
+// resolves no cascade, so no assertion about a rendered cursor is available at
+// this layer at all. Pinning the rule's existence is what is left; the rendered
+// effect is verified in a browser.
+//
+// Same shape as KAN-111, which asserted generated CSS because jsdom applies no
+// `:hover`.
+
+// Collapse whitespace so the assertions do not depend on formatting.
+const flat = appCss.replace(/\s+/g, ' ');
+
+describe('the drag stylesheet rules', () => {
+  test('a drag forces the grabbing cursor onto every element', () => {
+    expect(flat).toMatch(
+      /\[data-dragging\] \* \{[^}]*cursor: grabbing !important/
+    );
+  });
+
+  // `!important` is load-bearing, not lazy: these rules have to beat emotion
+  // classes, which are injected into the document after this stylesheet and
+  // would otherwise win on order alone. The same reasoning is already recorded
+  // on the [data-theme-switching] rule beside them.
+  test('the cursor rule is important, or emotion wins on order', () => {
+    const rule = flat.match(/\[data-dragging\] \* \{[^}]*\}/)?.[0] ?? '';
+    expect(rule).toContain('!important');
+  });
+
+  // The reason it must target `*` rather than a single ancestor: `cursor`
+  // inherits, and an explicit declaration on a descendant beats an inherited
+  // value whatever its importance. A rule scoped to one element could not win.
+  test('the cursor rule targets descendants, not just one element', () => {
+    expect(flat).toMatch(/\[data-dragging\] \*/);
+  });
+
+  test('a drag hides every row action strip', () => {
+    expect(flat).toMatch(/\[data-dragging\] \[data-row-actions\]/);
+  });
+
+  // CONTROL. The rules must be scoped to a drag; unscoped, they would hide
+  // every row's actions and force a grabbing cursor permanently.
+  test('CONTROL: neither rule applies outside a drag', () => {
+    expect(flat).not.toMatch(/(^|})\s*\* \{[^}]*cursor: grabbing/);
+    expect(flat).not.toMatch(/(^|})\s*\[data-row-actions\] \{[^}]*opacity: 0/);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,6 +44,16 @@ export default defineConfig({
           globals: true,
           setupFiles: ['vitest-localstorage-mock'],
           mockReset: false,
+          // Vitest stubs CSS imports by default, and that stub also swallows
+          // `?raw` -- App.css came back as an empty string, so a test asserting
+          // its contents passed against a file it never read. dragStyles.test.ts
+          // needs the real text, because the drag's cursor and action-strip
+          // rules live in App.css and jsdom can resolve neither.
+          //
+          // Safe here because this project runs in `node`, where nothing
+          // injects CSS at all: enabling it only means "return the file instead
+          // of a stub".
+          css: true,
           // The second glob is why scripts/prune_remote_code.test.mjs runs at
           // all. It is deliberately narrow: scripts/ sits outside tsconfig's
           // `include` and outside `npm run lint` (which is `eslint src`), so


### PR DESCRIPTION
## What

Two defects reported from the UI, with one shared root cause: **a style that was set and inert**.

- **KAN-134** — the pointer never becomes a grabbing hand during a drag.
- **KAN-135** — a tab's delete icon rides the pointer for the whole drag.

Both are in merged-but-unreleased code (KAN-128/129), so this keeps them out of users' hands.

## The cursor was set correctly and did nothing

`setBodyGrabbing` set `document.body.style.cursor = 'grabbing'`, and that is genuinely what it did. Measured in the popup, sampling `getComputedStyle(document.elementFromPoint(x, y)).cursor` on every `pointermove` — i.e. what the pointer is actually over:

```
{ phase: "move", bodyCursorInline: "grabbing", cursorAtPointer: "pointer" }
{ phase: "up",   bodyCursorInline: "grabbing", cursorAtPointer: "pointer" }
```

`cursor` inherits — but **an explicit declaration on a descendant beats an inherited value**, whatever its importance. Every row here declares one: the draggable node itself, `ClickableRow`, and three more in `WindowEntryContainer`. During a row drag the pointer is by construction always over the held row, so a property set on one ancestor could never win at any point in the gesture.

`!important` on the body would not have helped either: importance arbitrates within an element's own cascade, not against inheritance.

So the rule has to apply **to the elements themselves**, which means a selector rather than a property:

```css
[data-dragging] * { cursor: grabbing !important; user-select: none !important; }
```

`setBodyGrabbing` becomes `setDragging` and publishes `data-dragging` on `<html>`.

**This is not a new pattern.** `App.css:20` already carries `[data-theme-switching] * { transition: none !important }`, and its comment already records that the `!important` is load-bearing because emotion injects its classes later and would win on order alone. Same mechanism, same reason, three lines apart.

## The delete icon rides the pointer

The strip's reveal is keyed purely on hover, which predates dragging entirely. Measured during one drag of `cw1-t0`:

```
{ phase: "move", revealedStrips: ["cw1-t0"] }   <- the HELD row, throughout
{ phase: "up",   revealedStrips: ["cw1-t0"] }
{ phase: "move", revealedStrips: ["cw1-t3"] }   <- a row merely dragged OVER
```

The held row is translated to follow the pointer so it never stops being hovered; rows shifting aside pass under the pointer and fire their own `onMouseEnter`.

Worth stating plainly: this leaves a **destructive** control under the cursor at the exact moment of release. The post-drag click is already suppressed, so it is not reachable today — but the affordance says otherwise, and it is one refactor from being real.

The same attribute hides them, keyed off a `data-row-actions` marker because the reveal is an emotion class generated from React state, which no stylesheet can select.

**A React-context fix was considered and rejected.** `WindowEntryContainer` renders *inside* the window drag area but *contains* the tab drag area, so a hook called at the top of it reads the **window** area's drag state, not the tab's — the same provider-order constraint documented on KAN-132.

## The resting cursor stays `pointer`

Deliberate. These rows' primary action is still click-to-open — a tab row opens the tab, a window header opens the window. `grab` would advertise the secondary gesture at the expense of the primary one. Only the in-flight cursor changes.

## Why the old test passed against the bug

It asserted `document.body.style.cursor === 'grabbing'`. That was **true** for the whole drag, and silent about what rendered, because jsdom resolves no cascade.

Those three tests now assert the flag, which is what this layer can honestly check. The rule's existence is `dragStyles.test.ts`; the rendered result is a browser pass. That split — mechanism in jsdom, effect in Chrome — is the same one KAN-112 (paint order), KAN-114 (rendered height) and KAN-123 (hit area) all landed on.

`vite.config.ts` gains `css: true` on the unit project: vitest stubs CSS imports by default and the stub swallows `?raw` too, so `App.css` came back as an **empty string** — a test asserting its contents would have passed against a file it never read. Caught by probing the value rather than trusting the import. Safe in a node environment, where nothing injects CSS at all.

Also worth noting: the first version of that test used `node:fs` and failed `tsc`, correctly — tsconfig omits `"node"` from `types` on purpose, with a comment saying so, to stop `src/` reaching for APIs that do not exist in a browser.

## Evidence

**1020 tests pass**, tsc clean, lint 0 errors. Five mutations, each failing its own tests and no control:

| mutation | what failed |
| --- | --- |
| cursor rule scoped to one element instead of `*` | the 3 cursor-rule tests |
| `!important` dropped | "forces the grabbing cursor onto every element" |
| action-strip rule deleted | "a drag hides every row action strip" |
| flag never set | all 5 flag tests |
| `data-row-actions` marker removed | the 2 marker tests |

### In the real popup, against the rebuilt artifact

| | before | after |
| --- | --- | --- |
| cursor at pointer, mid-drag | `pointer` | **`grabbing`** |
| strips visible, mid-drag | held row throughout, swept rows in passing | **none** |
| resting cursor | `pointer` | `pointer` (unchanged) |
| hover reveal at rest | hovered row only | hovered row only |

The last row is the **control**. Without it, hiding every strip permanently and forcing the cursor forever would satisfy everything above it.

Closes KAN-134, KAN-135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
