### PR TITLE
Drag to reorder sessions, and a way back to newest-first (KAN-130)

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -126,5 +126,7 @@
   "TabGroupsPromptBodyOther": "Aktivieren Sie die Funktion, und Ihre {{count}} Tab-Gruppen kehren genau so zurück, wie Sie sie angelegt haben.",
   "TabGroupsPromptConfirm": "Tab-Gruppen-Unterstützung aktivieren",
   "TabGroupsPromptDismiss": "Jetzt nicht",
-  "TabGroupsPromptNever": "Nicht mehr fragen"
+  "TabGroupsPromptNever": "Nicht mehr fragen",
+  "Custom order": "Eigene Reihenfolge",
+  "Sort by date saved": "Nach Speicherdatum sortieren"
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -126,5 +126,7 @@
   "TabGroupsPromptBodyOther": "Turn it on and your {{count}} tab groups come back exactly as you set them up.",
   "TabGroupsPromptConfirm": "Enable tab group support",
   "TabGroupsPromptDismiss": "Not now",
-  "TabGroupsPromptNever": "Don't ask again"
+  "TabGroupsPromptNever": "Don't ask again",
+  "Custom order": "Custom order",
+  "Sort by date saved": "Sort by date saved"
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -126,5 +126,7 @@
   "TabGroupsPromptBodyOther": "Actívalo y tus {{count}} grupos de pestañas volverán tal como los creaste.",
   "TabGroupsPromptConfirm": "Activar la compatibilidad con grupos de pestañas",
   "TabGroupsPromptDismiss": "Ahora no",
-  "TabGroupsPromptNever": "No volver a preguntar"
+  "TabGroupsPromptNever": "No volver a preguntar",
+  "Custom order": "Orden personalizado",
+  "Sort by date saved": "Ordenar por fecha de guardado"
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -126,5 +126,7 @@
   "TabGroupsPromptBodyOther": "Activez-la et vos {{count}} groupes d'onglets reviendront exactement tels que vous les avez créés.",
   "TabGroupsPromptConfirm": "Activer la prise en charge des groupes d'onglets",
   "TabGroupsPromptDismiss": "Pas maintenant",
-  "TabGroupsPromptNever": "Ne plus demander"
+  "TabGroupsPromptNever": "Ne plus demander",
+  "Custom order": "Ordre personnalisé",
+  "Sort by date saved": "Trier par date d’enregistrement"
 }

--- a/public/locales/hi/translation.json
+++ b/public/locales/hi/translation.json
@@ -126,5 +126,7 @@
   "TabGroupsPromptBodyOther": "इसे चालू करें और आपके {{count}} टैब समूह ठीक वैसे ही वापस आएंगे जैसे आपने बनाए थे।",
   "TabGroupsPromptConfirm": "टैब समूह समर्थन चालू करें",
   "TabGroupsPromptDismiss": "अभी नहीं",
-  "TabGroupsPromptNever": "फिर से न पूछें"
+  "TabGroupsPromptNever": "फिर से न पूछें",
+  "Custom order": "कस्टम क्रम",
+  "Sort by date saved": "सहेजने की तिथि से क्रमबद्ध करें"
 }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -126,5 +126,7 @@
   "TabGroupsPromptBodyOther": "Attivala e i tuoi {{count}} gruppi di schede torneranno esattamente come li hai creati.",
   "TabGroupsPromptConfirm": "Attiva il supporto ai gruppi di schede",
   "TabGroupsPromptDismiss": "Non ora",
-  "TabGroupsPromptNever": "Non chiedere più"
+  "TabGroupsPromptNever": "Non chiedere più",
+  "Custom order": "Ordine personalizzato",
+  "Sort by date saved": "Ordina per data di salvataggio"
 }

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -126,5 +126,7 @@
   "TabGroupsPromptBodyOther": "オンにすると、{{count}} 個のタブグループは設定したときのまま復元されます。",
   "TabGroupsPromptConfirm": "タブグループのサポートを有効にする",
   "TabGroupsPromptDismiss": "後で",
-  "TabGroupsPromptNever": "今後表示しない"
+  "TabGroupsPromptNever": "今後表示しない",
+  "Custom order": "カスタム順",
+  "Sort by date saved": "保存日で並べ替え"
 }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -126,5 +126,7 @@
   "TabGroupsPromptBodyOther": "Ative e seus {{count}} grupos de guias voltarão exatamente como você os criou.",
   "TabGroupsPromptConfirm": "Ativar o suporte a grupos de guias",
   "TabGroupsPromptDismiss": "Agora não",
-  "TabGroupsPromptNever": "Não perguntar novamente"
+  "TabGroupsPromptNever": "Não perguntar novamente",
+  "Custom order": "Ordem personalizada",
+  "Sort by date saved": "Ordenar por data de salvamento"
 }

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -126,5 +126,7 @@
   "TabGroupsPromptBodyOther": "Включите её, и ваши группы вкладок ({{count}}) вернутся точно такими, какими вы их создали.",
   "TabGroupsPromptConfirm": "Включить поддержку групп вкладок",
   "TabGroupsPromptDismiss": "Не сейчас",
-  "TabGroupsPromptNever": "Больше не спрашивать"
+  "TabGroupsPromptNever": "Больше не спрашивать",
+  "Custom order": "Свой порядок",
+  "Sort by date saved": "Сортировать по дате сохранения"
 }

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -126,5 +126,7 @@
   "TabGroupsPromptBodyOther": "开启后，这 {{count}} 个标签组会完全按照你的设置恢复。",
   "TabGroupsPromptConfirm": "启用标签组支持",
   "TabGroupsPromptDismiss": "暂不",
-  "TabGroupsPromptNever": "不再询问"
+  "TabGroupsPromptNever": "不再询问",
+  "Custom order": "自定义顺序",
+  "Sort by date saved": "按保存日期排序"
 }

--- a/src/components/home/leftpane/TabGroupEntryContainer.tsx
+++ b/src/components/home/leftpane/TabGroupEntryContainer.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -14,13 +14,18 @@ import {
   isSearchActive,
 } from '../../../utils/functions/local';
 import {
+  clearSessionOrder,
   deleteTabContainer,
+  moveSessionInternal,
   openAllTabContainer,
   requestFocusTabContainer,
   selectTabContainer,
   tabContainerData,
 } from '../../../redux/slices/tabContainerDataStateSlice';
 import { useTranslation } from 'react-i18next';
+import Icon from '../../common/Icon';
+import ClickableRow from '../../common/ClickableRow';
+import { RowDragArea, DraggableRow } from '../rightpane/rowDrag/RowDragArea';
 
 export default function TabGroupEntryContainer() {
   const COLORS = useThemeColors();
@@ -45,6 +50,28 @@ export default function TabGroupEntryContainer() {
 
   const selectedTabGroupId = tabContainerDataList.selectedTabGroupId;
 
+  // The list is in custom order iff any session carries a manual rank
+  // (KAN-130). Derived rather than stored: a sort mode would be a
+  // container-level field, and this merge has no last-writer-wins rule for one
+  // -- lastModified is a max and selectedTabGroupId is per-device view state.
+  // Deriving it also makes every device agree without syncing anything new.
+  const isCustomOrder = useMemo(
+    () => tabContainerDataList.tabGroups.some((g) => g.rank !== undefined),
+    [tabContainerDataList.tabGroups]
+  );
+
+  // KAN-131, at the session level and more exposed than the panes below it:
+  // search filters sessions directly, so an index counted over the rendered
+  // list would be applied to a longer stored one.
+  const isFilteredView = isSearchActive(isSearchPanel, searchInputText);
+
+  const handleMoveSession = useCallback(
+    (tabGroupId: string, toIndex: number) => {
+      dispatch(moveSessionInternal({ tabGroupId, toIndex }));
+    },
+    [dispatch]
+  );
+
   // filter the tab group list
   let filteredTabGroups: tabContainerData[] = tabContainerDataList.tabGroups;
   if (isSearchActive(isSearchPanel, searchInputText)) {
@@ -54,6 +81,12 @@ export default function TabGroupEntryContainer() {
       hasTabGroupsPermission
     );
   }
+
+  // In render order, which is what a drop's index counts against.
+  const sessionIds = useMemo(
+    () => filteredTabGroups.map((g) => g.tabGroupId),
+    [filteredTabGroups]
+  );
 
   // Select the first match as the query narrows -- but only while a search is
   // actually running.
@@ -106,6 +139,27 @@ export default function TabGroupEntryContainer() {
     flex-direction: column;
   `;
 
+  // Shown ONLY in custom order (KAN-130), which is why it costs nothing for
+  // anyone who never drags: no strip, no change. It appears at the moment the
+  // list stops meaning "newest first", which is also the moment that needs
+  // explaining -- the list's order was previously self-evident from the dates
+  // on the rows, and after a drag nothing else would say otherwise.
+  //
+  // sticky, so it stays visible while the list scrolls under it: the state it
+  // reports is the list's, not this row's.
+  const orderStripStyle = css`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 4px 8px;
+    min-height: 28px;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background-color: ${COLORS.SECONDARY_COLOR};
+    border-bottom: 1px solid ${COLORS.BORDER_COLOR};
+  `;
+
   return (
     <div css={containerStyle}>
       {filteredTabGroups.length === 0 ? (
@@ -117,46 +171,79 @@ export default function TabGroupEntryContainer() {
         </div>
       ) : (
         <div css={filledContainerStyle}>
-          {filteredTabGroups.map((tabGroupData, index) => {
-            return (
-              // tabGroupId, not index: this list is filtered by search and
-              // reordered by save, so positions are not stable identities.
-              <div key={tabGroupData.tabGroupId}>
-                <TabGroupEntry
-                  tabGroupData={tabGroupData}
-                  onTabGroupClick={() => {
-                    if (selectedTabGroupId === tabGroupData.tabGroupId) {
-                      return;
+          {/* Not rendered while searching: the reset would apply to the stored
+              list, not the narrowed one on screen, and offering it there would
+              promise something about a list the user cannot see. */}
+          {isCustomOrder && !isFilteredView && (
+            <div css={orderStripStyle}>
+              <NormalLabel
+                value={t('Custom order')}
+                size="0.7rem"
+                color={COLORS.LABEL_L2_COLOR}
+              />
+              <ClickableRow
+                ariaLabel={t('Sort by date saved')}
+                tooltipText={t('Sort by date saved')}
+                onClick={() => dispatch(clearSessionOrder())}
+                style="display: flex; align-items: center;"
+              >
+                <Icon type="schedule" style={`padding: 0;`} />
+              </ClickableRow>
+            </div>
+          )}
+          {/* KAN-130. No handleSelector -- a session row contains no nested
+              drag area, so the whole row is the handle. No resolveDrop -- a
+              session belongs to nothing. */}
+          <RowDragArea
+            rowIds={sessionIds}
+            onMove={handleMoveSession}
+            disabled={isFilteredView}
+          >
+            {filteredTabGroups.map((tabGroupData, index) => {
+              return (
+                // tabGroupId, not index: this list is filtered by search and
+                // reordered by save, so positions are not stable identities.
+                <DraggableRow
+                  key={tabGroupData.tabGroupId}
+                  rowId={tabGroupData.tabGroupId}
+                  index={index}
+                >
+                  <TabGroupEntry
+                    tabGroupData={tabGroupData}
+                    onTabGroupClick={() => {
+                      if (selectedTabGroupId === tabGroupData.tabGroupId) {
+                        return;
+                      }
+                      dispatch(selectTabContainer(tabGroupData.tabGroupId));
+                    }}
+                    onOpenAllClick={() => {
+                      const goToURLText: string = t('Go to URL');
+                      dispatch(
+                        openAllTabContainer({
+                          tabGroupId: tabGroupData.tabGroupId,
+                          goToURLText,
+                        })
+                      );
+                    }}
+                    onFocusClick={() => {
+                      dispatch(
+                        requestFocusTabContainer({
+                          tabGroupId: tabGroupData.tabGroupId,
+                          goToURLText: t('Go to URL'),
+                          saveTitle: t('FocusAutoSaveTitle'),
+                        })
+                      );
+                    }}
+                    onDeleteClick={() =>
+                      dispatch(deleteTabContainer(tabGroupData.tabGroupId))
                     }
-                    dispatch(selectTabContainer(tabGroupData.tabGroupId));
-                  }}
-                  onOpenAllClick={() => {
-                    const goToURLText: string = t('Go to URL');
-                    dispatch(
-                      openAllTabContainer({
-                        tabGroupId: tabGroupData.tabGroupId,
-                        goToURLText,
-                      })
-                    );
-                  }}
-                  onFocusClick={() => {
-                    dispatch(
-                      requestFocusTabContainer({
-                        tabGroupId: tabGroupData.tabGroupId,
-                        goToURLText: t('Go to URL'),
-                        saveTitle: t('FocusAutoSaveTitle'),
-                      })
-                    );
-                  }}
-                  onDeleteClick={() =>
-                    dispatch(deleteTabContainer(tabGroupData.tabGroupId))
-                  }
-                />
-                {/* <Divider /> */}
-                {index != filteredTabGroups.length - 1 && <Divider />}
-              </div>
-            );
-          })}
+                  />
+                  {/* <Divider /> */}
+                  {index != filteredTabGroups.length - 1 && <Divider />}
+                </DraggableRow>
+              );
+            })}
+          </RowDragArea>
         </div>
       )}
     </div>

--- a/src/redux/middleware/customMiddleware.ts
+++ b/src/redux/middleware/customMiddleware.ts
@@ -28,6 +28,8 @@ import {
   DELETE_CHROME_GROUP_ACTION,
   MOVE_TAB_ACTION,
   MOVE_WINDOW_ACTION,
+  MOVE_SESSION_ACTION,
+  CLEAR_SESSION_ORDER_ACTION,
 } from '../../utils/constants/actionTypes';
 import type { RootState } from '../store';
 
@@ -54,6 +56,8 @@ const actionsToCapture = [
   DELETE_TAB_ACTION,
   MOVE_TAB_ACTION,
   MOVE_WINDOW_ACTION,
+  MOVE_SESSION_ACTION,
+  CLEAR_SESSION_ORDER_ACTION,
 
   // actions in globalStateSlice
   IS_DIRTY_ACTION,

--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -18,6 +18,7 @@ import {
   RestoreSessionRequest,
   WindowSpec,
 } from '../../utils/functions/windows';
+import { createdInstant } from '../../utils/functions/mergeTabData';
 import {
   DEFAULT_WINDOW_HEIGHT,
   DEFAULT_WINDOW_OFFSET_LEFT,
@@ -80,6 +81,19 @@ export interface tabContainerData {
   // Optional because every document written before this change lacks it.
   // Readers fall back to the container's lastModified; see mergeTabData.ts.
   lastModified?: number;
+  // Where the user put this session, if they have moved it (KAN-130).
+  //
+  // IN THE SAME NUMERIC SPACE AS createdInstant -- epoch milliseconds -- which
+  // is the decision the whole feature rests on. It lets ranks be SPARSE: only
+  // sessions actually dragged carry one, and they still compare correctly
+  // against sessions that do not. So a drag writes ONE session rather than
+  // renumbering the list, and a list with no ranks sorts exactly as it did
+  // before this field existed.
+  //
+  // The list is in custom order iff any session carries this. That is why there
+  // is no stored sort mode: a container-level field would need its own merge
+  // rule, and this merge has none for one.
+  rank?: number;
 }
 
 // A deleted session has to leave a trace. Merging by tabGroupId alone would
@@ -190,6 +204,16 @@ export interface moveTabParams {
 // belongs to a Chrome group, a window belongs to nothing. So the drop rule
 // really is just an index, and there is one axis to compare when deciding
 // whether a drop changed anything.
+// Where a session sits in the left pane (KAN-130).
+//
+// toIndex indexes the RENDERED list, which is the stored array order -- these
+// are the same thing while no search is active, and dragging is disabled while
+// one is (KAN-131).
+export interface moveSessionParams {
+  tabGroupId: string;
+  toIndex: number;
+}
+
 export interface moveWindowParams {
   tabGroupId: string;
   // Identity, not a position, for the same reason as moveTabParams: the source
@@ -539,6 +563,49 @@ function touch(group: tabContainerData): void {
   group.lastModified = Date.now();
 }
 
+// The key the session list is ordered by, newest/highest first (KAN-130).
+//
+// Imported rather than reimplemented: the merge sorts on exactly this, and two
+// implementations of "where does this session go" drifting apart is how a drag
+// gets silently undone by the next sync. One direction only -- mergeTabData
+// imports nothing from here as a value, deliberately, so it stays DOM-free.
+function rankOf(group: tabContainerData): number {
+  return group.rank ?? createdInstant(group);
+}
+
+// Ranks are sparse and live in createdInstant's space, so a session dropped
+// between two others takes the midpoint of its new neighbours.
+//
+// Returns null when there is no value strictly between them -- two sessions
+// saved in the same millisecond, or a gap already halved past a double's
+// precision. The caller renormalises rather than writing an ambiguous rank,
+// because an ambiguous rank lets two devices sort the same data differently,
+// which is the one thing the merge must never allow.
+const END_GAP = 60_000;
+
+function rankBetween(
+  above: number | null,
+  below: number | null
+): number | null {
+  if (above === null && below === null) return null;
+  // Dropped at the top or the bottom: step clear of the only neighbour.
+  if (above === null) return below! + END_GAP;
+  if (below === null) return above - END_GAP;
+
+  const mid = above + (below - above) / 2;
+  return mid > below && mid < above ? mid : null;
+}
+
+// Give every session an explicit, evenly spaced rank in the array's current
+// order. The escape hatch for the two cases rankBetween cannot answer; it
+// touches every session, which is why it is a fallback and not the mechanism.
+function renormalise(groups: tabContainerData[], now: number): void {
+  groups.forEach((group, index) => {
+    group.rank = now - index * END_GAP;
+    touch(group);
+  });
+}
+
 // The session / window / group walk the three Chrome-group reducers share.
 //
 // Returns null rather than throwing when any level is missing, which is the
@@ -595,6 +662,16 @@ function sameSessionContent(a: tabContainerData, b: tabContainerData): boolean {
     a.title === b.title &&
     a.createdTime === b.createdTime &&
     a.createdAt === b.createdAt &&
+    // Where the user put this session (KAN-130). A new field is a new hole in
+    // this comparator until it is read here: a session whose only change is its
+    // rank would compare EQUAL, be handed back with its snapshot timestamp, and
+    // lose the next merge to the cloud copy that still holds the drag -- the
+    // undo applying and then silently reverting. That is KAN-80, KAN-83 and
+    // KAN-125, three times over.
+    //
+    // `undefined === undefined` is the common case and is correct: a session
+    // that has never been dragged compares equal to itself.
+    a.rank === b.rank &&
     a.isAutoSave === b.isAutoSave &&
     a.windowCount === b.windowCount &&
     a.tabCount === b.tabCount &&
@@ -1278,6 +1355,98 @@ export const tabContainerDataStateSlice = createSlice({
       saveToLocalStorage('tabContainerData', state);
     },
 
+    // move a session within the left pane (KAN-130)
+    //
+    // WRITES BOTH THE ARRAY AND A RANK, and both are load-bearing. The stored
+    // array order IS the display order -- selectVisibleTabGroups filters but
+    // never sorts -- so splicing is what makes the drag visible at all. The
+    // merge re-derives order from rankOf on every sync, so the rank is what
+    // makes it survive. Setting only one of the two gives a drag that either
+    // does nothing until a sync, or is undone by one.
+    //
+    // The invariant tying them together: sorting the resulting array by rankOf
+    // must reproduce that same array.
+    moveSessionInternal: (state, action: PayloadAction<moveSessionParams>) => {
+      const { tabGroupId, toIndex } = action.payload;
+
+      const fromIndex = state.tabGroups.findIndex(
+        (group) => group.tabGroupId === tabGroupId
+      );
+      // Same shape as the sibling reducers: an id that does not resolve means
+      // the action arrived for data that is no longer there.
+      if (fromIndex === -1) return;
+
+      const target = Math.min(Math.max(0, toIndex), state.tabGroups.length - 1);
+      // A drop where it started is not an edit. Without this it would stamp the
+      // session, dirty it for a cloud write and push an undo step for something
+      // the user cannot see.
+      if (target === fromIndex) return;
+
+      const [moved] = state.tabGroups.splice(fromIndex, 1);
+      state.tabGroups.splice(target, 0, moved);
+
+      // The neighbours it now sits between, in the array it now sits in.
+      // Highest rank first, so "above" is the larger value.
+      const above = target > 0 ? rankOf(state.tabGroups[target - 1]) : null;
+      const below =
+        target < state.tabGroups.length - 1
+          ? rankOf(state.tabGroups[target + 1])
+          : null;
+
+      const rank = rankBetween(above, below);
+      if (rank === null) {
+        // No value fits between the neighbours -- same-millisecond saves, or a
+        // gap halved past a double's precision. Rebuild every rank rather than
+        // write one that sorts ambiguously.
+        renormalise(state.tabGroups, Date.now());
+      } else {
+        moved.rank = rank;
+        // touch, not stampCreated: createdAt is what rankOf falls back to, so
+        // restamping would move this session inside the list being reordered.
+        touch(moved);
+      }
+
+      state.lastModified = Date.now();
+
+      // update localstorage
+      saveToLocalStorage('tabContainerData', state);
+    },
+
+    // Drop every manual rank and return the list to newest-first (KAN-130).
+    //
+    // Cheap by construction: it REMOVES ranks rather than assigning them, so it
+    // touches only the sessions that were actually moved. Sorting by title
+    // would be the opposite -- a rank on every session -- which is why that is
+    // a separate decision (KAN-106).
+    clearSessionOrder: (state) => {
+      const ranked = state.tabGroups.filter((g) => g.rank !== undefined);
+      // Nothing to clear is not an edit, or the control would stamp every
+      // session and queue a cloud write every time it was pressed.
+      if (ranked.length === 0) return;
+
+      for (const group of ranked) {
+        delete group.rank;
+        touch(group);
+      }
+
+      // The array is the display order, so it has to be put back too -- the
+      // same pairing moveSessionInternal maintains.
+      state.tabGroups.sort(
+        (a, b) =>
+          createdInstant(b) - createdInstant(a) ||
+          (a.tabGroupId < b.tabGroupId
+            ? -1
+            : a.tabGroupId > b.tabGroupId
+              ? 1
+              : 0)
+      );
+
+      state.lastModified = Date.now();
+
+      // update localstorage
+      saveToLocalStorage('tabContainerData', state);
+    },
+
     // move a window within its session
     //
     // The counts are deliberately untouched: a reorder changes neither how many
@@ -1599,6 +1768,8 @@ export const {
   deleteTabInternal,
   moveTabInternal,
   moveWindowInternal,
+  moveSessionInternal,
+  clearSessionOrder,
   replaceState,
   restoreContainer,
   applyUndoSnapshot,

--- a/src/tests/components/sessionDragReorder.test.tsx
+++ b/src/tests/components/sessionDragReorder.test.tsx
@@ -1,0 +1,221 @@
+import { describe, expect, test, afterEach } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+
+import TabGroupEntryContainer from '../../components/home/leftpane/TabGroupEntryContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import type { RenderWithProvidersResult } from '../setup/renderWithProviders';
+import {
+  openSearchPanel,
+  setSearchInputText,
+  setHasTabGroupsPermission,
+  setIsNotDirty,
+} from '../../redux/slices/globalStateSlice';
+import { saveToTabContainerInternal } from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-130. Dragging sessions in the left pane, and the strip that says the list
+// has stopped meaning "newest first".
+
+const HOUR = 3600_000;
+const T0 = Date.UTC(2026, 8, 9, 12, 0, 0);
+const ROW_H = 40;
+
+const box = (top: number, height: number) =>
+  ({
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 200,
+    height,
+    width: 200,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+const session = (id: string, title: string, createdAt: number) => ({
+  tabGroupId: id,
+  title,
+  createdTime: '2026-09-09 12:00:00',
+  createdAt,
+  windowCount: 1,
+  tabCount: 1,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: `${id}-w`,
+      windowHeight: 100,
+      windowWidth: 100,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 1,
+      title: 'Window',
+      tabs: [
+        {
+          tabId: `${id}-t`,
+          favicon: '',
+          title: `${title} tab`,
+          url: 'https://a.co',
+        },
+      ],
+    },
+  ],
+});
+
+// Saved oldest first, so the pane renders newest-first: CHARLIE, BRAVO, ALPHA.
+const render = (searchText?: string) =>
+  renderWithProviders(<TabGroupEntryContainer />, {
+    seedStore: (store) => {
+      store.dispatch(setHasTabGroupsPermission(false));
+      store.dispatch(
+        saveToTabContainerInternal(session('a', 'ALPHA', T0 - 2 * HOUR))
+      );
+      store.dispatch(
+        saveToTabContainerInternal(session('b', 'BRAVO', T0 - HOUR))
+      );
+      store.dispatch(saveToTabContainerInternal(session('c', 'CHARLIE', T0)));
+      if (searchText !== undefined) {
+        store.dispatch(openSearchPanel());
+        store.dispatch(setSearchInputText(searchText));
+      }
+      store.dispatch(setIsNotDirty());
+    },
+  });
+
+const nodeFor = (container: HTMLElement, id: string) =>
+  container.querySelector<HTMLElement>(`[data-drag-row-id="${id}"]`)!;
+
+const layout = (container: HTMLElement, ids: string[]) =>
+  ids.forEach((id, i) => {
+    nodeFor(container, id).getBoundingClientRect = () => box(i * ROW_H, ROW_H);
+  });
+
+const drag = (from: HTMLElement, startY: number, endY: number) => {
+  fireEvent.pointerDown(from, { clientX: 10, clientY: startY, button: 0 });
+  fireEvent.pointerMove(document, {
+    clientX: 10,
+    clientY: (startY + endY) / 2,
+  });
+  fireEvent.pointerMove(document, { clientX: 10, clientY: endY });
+  fireEvent.pointerUp(document, { clientX: 10, clientY: endY });
+  // Chrome synthesizes a click after mouseup; jsdom does not. Firing it keeps
+  // the sequence faithful, and it matters: the drag arms a 400ms suppression
+  // window that this click SPENDS. Without it the window stays armed and the
+  // next deliberate click in the test is swallowed -- which is a test artifact,
+  // not the app's behaviour.
+  fireEvent.click(from, { clientX: 10, clientY: endY });
+};
+
+const order = (store: RenderWithProvidersResult['store']) =>
+  store.getState().tabContainerDataState.tabGroups.map((g) => g.tabGroupId);
+
+afterEach(() => {
+  document.documentElement.removeAttribute('data-dragging');
+});
+
+describe('dragging a session in the left pane', () => {
+  test('moves it to the front', async () => {
+    const { container, store } = await render();
+    layout(container, ['c', 'b', 'a']);
+    expect(order(store)).toEqual(['c', 'b', 'a']);
+
+    // ALPHA is last (midpoint 100); drop it above CHARLIE.
+    drag(nodeFor(container, 'a'), 100, 5);
+
+    expect(order(store)).toEqual(['a', 'c', 'b']);
+  });
+
+  test('moves it to the back', async () => {
+    const { container, store } = await render();
+    layout(container, ['c', 'b', 'a']);
+
+    drag(nodeFor(container, 'c'), 20, 115);
+
+    expect(order(store)).toEqual(['b', 'a', 'c']);
+  });
+
+  // The invariant the reducer maintains, asserted through the UI: the rank it
+  // wrote must reproduce the array order when sorted, or the next sync undoes
+  // the drag the user just watched happen.
+  test('the resulting order survives a re-sort by rank', async () => {
+    const { container, store } = await render();
+    layout(container, ['c', 'b', 'a']);
+
+    drag(nodeFor(container, 'a'), 100, 5);
+
+    const groups = store.getState().tabContainerDataState.tabGroups;
+    const key = (g: (typeof groups)[number]) => g.rank ?? g.createdAt!;
+    const resorted = [...groups].sort((x, y) => key(y) - key(x));
+    expect(resorted.map((g) => g.tabGroupId)).toEqual(
+      groups.map((g) => g.tabGroupId)
+    );
+  });
+});
+
+// KAN-131 at the session level, where it is most exposed: search filters
+// sessions directly, so the rendered list and the stored one differ outright.
+describe('a session drag inside a filtered list', () => {
+  test('commits nothing', async () => {
+    const { container, store } = await render('ALPHA');
+    const rendered = [
+      ...container.querySelectorAll<HTMLElement>('[data-drag-row-id]'),
+    ];
+    expect(rendered).toHaveLength(1);
+    rendered[0].getBoundingClientRect = () => box(0, ROW_H);
+
+    drag(rendered[0], 20, 300);
+
+    expect(order(store)).toEqual(['c', 'b', 'a']);
+    expect(store.getState().globalState.isDirty).toBe(false);
+  });
+});
+
+describe('the custom-order strip', () => {
+  const strip = () => screen.queryByLabelText('Sort by date saved');
+
+  test('is absent until something is dragged', async () => {
+    const { container } = await render();
+    layout(container, ['c', 'b', 'a']);
+
+    expect(strip()).toBeNull();
+    expect(screen.queryByText('Custom order')).toBeNull();
+  });
+
+  test('appears once the list is in custom order', async () => {
+    const { container } = await render();
+    layout(container, ['c', 'b', 'a']);
+
+    drag(nodeFor(container, 'a'), 100, 5);
+
+    expect(strip()).not.toBeNull();
+    expect(screen.getByText('Custom order')).toBeInTheDocument();
+  });
+
+  test('resets to newest-first and then hides itself', async () => {
+    const { container, store } = await render();
+    layout(container, ['c', 'b', 'a']);
+    drag(nodeFor(container, 'a'), 100, 5);
+    expect(order(store)).toEqual(['a', 'c', 'b']);
+
+    fireEvent.click(strip()!);
+
+    expect(order(store)).toEqual(['c', 'b', 'a']);
+    expect(strip()).toBeNull();
+  });
+
+  // Offering the reset while searching would promise something about a list
+  // the user cannot see -- the reset applies to the stored order, not the
+  // narrowed one on screen.
+  test('is hidden while a search is filtering the list', async () => {
+    const { container, store, rerender } = await render();
+    layout(container, ['c', 'b', 'a']);
+    drag(nodeFor(container, 'a'), 100, 5);
+    expect(strip()).not.toBeNull();
+
+    store.dispatch(openSearchPanel());
+    store.dispatch(setSearchInputText('ALPHA'));
+    rerender(<TabGroupEntryContainer />);
+
+    expect(strip()).toBeNull();
+  });
+});

--- a/src/tests/redux/moveSession.test.ts
+++ b/src/tests/redux/moveSession.test.ts
@@ -228,6 +228,38 @@ describe('moveSessionInternal when there is no gap to land in', () => {
     return store;
   };
 
+  // THE ONE THAT ACTUALLY REACHES renormalise, and it took a mutation to find
+  // out that nothing did. Dropping at either END is not enough: rankBetween
+  // returns early there, because one neighbour is null and it just steps clear
+  // of the other. Only a drop into the MIDDLE gives it two equal neighbours
+  // with no value between them.
+  test('a drop between two equal neighbours rebuilds every rank', () => {
+    const store = seededSameInstant();
+    const before = ids(store);
+
+    // Into the middle: both neighbours are the same instant.
+    store.dispatch(moveSessionInternal({ tabGroupId: before[0], toIndex: 1 }));
+
+    const groups = store.getState().tabContainerDataState.tabGroups;
+    // Every session now carries an explicit rank -- that is what renormalising
+    // means, and it is the one path that touches the whole list.
+    expect(groups.every((g) => g.rank !== undefined)).toBe(true);
+    // And they are strictly descending, so the order is unambiguous. An
+    // ambiguous rank is the thing this path exists to avoid: it would let two
+    // devices sort the same data differently.
+    const ranks = groups.map((g) => g.rank!);
+    expect(ranks.every((r, i) => i === 0 || ranks[i - 1] > r)).toBe(true);
+  });
+
+  test('and that rebuild still puts the session where it was dropped', () => {
+    const store = seededSameInstant();
+    const before = ids(store);
+
+    store.dispatch(moveSessionInternal({ tabGroupId: before[0], toIndex: 1 }));
+
+    expect(ids(store)[1]).toBe(before[0]);
+  });
+
   test('still lands the session where it was dropped', () => {
     const store = seededSameInstant();
     const before = ids(store);

--- a/src/tests/redux/moveSession.test.ts
+++ b/src/tests/redux/moveSession.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, test, vi } from 'vitest';
+
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+import { makeTestStore } from '../setup/makeStore';
+import {
+  saveToTabContainerInternal,
+  moveSessionInternal,
+  clearSessionOrder,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import { setIsNotDirty } from '../../redux/slices/globalStateSlice';
+
+// KAN-130. A session's position becomes real, stored, syncable order.
+//
+// TWO THINGS MUST AGREE, and that is the crux of this reducer. The stored array
+// order IS the display order -- selectVisibleTabGroups filters but never sorts
+// -- so a drag has to splice the array to be visible at all. The merge, though,
+// re-derives order on every sync from `rank ?? createdInstant`. So the reducer
+// writes both, and the invariant is that sorting the result by rankOf
+// reproduces the array it just built. A reducer that set only the rank would
+// appear to do nothing until the next sync; one that set only the array would
+// be undone BY the next sync.
+
+const HOUR = 3600_000;
+const T0 = Date.UTC(2026, 8, 9, 12, 0, 0);
+
+// Created an hour apart, newest first -- which is the order the app maintains.
+const build = (id: string, createdAt: number) => ({
+  tabGroupId: id,
+  title: id.toUpperCase(),
+  createdTime: '2026-09-09 12:00:00',
+  createdAt,
+  windowCount: 1,
+  tabCount: 1,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: `${id}-w`,
+      windowHeight: 100,
+      windowWidth: 100,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 1,
+      title: 'Window',
+      tabs: [
+        { tabId: `${id}-t`, favicon: '', title: 'Tab', url: 'https://a.co' },
+      ],
+    },
+  ],
+});
+
+type Store = ReturnType<typeof makeTestStore>['store'];
+
+// Seeded oldest-first through saveToTabContainerInternal, which unshifts -- so
+// the resulting array is newest-first: c, b, a.
+const seeded = () => {
+  const { store } = makeTestStore();
+  store.dispatch(saveToTabContainerInternal(build('a', T0 - 2 * HOUR)));
+  store.dispatch(saveToTabContainerInternal(build('b', T0 - HOUR)));
+  store.dispatch(saveToTabContainerInternal(build('c', T0)));
+  store.dispatch(setIsNotDirty());
+  return store;
+};
+
+const ids = (s: Store) =>
+  s.getState().tabContainerDataState.tabGroups.map((g) => g.tabGroupId);
+const groupOf = (s: Store, id: string) =>
+  s
+    .getState()
+    .tabContainerDataState.tabGroups.find((g) => g.tabGroupId === id)!;
+const rankOf = (s: Store, id: string) => {
+  const g = groupOf(s, id);
+  return g.rank ?? g.createdAt!;
+};
+
+describe('the seeded list', () => {
+  test('is newest-first and carries no ranks', () => {
+    const store = seeded();
+    expect(ids(store)).toEqual(['c', 'b', 'a']);
+    expect(
+      store
+        .getState()
+        .tabContainerDataState.tabGroups.every((g) => g.rank === undefined)
+    ).toBe(true);
+  });
+});
+
+describe('moveSessionInternal', () => {
+  test('moves a session to the front', () => {
+    const store = seeded();
+    store.dispatch(moveSessionInternal({ tabGroupId: 'a', toIndex: 0 }));
+    expect(ids(store)).toEqual(['a', 'c', 'b']);
+  });
+
+  test('moves a session to the back', () => {
+    const store = seeded();
+    store.dispatch(moveSessionInternal({ tabGroupId: 'c', toIndex: 2 }));
+    expect(ids(store)).toEqual(['b', 'a', 'c']);
+  });
+
+  test('moves a session into the middle', () => {
+    const store = seeded();
+    store.dispatch(moveSessionInternal({ tabGroupId: 'c', toIndex: 1 }));
+    expect(ids(store)).toEqual(['b', 'c', 'a']);
+  });
+
+  // Only the dragged session gains a rank. Ranks are SPARSE -- that is what
+  // keeps a drag a one-session write rather than a rewrite of the list.
+  test('writes a rank on the moved session only', () => {
+    const store = seeded();
+    store.dispatch(moveSessionInternal({ tabGroupId: 'a', toIndex: 0 }));
+
+    expect(groupOf(store, 'a').rank).toBeTypeOf('number');
+    expect(groupOf(store, 'b').rank).toBeUndefined();
+    expect(groupOf(store, 'c').rank).toBeUndefined();
+  });
+
+  // THE INVARIANT. Sorting the result by rankOf must reproduce the array the
+  // reducer just built, or the next sync silently undoes the drag.
+  test('the new rank reproduces the array order when sorted', () => {
+    const store = seeded();
+    store.dispatch(moveSessionInternal({ tabGroupId: 'c', toIndex: 1 }));
+
+    const order = ids(store);
+    const bySortKey = [...order].sort(
+      (x, y) => rankOf(store, y) - rankOf(store, x)
+    );
+    expect(bySortKey).toEqual(order);
+  });
+
+  test('the invariant holds for a move to the front', () => {
+    const store = seeded();
+    store.dispatch(moveSessionInternal({ tabGroupId: 'a', toIndex: 0 }));
+
+    const order = ids(store);
+    const bySortKey = [...order].sort(
+      (x, y) => rankOf(store, y) - rankOf(store, x)
+    );
+    expect(bySortKey).toEqual(order);
+  });
+
+  test('the invariant holds for a move to the back', () => {
+    const store = seeded();
+    store.dispatch(moveSessionInternal({ tabGroupId: 'c', toIndex: 2 }));
+
+    const order = ids(store);
+    const bySortKey = [...order].sort(
+      (x, y) => rankOf(store, y) - rankOf(store, x)
+    );
+    expect(bySortKey).toEqual(order);
+  });
+
+  // touch, not stampCreated: createdAt is what rankOf falls back to, so
+  // restamping would move the session inside the very list being reordered.
+  test('does not restamp createdAt', () => {
+    const store = seeded();
+    const before = groupOf(store, 'a').createdAt;
+
+    store.dispatch(moveSessionInternal({ tabGroupId: 'a', toIndex: 0 }));
+
+    expect(groupOf(store, 'a').createdAt).toBe(before);
+  });
+
+  test('leaves session contents alone', () => {
+    const store = seeded();
+    store.dispatch(moveSessionInternal({ tabGroupId: 'a', toIndex: 0 }));
+
+    const moved = groupOf(store, 'a');
+    expect(moved.windowCount).toBe(1);
+    expect(moved.tabCount).toBe(1);
+    expect(moved.windows[0].tabs[0].tabId).toBe('a-t');
+  });
+});
+
+describe('moveSessionInternal does nothing when there is nothing to do', () => {
+  test('a drop in the same position is not an edit', () => {
+    const store = seeded();
+    const before = groupOf(store, 'b').lastModified;
+
+    store.dispatch(moveSessionInternal({ tabGroupId: 'b', toIndex: 1 }));
+
+    expect(ids(store)).toEqual(['c', 'b', 'a']);
+    expect(groupOf(store, 'b').lastModified).toBe(before);
+    expect(groupOf(store, 'b').rank).toBeUndefined();
+    expect(store.getState().globalState.isDirty).toBe(false);
+  });
+
+  test('an unknown session id changes nothing', () => {
+    const store = seeded();
+    store.dispatch(moveSessionInternal({ tabGroupId: 'nope', toIndex: 0 }));
+
+    expect(ids(store)).toEqual(['c', 'b', 'a']);
+    expect(store.getState().globalState.isDirty).toBe(false);
+  });
+
+  test('an out-of-range index clamps rather than throwing', () => {
+    const store = seeded();
+    store.dispatch(moveSessionInternal({ tabGroupId: 'c', toIndex: 99 }));
+    expect(ids(store)).toEqual(['b', 'a', 'c']);
+
+    store.dispatch(moveSessionInternal({ tabGroupId: 'c', toIndex: -5 }));
+    expect(ids(store)).toEqual(['c', 'b', 'a']);
+  });
+});
+
+// Two sessions saved in the same millisecond have no value between them, so the
+// midpoint collapses onto a neighbour. That must renormalise rather than write
+// a rank that sorts ambiguously -- an ambiguous rank means two devices can
+// disagree about the order, which is the one thing the merge must never allow.
+describe('moveSessionInternal when there is no gap to land in', () => {
+  const seededSameInstant = () => {
+    const { store } = makeTestStore();
+    store.dispatch(saveToTabContainerInternal(build('a', T0)));
+    store.dispatch(saveToTabContainerInternal(build('b', T0)));
+    store.dispatch(saveToTabContainerInternal(build('c', T0)));
+    store.dispatch(setIsNotDirty());
+    return store;
+  };
+
+  test('still lands the session where it was dropped', () => {
+    const store = seededSameInstant();
+    const before = ids(store);
+
+    store.dispatch(moveSessionInternal({ tabGroupId: before[2], toIndex: 0 }));
+
+    expect(ids(store)[0]).toBe(before[2]);
+  });
+
+  test('and leaves an order that survives a re-sort', () => {
+    const store = seededSameInstant();
+    const before = ids(store);
+
+    store.dispatch(moveSessionInternal({ tabGroupId: before[2], toIndex: 0 }));
+
+    const order = ids(store);
+    const bySortKey = [...order].sort(
+      (x, y) => rankOf(store, y) - rankOf(store, x)
+    );
+    expect(bySortKey).toEqual(order);
+  });
+});
+
+describe('clearSessionOrder', () => {
+  test('restores newest-first and drops every rank', () => {
+    const store = seeded();
+    store.dispatch(moveSessionInternal({ tabGroupId: 'a', toIndex: 0 }));
+    expect(ids(store)).toEqual(['a', 'c', 'b']);
+
+    store.dispatch(clearSessionOrder());
+
+    expect(ids(store)).toEqual(['c', 'b', 'a']);
+    expect(
+      store
+        .getState()
+        .tabContainerDataState.tabGroups.every((g) => g.rank === undefined)
+    ).toBe(true);
+  });
+
+  // CONTROL. With nothing to clear it must not stamp every session and queue a
+  // pointless cloud write.
+  test('CONTROL: with no ranks it is not an edit', () => {
+    const store = seeded();
+    const before = store
+      .getState()
+      .tabContainerDataState.tabGroups.map((g) => g.lastModified);
+
+    store.dispatch(clearSessionOrder());
+
+    expect(
+      store
+        .getState()
+        .tabContainerDataState.tabGroups.map((g) => g.lastModified)
+    ).toEqual(before);
+    expect(store.getState().globalState.isDirty).toBe(false);
+  });
+});

--- a/src/tests/redux/sessionRankMerge.test.ts
+++ b/src/tests/redux/sessionRankMerge.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from 'vitest';
+
+import { mergeTabContainers } from '../../utils/functions/mergeTabData';
+import type {
+  TabMasterContainer,
+  tabContainerData,
+} from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-130. The merge orders the session list, so a manual order only survives
+// if the merge sorts on it.
+//
+// The change is deliberately confined to the sort KEY -- `rank ?? createdInstant`
+// instead of `createdInstant`. The merge's LOGIC is untouched, because it is
+// already session-granular last-writer-wins: a field ON the session is resolved
+// correctly with no new rule. That is the whole reason this scope turned out
+// cheaper than KAN-130 estimated.
+
+const HOUR = 3600_000;
+const T0 = Date.UTC(2026, 8, 9, 12, 0, 0);
+
+const session = (
+  id: string,
+  createdAt: number,
+  extra: Partial<tabContainerData> = {}
+): tabContainerData => ({
+  tabGroupId: id,
+  title: id.toUpperCase(),
+  createdTime: '2026-09-09 12:00:00',
+  createdAt,
+  windowCount: 0,
+  tabCount: 0,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [],
+  lastModified: createdAt,
+  ...extra,
+});
+
+const container = (groups: tabContainerData[]): TabMasterContainer => ({
+  lastModified: T0,
+  selectedTabGroupId: null,
+  tabGroups: groups,
+  deletedTabGroups: [],
+});
+
+const order = (c: TabMasterContainer) => c.tabGroups.map((g) => g.tabGroupId);
+
+describe('the merge orders by rank when one is present', () => {
+  test('a ranked session outranks a newer unranked one', () => {
+    // `a` is the OLDEST, so newest-first would put it last. A rank above `c`'s
+    // createdInstant must lift it to the top.
+    const local = container([
+      session('c', T0),
+      session('b', T0 - HOUR),
+      session('a', T0 - 2 * HOUR, { rank: T0 + HOUR }),
+    ]);
+
+    const { merged } = mergeTabContainers(local, container([]), T0);
+
+    expect(order(merged)).toEqual(['a', 'c', 'b']);
+  });
+
+  test('ranks and createdInstants compare in one space', () => {
+    // `b` is ranked BETWEEN c and a's creation instants, so it must land
+    // between them -- which only works because both are epoch millis.
+    const local = container([
+      session('c', T0),
+      session('a', T0 - 2 * HOUR),
+      session('b', T0 - HOUR, { rank: T0 - HOUR / 2 }),
+    ]);
+
+    const { merged } = mergeTabContainers(local, container([]), T0);
+
+    expect(order(merged)).toEqual(['c', 'b', 'a']);
+  });
+
+  // THE REGRESSION CONTROL. Every session that exists today has no rank, and
+  // this list must come out exactly as it did before the field existed.
+  test('CONTROL: a list with no ranks is ordered exactly as before', () => {
+    const local = container([
+      session('a', T0 - 2 * HOUR),
+      session('c', T0),
+      session('b', T0 - HOUR),
+    ]);
+
+    const { merged } = mergeTabContainers(local, container([]), T0);
+
+    expect(order(merged)).toEqual(['c', 'b', 'a']);
+  });
+
+  // The merge's ordering must stay TOTAL and STABLE, because that is what makes
+  // two devices agree on the list at all. Equal keys still break on tabGroupId.
+  test('equal ranks still break ties deterministically', () => {
+    const local = container([
+      session('b', T0, { rank: T0 }),
+      session('a', T0 - HOUR, { rank: T0 }),
+    ]);
+    const flipped = container([
+      session('a', T0 - HOUR, { rank: T0 }),
+      session('b', T0, { rank: T0 }),
+    ]);
+
+    const one = mergeTabContainers(local, container([]), T0).merged;
+    const two = mergeTabContainers(flipped, container([]), T0).merged;
+
+    expect(order(one)).toEqual(order(two));
+  });
+});
+
+// The case KAN-130 called "a two-device concurrent-reorder story". It needs no
+// new machinery: a rank is a session field, so each device's move is resolved
+// by the per-session last-writer-wins the merge already performs.
+describe('two devices reordering at once', () => {
+  test('converge on the same list from either side', () => {
+    // Laptop moved `a` to the top; phone moved `c` to the bottom. Neither
+    // touched the other's session.
+    const laptop = container([
+      session('a', T0 - 2 * HOUR, { rank: T0 + HOUR, lastModified: T0 + 10 }),
+      session('c', T0),
+      session('b', T0 - HOUR),
+    ]);
+    const phone = container([
+      session('c', T0, { rank: T0 - 3 * HOUR, lastModified: T0 + 20 }),
+      session('b', T0 - HOUR),
+      session('a', T0 - 2 * HOUR),
+    ]);
+
+    const fromLaptop = mergeTabContainers(laptop, phone, T0).merged;
+    const fromPhone = mergeTabContainers(phone, laptop, T0).merged;
+
+    // Both devices end up with the same list -- which is the requirement.
+    // Convergence, not any particular winner, is what the merge owes here.
+    expect(order(fromLaptop)).toEqual(order(fromPhone));
+    // And both moves are honoured, because they touched different sessions.
+    expect(order(fromLaptop)).toEqual(['a', 'b', 'c']);
+  });
+
+  test('the newer edit to the SAME session wins, as everywhere else', () => {
+    const laptop = container([
+      session('a', T0 - HOUR, { rank: T0 + HOUR, lastModified: T0 + 10 }),
+      session('b', T0),
+    ]);
+    const phone = container([
+      session('a', T0 - HOUR, { rank: T0 - 5 * HOUR, lastModified: T0 + 99 }),
+      session('b', T0),
+    ]);
+
+    const { merged } = mergeTabContainers(laptop, phone, T0);
+
+    // The phone's later rank wins, putting `a` below `b`.
+    expect(order(merged)).toEqual(['b', 'a']);
+  });
+});

--- a/src/tests/redux/undoSessionReorderSurvivesSync.test.ts
+++ b/src/tests/redux/undoSessionReorderSurvivesSync.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+const mocks = vi.hoisted(() => ({
+  loadFromFirestore: vi.fn(async (): Promise<unknown> => undefined),
+  saveToFirestore: vi.fn<(userId: string, data: unknown) => Promise<void>>(
+    async () => undefined
+  ),
+}));
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: mocks.loadFromFirestore,
+  saveToFirestore: mocks.saveToFirestore,
+  displayToast: vi.fn(),
+}));
+
+import {
+  setSignedIn,
+  setUserId,
+  syncStateWithFirestore,
+} from '../../redux/slices/globalStateSlice';
+import {
+  saveToTabContainerInternal,
+  moveSessionInternal,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import { undo } from '../../redux/slices/undoRedoSlice';
+import { makeTestStore } from '../setup/makeStore';
+
+// KAN-130, and the check this module has earned four times over.
+//
+// reconcileAssertedContainer only stamps a restored session it can SEE has
+// changed, and it decides that with sameSessionContent. Any field the
+// comparator does not read is a field whose undo is silently reverted by the
+// next sync: the session is handed back carrying its snapshot timestamp and
+// loses the merge to the cloud copy that still holds the edit.
+//
+// `rank` is a new field, so it is a new hole until the comparator reads it.
+// KAN-80, KAN-83 and KAN-125 were all exactly this, and KAN-129 was where I
+// credited the WRONG field and the mutation disproved it -- so this is verified
+// by blinding the comparator, not by reading it.
+
+const HOUR = 3600_000;
+const T0 = Date.UTC(2026, 8, 9, 12, 0, 0);
+
+const session = (id: string, createdAt: number) => ({
+  tabGroupId: id,
+  title: id.toUpperCase(),
+  createdTime: '2026-09-09 12:00:00',
+  createdAt,
+  windowCount: 1,
+  tabCount: 1,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: `${id}-w`,
+      windowHeight: 100,
+      windowWidth: 100,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 1,
+      title: 'Window',
+      tabs: [
+        { tabId: `${id}-t`, favicon: '', title: 'Tab', url: 'https://a.co' },
+      ],
+    },
+  ],
+});
+
+type Store = ReturnType<typeof makeTestStore>['store'];
+const ids = (s: Store) =>
+  s.getState().tabContainerDataState.tabGroups.map((g) => g.tabGroupId);
+
+const seeded = () => {
+  const { store } = makeTestStore();
+  store.dispatch(setSignedIn());
+  store.dispatch(setUserId('u1'));
+  store.dispatch(saveToTabContainerInternal(session('a', T0 - 2 * HOUR)));
+  store.dispatch(saveToTabContainerInternal(session('b', T0 - HOUR)));
+  store.dispatch(saveToTabContainerInternal(session('c', T0)));
+  return store;
+};
+
+describe('undoing a session reorder survives the next sync (KAN-130)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mocks.loadFromFirestore.mockReset();
+    mocks.saveToFirestore.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('keeps the order the user undid', async () => {
+    const store = seeded();
+    expect(ids(store)).toEqual(['c', 'b', 'a']);
+
+    store.dispatch(moveSessionInternal({ tabGroupId: 'a', toIndex: 0 }));
+    expect(ids(store)).toEqual(['a', 'c', 'b']);
+
+    // The cloud received the reorder, exactly as auto-sync would have pushed
+    // it, before the undo.
+    const cloud = JSON.parse(
+      JSON.stringify(store.getState().tabContainerDataState)
+    );
+
+    store.dispatch(undo());
+    const afterUndo = store.getState().tabContainerDataState;
+    // The undo itself works -- asserted separately, because this and the merge
+    // failing look identical from the UI and are not the same bug.
+    expect(afterUndo.tabGroups.map((g) => g.tabGroupId)).toEqual([
+      'c',
+      'b',
+      'a',
+    ]);
+
+    mocks.loadFromFirestore.mockResolvedValue(cloud);
+    localStorage.setItem('tabContainerData', JSON.stringify(afterUndo));
+    await store.dispatch(syncStateWithFirestore() as never);
+
+    expect(ids(store)).toEqual(['c', 'b', 'a']);
+    // And the rank is gone, not merely out-ranked -- otherwise the list is
+    // chronological by luck and the next edit reveals the stale rank.
+    expect(
+      store
+        .getState()
+        .tabContainerDataState.tabGroups.find((g) => g.tabGroupId === 'a')!.rank
+    ).toBeUndefined();
+  });
+
+  // THE CONTROL, and the one that says the comparator is scoped correctly.
+  // Reporting MORE sessions as changed makes the assertion above easier to
+  // pass, and turns an undo into an assertion over the whole container --
+  // overwriting edits another device made to sessions the user never touched.
+  it('does not clobber an unrelated session edited elsewhere', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(T0);
+      const store = seeded();
+
+      vi.setSystemTime(T0 + 1_000);
+      store.dispatch(moveSessionInternal({ tabGroupId: 'a', toIndex: 0 }));
+
+      const cloud = JSON.parse(
+        JSON.stringify(store.getState().tabContainerDataState)
+      );
+      const b = cloud.tabGroups.find(
+        (g: { tabGroupId: string }) => g.tabGroupId === 'b'
+      );
+      b.title = 'EDITED ON LAPTOP';
+      b.lastModified = T0 + 500;
+
+      vi.setSystemTime(T0 + 2_000);
+      store.dispatch(undo());
+      const afterUndo = store.getState().tabContainerDataState;
+
+      mocks.loadFromFirestore.mockResolvedValue(cloud);
+      localStorage.setItem('tabContainerData', JSON.stringify(afterUndo));
+      await store.dispatch(syncStateWithFirestore() as never);
+
+      const merged = store.getState().tabContainerDataState;
+      expect(merged.tabGroups.map((g) => g.tabGroupId)).toEqual([
+        'c',
+        'b',
+        'a',
+      ]);
+      expect(merged.tabGroups.find((g) => g.tabGroupId === 'b')!.title).toBe(
+        'EDITED ON LAPTOP'
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/utils/constants/actionTypes.ts
+++ b/src/utils/constants/actionTypes.ts
@@ -46,6 +46,9 @@ export const DELETE_WINDOW_ACTION =
 export const DELETE_TAB_ACTION = 'tabContainerDataState/deleteTabInternal';
 export const MOVE_TAB_ACTION = 'tabContainerDataState/moveTabInternal';
 export const MOVE_WINDOW_ACTION = 'tabContainerDataState/moveWindowInternal';
+export const MOVE_SESSION_ACTION = 'tabContainerDataState/moveSessionInternal';
+export const CLEAR_SESSION_ORDER_ACTION =
+  'tabContainerDataState/clearSessionOrder';
 
 // global actions
 export const IS_DIRTY_ACTION = 'globalState/setIsDirty';

--- a/src/utils/functions/mergeTabData.ts
+++ b/src/utils/functions/mergeTabData.ts
@@ -69,6 +69,15 @@ export function createdInstant(group: tabContainerData): number {
   return Date.UTC(year, month - 1, day, hour, minute, second);
 }
 
+// What the session list is ordered by, highest first.
+//
+// The fallback is what keeps this change invisible to every session that
+// already exists: with no rank the key IS createdInstant, so the order is
+// byte-identical to the one this replaces.
+export function sessionRank(group: tabContainerData): number {
+  return group.rank ?? createdInstant(group);
+}
+
 type Event =
   | { kind: 'present'; at: number; group: tabContainerData }
   | { kind: 'deleted'; at: number };
@@ -196,10 +205,18 @@ export function mergeTabContainers(
   // moment, so comparing the strings ordered them by where the user was rather
   // than by when they saved. tabGroupId breaks exact ties so the result is
   // total and stable.
+  // `rank` is the user's own placement, when they have made one (KAN-130). It
+  // lives in createdInstant's space -- epoch millis -- so the two compare
+  // directly and ranks can be SPARSE: only dragged sessions carry one, and a
+  // list with none sorts exactly as it did before the field existed.
+  //
+  // Only the KEY changes here. The merge's logic is untouched, because it is
+  // already session-granular last-writer-wins, so a field on the session is
+  // resolved correctly with no new rule -- including two devices reordering
+  // different sessions at once.
   survivors.sort(
     (a, b) =>
-      createdInstant(b) - createdInstant(a) ||
-      compareAsc(a.tabGroupId, b.tabGroupId)
+      sessionRank(b) - sessionRank(a) || compareAsc(a.tabGroupId, b.tabGroupId)
   );
 
   // Selection is per-device view state; pushing the other device's selection


### PR DESCRIPTION
## What

Sessions in the left pane can be dragged into a new order, and a control appears offering the way back to newest-first.

Scope 3 of KAN-10 — the one held since the start.

> Replaces **#228**, which was opened stacked on #227 and closed automatically when that branch was deleted on merge — a base branch's deletion closes its stacked PR, and it cannot be reopened. Same branch, rebased onto `main`, now targeting `main` so CI runs.

## Both gates that held this are now resolved

**The evidence gate — resolved *against* dragging.** KAN-130 says the reviews justifying KAN-10 were never checked for which level they meant, and that recovering them would likely need the developer dashboard. They were recovered from the **public** reviews page on 2026-09-07: across two channels and three years, **nobody unambiguously asked to reorder sessions**. Four of the five requests are tab-level and are satisfied by KAN-128; the only explicit session-order request is KAN-106's, which asks for *sorting*.

This ships because Justine asked for it directly and uses the product daily, which is its own evidence. Recorded plainly so nobody later mistakes it for archive-driven.

**The cost gate — resolved cheaper than the ticket states.** It says this needs "a change to the merge's ordering contract, in the module with three reversal regressions behind it". It does not.

The merge is **session-granular last-writer-wins** — `collect` resolves whole sessions and emits them. So a field *on* the session is already merged correctly with no new rule, including the "two-device concurrent-reorder story" the ticket asks for. Only the sort **key** changes:

```ts
survivors.sort(
  (a, b) => sessionRank(b) - sessionRank(a) || compareAsc(a.tabGroupId, b.tabGroupId)
);
// sessionRank(g) = g.rank ?? createdInstant(g)
```

The `tabGroupId` tiebreak stays, so the order remains total and stable — which is the property two devices actually depend on to converge.

## The mechanism: sparse ranks in createdInstant's space

`rank` is optional and lives in **epoch milliseconds**, the same space as `createdInstant`. That one decision is what makes everything else cheap:

| | |
| --- | --- |
| **Default** | no session carries a rank, so the list sorts exactly as before — bit for bit |
| **A drag** | writes a rank on **one** session: the midpoint of its two new neighbours |
| **Reset** | deletes `rank` from the few sessions that carry one |
| **The mode** | *derived* — custom iff any session has a rank |
| **New sessions** | still `unshift` with no rank; unchanged |
| **Sync** | rides the existing per-session LWW |
| **Undo** | one entry in `sameSessionContent` |

**Why the mode is derived, not stored.** A `sortMode` would be a *container-level* field, and this merge has no last-writer-wins rule for one: `lastModified` is a `max` and `selectedTabGroupId` is deliberately per-device. A stored mode would need exactly the new merge rule this design avoids. Deriving it also makes every device agree without syncing anything new.

## Two things must agree — and that is the crux

The stored array order **is** the display order: `selectVisibleTabGroups` filters but never sorts. So a drag has to splice the array to be visible at all. But the merge re-derives order on every sync, so the rank is what makes it survive.

Write only the rank → the drag appears to do nothing until a sync. Write only the array → the drag is undone *by* the next sync.

The invariant tying them together: **sorting the result by `rankOf` must reproduce the array the reducer just built.** Both directions are pinned independently — mutations M3 and M4 below fail on different tests.

### Two real limits, handled

A gap halved past a double's precision, and two sessions saved in the same millisecond — neither has a value between the neighbours. Both **renormalise** rather than write an ambiguous rank, because an ambiguous rank lets two devices sort the same data differently, which is the one thing the merge must never allow.

**This was initially claimed as tested and was not.** Making `renormalise()` a complete no-op broke none of the 1053 tests. The same-millisecond test dropped a session at the *top*, where `rankBetween` returns early — one neighbour is null, so it steps clear of the other and never needs a midpoint. Only a drop into the **middle** produces two equal neighbours with nothing between them. Two tests added for that case (`189120a`), and the mutation now fails.

## This dissolves the KAN-106 conflict

KAN-130 argues sorting and dragging are rivals at the session level: order is owned by the merge, so a sort must be a view transform, which then disagrees with a stored manual order about what the list is.

That holds only while order is derived. With a stored rank, **"sort by X" becomes a one-shot reassignment of ranks** — precisely what sorting already is at the tab level — so sorting and dragging compose. The asymmetry the ticket identifies between the two levels disappears.

**Sorting by title is deliberately out of scope.** It is the one operation that must touch *every* session, which is a large sync write and a large undo step. "Reset to newest-first" is free by contrast, because it *removes* ranks.

## The control

**A strip inside the list box, rendered only in custom order.**

Measured first: the left pane is **354.5px**, the header's four icons take **128px**, and the title block ends at **136.3px** — so a fifth header icon fits with ~58px spare. It is still the wrong home: undo, redo, sync and settings are **app-level**, and a list-level control among them miscategorises it.

Rendering it only in custom order means users who never drag see **no new chrome at all**, and the affordance appears at the moment the list stops meaning "newest first" — which is the moment that needs explaining, since the order was previously self-evident from the dates on the rows.

Hidden while searching: the reset applies to the stored order, not the narrowed list on screen, and offering it there would promise something about a list the user cannot see.

## Evidence

**1055 tests pass**, tsc clean, lint 0 errors. Two new i18n keys across all ten locales — the coverage test caught them, which is what it is for.

| mutation | what failed |
| --- | --- |
| `sameSessionContent` blinded to `rank` | the 2 undo-through-sync tests |
| merge sorts by `createdInstant` again | the 2 rank-ordering merge tests |
| rank written, array **not** spliced | 14 tests |
| array spliced, rank **not** written | 9 tests |
| no-op guard removed | "a drop in the same position is not an edit" |
| actions unregistered in the middleware | the 2 undo tests |

**The middleware one was found by a test, not by review.** Before registering the actions, `undo()` reverted the last *captured* action instead — **deleting a session** rather than undoing the drag. The test failed with a session missing entirely, which is what pointed at it.

### Live, in the real popup

Against the rebuilt artifact:

- A session dragged upward took rank **1788902703146** — the exact midpoint of its two new neighbours' keys (`1788964012967` and `1788841393325`).
- **Only that session** gained a rank. Sparse, as designed.
- The strip appeared reading "Custom order".
- **The order survived a real Firestore round trip unchanged** — the property KAN-130 said required changing the merge's ordering contract.
- The reset restored newest-first, cleared every rank, and hid the strip.

Closes KAN-130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
