### PR TITLE
Guard applyUndoSnapshot against having nothing to restore (KAN-137)

### DIFF
--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -1552,11 +1552,32 @@ export const tabContainerDataStateSlice = createSlice({
     applyUndoSnapshot: (
       state,
       action: PayloadAction<{
-        snapshot: TabMasterContainer;
+        // Optional because the dispatcher genuinely can pass nothing -- see the
+        // guard below. Declaring it required did not make it so; it only hid
+        // the case from the compiler.
+        snapshot: TabMasterContainer | undefined;
         withdrawTabGroupIds: string[];
       }>
     ) => {
       const { snapshot, withdrawTabGroupIds } = action.payload;
+
+      // There may be no snapshot to restore, and the type above said otherwise
+      // (KAN-137). customMiddleware builds this action as a plain object
+      // literal rather than through the action creator, so nothing checks the
+      // payload: it passes `presentState.tabContainerDataState`, which is
+      // undefined until `present` has been seeded. reconcileAssertedContainer
+      // then read `.tabGroups` off undefined and threw INSIDE dispatch().
+      //
+      // The damage surfaced nowhere near here. In MainContainer's cmd+Z
+      // handler the throw unwound before the next line -- event.preventDefault()
+      // -- so the visible symptom was a keyboard shortcut that dispatched undo
+      // yet left the event un-prevented, and nine tests failed for a change
+      // that touched neither keyboard handling nor sessions.
+      //
+      // Nothing to restore means nothing to do; the alternative is replacing
+      // the container with undefined.
+      if (!snapshot) return state;
+
       const liveAt = new Map(
         state.tabGroups.map((tabGroup) => [
           tabGroup.tabGroupId,

--- a/src/tests/components/sliceImportCycle.test.tsx
+++ b/src/tests/components/sliceImportCycle.test.tsx
@@ -1,0 +1,63 @@
+// KAN-137. Importing the session slice must not break unrelated code.
+//
+// THE IMPORT ORDER BELOW IS THE TEST. `tabContainerDataStateSlice` is imported
+// FIRST, before MainContainer, which is what a component importing it does to
+// the module graph. While tabContainerDataStateSlice and globalStateSlice
+// imported each other at runtime, that ordering left one of them partially
+// initialised, and the damage surfaced somewhere else entirely.
+//
+// What it looked like: a cmd+Z chord dispatched `undoRedo/undo` but
+// `event.defaultPrevented` stayed false, so it read as a broken keyboard
+// shortcut. The real cause was `Cannot read properties of undefined (reading
+// 'tabGroups')` thrown inside dispatch(), which unwound before MainContainer's
+// handler reached its next line -- `event.preventDefault()`. Nine tests in
+// undoRedoChords.test.tsx failed for a change that touched neither keyboard
+// handling nor sessions.
+//
+// It never reached users: rollup hoists cyclic bindings differently from
+// vitest's module runner, and the built extension worked. It failed CI, which
+// is enough -- the next person to import this slice would lose the same hour.
+import { clearSessionOrder } from '../../redux/slices/tabContainerDataStateSlice';
+
+import { describe, expect, test } from 'vitest';
+import { act } from '@testing-library/react';
+
+import MainContainer from '../../components/MainContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+
+describe('importing the session slice early', () => {
+  test('the action creator is defined, not a partially initialised module', () => {
+    expect(typeof clearSessionOrder).toBe('function');
+    expect(clearSessionOrder().type).toBe(
+      'tabContainerDataState/clearSessionOrder'
+    );
+  });
+
+  // The canary. This is the assertion that actually failed, two steps
+  // downstream of the cycle, and it is why the test lives here rather than
+  // being a static import-graph check: what matters is that nothing throws
+  // during dispatch, not that any particular edge is absent.
+  test('a cmd+Z chord still reaches preventDefault', async () => {
+    const errors: string[] = [];
+    const onError = (e: ErrorEvent) => errors.push(String(e.message));
+    window.addEventListener('error', onError);
+
+    await renderWithProviders(<MainContainer />);
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'z',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => {
+      document.body.dispatchEvent(event);
+    });
+    window.removeEventListener('error', onError);
+
+    // Asserted before defaultPrevented, because it names the CAUSE. Left to
+    // the flag alone, a failure here reads as a keyboard bug.
+    expect(errors).toEqual([]);
+    expect(event.defaultPrevented).toBe(true);
+  });
+});

--- a/src/tests/redux/undoWithNoSnapshot.test.ts
+++ b/src/tests/redux/undoWithNoSnapshot.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test, vi } from 'vitest';
+
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+import { makeTestStore } from '../setup/makeStore';
+import {
+  saveToTabContainerInternal,
+  applyUndoSnapshot,
+} from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-137. applyUndoSnapshot can be handed nothing to restore.
+//
+// customMiddleware builds this action as a plain object literal rather than
+// through the action creator, so nothing type-checks the payload -- it passes
+// `presentState.tabContainerDataState`, which is undefined until `present` has
+// been seeded. reconcileAssertedContainer then read `.tabGroups` off undefined
+// and threw inside dispatch().
+//
+// The guard's SHAPE matters as much as its presence: returning the initial
+// state instead of the current one would satisfy "does not throw" while
+// deleting every session the user has. That is what the second test here is
+// for -- removing the guard fails the first, and weakening it to
+// `return initialState` fails the second.
+
+const build = (id: string) => ({
+  tabGroupId: id,
+  title: id.toUpperCase(),
+  createdTime: '2026-09-09 12:00:00',
+  createdAt: Date.UTC(2026, 8, 9, 12, 0, 0),
+  windowCount: 1,
+  tabCount: 1,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: `${id}-w`,
+      windowHeight: 100,
+      windowWidth: 100,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 1,
+      title: 'Window',
+      tabs: [
+        { tabId: `${id}-t`, favicon: '', title: 'Tab', url: 'https://a.co' },
+      ],
+    },
+  ],
+});
+
+const seeded = () => {
+  const { store } = makeTestStore();
+  store.dispatch(saveToTabContainerInternal(build('a')));
+  store.dispatch(saveToTabContainerInternal(build('b')));
+  return store;
+};
+
+describe('applyUndoSnapshot with nothing to restore', () => {
+  test('does not throw', () => {
+    const store = seeded();
+
+    expect(() =>
+      store.dispatch(
+        applyUndoSnapshot({ snapshot: undefined, withdrawTabGroupIds: [] })
+      )
+    ).not.toThrow();
+  });
+
+  // THE ONE THAT DECIDES THE GUARD'S SHAPE. "Nothing to restore" means leave
+  // the container alone -- not reset it. A guard returning initialState would
+  // pass every other test in the suite while silently deleting the user's
+  // sessions.
+  test('leaves every existing session in place', () => {
+    const store = seeded();
+    const before = store
+      .getState()
+      .tabContainerDataState.tabGroups.map((g) => g.tabGroupId);
+    expect(before).toEqual(['b', 'a']);
+
+    store.dispatch(
+      applyUndoSnapshot({ snapshot: undefined, withdrawTabGroupIds: [] })
+    );
+
+    expect(
+      store.getState().tabContainerDataState.tabGroups.map((g) => g.tabGroupId)
+    ).toEqual(before);
+  });
+
+  test('and leaves the container timestamp alone', () => {
+    const store = seeded();
+    const before = store.getState().tabContainerDataState.lastModified;
+
+    store.dispatch(
+      applyUndoSnapshot({ snapshot: undefined, withdrawTabGroupIds: [] })
+    );
+
+    expect(store.getState().tabContainerDataState.lastModified).toBe(before);
+  });
+});


### PR DESCRIPTION
## What

`applyUndoSnapshot` can be handed nothing to restore, and dereferenced it.

```ts
if (!snapshot) return state;
```

Plus `snapshot: TabMasterContainer | undefined`, so the type says what is true.

## The failure looked like a keyboard bug

Adding one import of the session slice to a left-pane component failed **9 tests in `undoRedoChords.test.tsx`** — a file about keyboard shortcuts, in a change that touched neither keyboard handling nor sessions. The visible assertion:

```
expect(r.prevented).toBe(true)   // cmd+Z dispatched undo, but defaultPrevented was false
```

A `window.addEventListener('error')` probe gave the real story:

```
TypeError: Cannot read properties of undefined (reading 'tabGroups')
    at reconcileAssertedContainer  (tabContainerDataStateSlice.ts:1706)
    at applyUndoSnapshot           (tabContainerDataStateSlice.ts:1565)
```

The throw happens **inside `dispatch()`**. In `MainContainer`'s handler it unwound before the next line — `event.preventDefault()` — so the symptom appeared two steps downstream of the cause.

## Root cause

`customMiddleware` builds this action as a **plain object literal** rather than through the action creator:

```ts
store.dispatch({
  type: TAB_CONTAINER_APPLY_UNDO_SNAPSHOT_ACTION,
  payload: { snapshot: presentState.tabContainerDataState, withdrawTabGroupIds },
});
```

so nothing type-checks the payload. `presentState.tabContainerDataState` is `undefined` until `present` has been seeded. The reducer declared `snapshot: TabMasterContainer`, non-optional — **a lie the compiler could not catch**, precisely because the dispatcher bypasses the creator.

Importing the slice earlier only changed *whether `present` was seeded by the time undo ran*. It perturbed the timing; it was never the cause.

## I filed this with the wrong diagnosis

KAN-137 was filed blaming a module cycle between `tabContainerDataStateSlice` and `globalStateSlice`, and I began cutting that edge — extracting `replaceState` into a neutral module. Two edges in, the failure persisted. A stack trace found it in one step.

**That extraction is reverted.** It was unproven scope creep on the path every merge lands through, and the guard alone fixes it.

Worth recording: `madge` reports **24** circular dependencies on `main` and **25** with that "fix" — because it counts type-only imports, which emit nothing at runtime. The number badly overstates the problem and was not a useful signal. The cycles are real; they were not causing this, and this PR leaves them alone.

## The guard's shape needed its own test

Removing the guard fails the canary. But weakening it to `return initialState` **passed every test in the suite** — while silently deleting every session the user has. Found by mutating, not by reading.

| mutation | what failed |
| --- | --- |
| guard removed | the cmd+Z canary |
| guard returns `initialState` | the 2 "sessions preserved" tests |

## Tests

**1060 pass**, tsc clean, lint 0 errors.

- `sliceImportCycle.test.tsx` reproduces the original failure independently of the feature that found it: it imports the session slice **first**, then renders `MainContainer`, and asserts no error escapes `dispatch()`. It asserts the collected errors *before* the `defaultPrevented` flag, deliberately — the flag alone reads as a keyboard bug and hides the cause.
- `undoWithNoSnapshot.test.ts` pins the guard's shape: does not throw, leaves every session in place, leaves the container timestamp alone.

## Unblocks

**KAN-136**, whose sort menu needs the session slice imported into the header.

Closes KAN-137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
