### PR TITLE
Track when a session's contents last changed (KAN-138)

### DIFF
--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -81,6 +81,19 @@ export interface tabContainerData {
   // Optional because every document written before this change lacks it.
   // Readers fall back to the container's lastModified; see mergeTabData.ts.
   lastModified?: number;
+  // When this session's CONTENTS last changed (KAN-138).
+  //
+  // Distinct from lastModified, which means "differs from the cloud's copy" and
+  // must be bumped by anything that has to sync -- REORDERING INCLUDED, or the
+  // reorder is reverted by the next merge (KAN-80, KAN-83, KAN-125). A
+  // whole-list sort therefore flattens every lastModified to the same instant,
+  // which makes it useless as a "recently changed" ordering.
+  //
+  // This one is bumped only by edits to what the session HOLDS, never by where
+  // it sits in the list. Optional, like createdAt and rank: absent on every
+  // session written before it existed, and readers fall back.
+  contentModified?: number;
+
   // Where the user put this session, if they have moved it (KAN-130).
   //
   // IN THE SAME NUMERIC SPACE AS createdInstant -- epoch milliseconds -- which
@@ -563,6 +576,20 @@ function touch(group: tabContainerData): void {
   group.lastModified = Date.now();
 }
 
+// The session's CONTENTS changed (KAN-138) -- as opposed to merely its place in
+// the list.
+//
+// Every content reducer calls this; the ordering reducers and applyUndoSnapshot
+// call plain `touch`. That split is the whole feature: it is what keeps
+// contentModified meaningful after a sort, which flattens every lastModified.
+//
+// An undo restores contentModified from its snapshot rather than setting it to
+// now, which is why applyUndoSnapshot must NOT use this.
+function touchContent(group: tabContainerData): void {
+  touch(group);
+  group.contentModified = Date.now();
+}
+
 // The key the session list is ordered by, newest/highest first (KAN-130).
 //
 // Imported rather than reimplemented: the merge sorts on exactly this, and two
@@ -772,7 +799,7 @@ export const tabContainerDataStateSlice = createSlice({
     ) => {
       const newTabGroupId = action.payload.tabGroupId;
       state.tabGroups.unshift(action.payload);
-      touch(state.tabGroups[0]);
+      touchContent(state.tabGroups[0]);
       state.lastModified = Date.now();
 
       // update localstorage
@@ -822,7 +849,7 @@ export const tabContainerDataStateSlice = createSlice({
         state.tabGroups[tabGroupIndex].tabCount += window.tabCount;
         stampCreated(state.tabGroups[tabGroupIndex]);
         state.tabGroups[tabGroupIndex].windows.unshift(window);
-        touch(state.tabGroups[tabGroupIndex]);
+        touchContent(state.tabGroups[tabGroupIndex]);
       }
       state.lastModified = Date.now();
 
@@ -853,7 +880,7 @@ export const tabContainerDataStateSlice = createSlice({
           state.tabGroups[tabGroupIndex].windows[windowIndex].tabs.unshift(
             currentTabData
           );
-          touch(state.tabGroups[tabGroupIndex]);
+          touchContent(state.tabGroups[tabGroupIndex]);
         }
       }
       state.lastModified = Date.now();
@@ -890,7 +917,7 @@ export const tabContainerDataStateSlice = createSlice({
       );
       if (tabGroupIndex !== -1) {
         state.tabGroups[tabGroupIndex].title = normalizeTitle(newTitle);
-        touch(state.tabGroups[tabGroupIndex]);
+        touchContent(state.tabGroups[tabGroupIndex]);
       }
       state.lastModified = Date.now();
       // update localstorage
@@ -918,7 +945,7 @@ export const tabContainerDataStateSlice = createSlice({
         if (windowIndex !== -1) {
           state.tabGroups[tabGroupIndex].windows[windowIndex].title =
             normalizeTitle(newTitle);
-          touch(state.tabGroups[tabGroupIndex]);
+          touchContent(state.tabGroups[tabGroupIndex]);
         }
       }
       state.lastModified = Date.now();
@@ -968,7 +995,7 @@ export const tabContainerDataStateSlice = createSlice({
       if (group.title === newTitle) return;
 
       group.title = newTitle;
-      touch(state.tabGroups[tabGroupIndex]);
+      touchContent(state.tabGroups[tabGroupIndex]);
       state.lastModified = Date.now();
       // update localstorage
       saveToLocalStorage('tabContainerData', state);
@@ -1020,7 +1047,7 @@ export const tabContainerDataStateSlice = createSlice({
       container.tabCount += 1;
       window.tabCount += 1;
       stampCreated(container);
-      touch(container);
+      touchContent(container);
       state.lastModified = Date.now();
       saveToLocalStorage('tabContainerData', state);
     },
@@ -1057,7 +1084,7 @@ export const tabContainerDataStateSlice = createSlice({
       if (group.color === color) return;
 
       group.color = color;
-      touch(container);
+      touchContent(container);
       state.lastModified = Date.now();
       saveToLocalStorage('tabContainerData', state);
     },
@@ -1088,7 +1115,7 @@ export const tabContainerDataStateSlice = createSlice({
         if (tab.chromeGroupId === groupId) delete tab.chromeGroupId;
       }
 
-      touch(container);
+      touchContent(container);
       state.lastModified = Date.now();
       saveToLocalStorage('tabContainerData', state);
     },
@@ -1138,7 +1165,7 @@ export const tabContainerDataStateSlice = createSlice({
         bury(state, container.tabGroupId);
         state.tabGroups.splice(containerIndex, 1);
       } else {
-        touch(container);
+        touchContent(container);
       }
 
       state.lastModified = Date.now();
@@ -1202,7 +1229,7 @@ export const tabContainerDataStateSlice = createSlice({
           bury(state, state.tabGroups[tabGroupIndex].tabGroupId);
           state.tabGroups.splice(tabGroupIndex, 1);
         } else {
-          touch(state.tabGroups[tabGroupIndex]);
+          touchContent(state.tabGroups[tabGroupIndex]);
         }
       }
       state.lastModified = Date.now();
@@ -1264,7 +1291,7 @@ export const tabContainerDataStateSlice = createSlice({
           bury(state, state.tabGroups[tabGroupIndex].tabGroupId);
           state.tabGroups.splice(tabGroupIndex, 1);
         } else {
-          touch(state.tabGroups[tabGroupIndex]);
+          touchContent(state.tabGroups[tabGroupIndex]);
         }
       }
       state.lastModified = Date.now();
@@ -1348,7 +1375,7 @@ export const tabContainerDataStateSlice = createSlice({
       // touch, not stampCreated: a reorder is an edit, and stampCreated would
       // reset createdAt, which is what the merge orders the session list by.
       // Nudging a tab must not send its session to the top of the left pane.
-      touch(container);
+      touchContent(container);
       state.lastModified = Date.now();
 
       // update localstorage
@@ -1494,7 +1521,7 @@ export const tabContainerDataStateSlice = createSlice({
       // touch, not stampCreated: a reorder is an edit, and stampCreated would
       // reset createdAt, which is what the merge orders the session list by.
       // Nudging a window must not send its session to the top of the left pane.
-      touch(container);
+      touchContent(container);
       state.lastModified = Date.now();
 
       // update localstorage

--- a/src/tests/redux/contentModified.test.ts
+++ b/src/tests/redux/contentModified.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+import { makeTestStore } from '../setup/makeStore';
+import {
+  saveToTabContainerInternal,
+  addCurrTabToWindowInternal,
+  updateTabGroupTitle,
+  updateWindowGroupTitle,
+  updateChromeTabGroupTitle,
+  updateChromeTabGroupColor,
+  ungroupChromeTabGroup,
+  deleteChromeTabGroupInternal,
+  addCurrTabToChromeGroupInternal,
+  deleteWindowInternal,
+  deleteTabInternal,
+  moveTabInternal,
+  moveWindowInternal,
+  moveSessionInternal,
+  clearSessionOrder,
+} from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-138. `contentModified` records when a session's CONTENTS changed, as
+// opposed to when it last needed syncing.
+//
+// TABLE-DRIVEN ON PURPOSE. The implementation is one helper swapped in at
+// fourteen call sites, and the way that goes wrong is missing one -- a content
+// edit that silently fails to update the field, invisible until someone sorts
+// by it and a session sits in the wrong place. Enumerating the actions makes a
+// missed site a test failure instead of a hope.
+//
+// Adding a content reducer without a row here is the same mistake one level up,
+// so the count is asserted too.
+
+const T0 = Date.UTC(2026, 8, 9, 12, 0, 0);
+
+const build = () => ({
+  tabGroupId: 'tg',
+  title: 'Session',
+  createdTime: '2026-09-09 12:00:00',
+  createdAt: T0,
+  // Two windows and three tabs, matching the fixture below. Declaring
+  // windowCount: 1 here made deleteWindowInternal drive the count to zero and
+  // remove the whole session -- the documented cascade doing its job against a
+  // fixture that lied about its own shape.
+  windowCount: 2,
+  tabCount: 3,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: 'w1',
+      windowHeight: 100,
+      windowWidth: 100,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 2,
+      title: 'Window',
+      tabs: [
+        {
+          tabId: 't1',
+          favicon: '',
+          title: 'One',
+          url: 'https://a.co',
+          chromeGroupId: 'grp',
+        },
+        { tabId: 't2', favicon: '', title: 'Two', url: 'https://b.co' },
+      ],
+      chromeTabGroups: [{ groupId: 'grp', title: 'Research', color: 'blue' }],
+    },
+    {
+      windowId: 'w2',
+      windowHeight: 100,
+      windowWidth: 100,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 1,
+      title: 'Second',
+      tabs: [{ tabId: 't3', favicon: '', title: 'Three', url: 'https://c.co' }],
+    },
+  ],
+});
+
+type Store = ReturnType<typeof makeTestStore>['store'];
+
+const seeded = () => {
+  const { store } = makeTestStore();
+  store.dispatch(saveToTabContainerInternal(build()));
+  return store;
+};
+
+const contentModifiedOf = (s: Store) =>
+  s
+    .getState()
+    .tabContainerDataState.tabGroups.find((g) => g.tabGroupId === 'tg')
+    ?.contentModified;
+
+// Every reducer that changes what a session HOLDS.
+const CONTENT_EDITS: [string, (s: Store) => void][] = [
+  [
+    'addCurrTabToWindowInternal',
+    (s) =>
+      s.dispatch(
+        addCurrTabToWindowInternal({
+          tabGroupId: 'tg',
+          windowId: 'w1',
+          tabData: {
+            tabId: 'new',
+            favicon: '',
+            title: 'N',
+            url: 'https://n.co',
+          },
+        })
+      ),
+  ],
+  [
+    'updateTabGroupTitle',
+    (s) =>
+      s.dispatch(
+        updateTabGroupTitle({ tabGroupId: 'tg', editableTitle: 'Renamed' })
+      ),
+  ],
+  [
+    'updateWindowGroupTitle',
+    (s) =>
+      s.dispatch(
+        updateWindowGroupTitle({
+          tabGroupId: 'tg',
+          windowId: 'w1',
+          editableTitle: 'Renamed',
+        })
+      ),
+  ],
+  [
+    'updateChromeTabGroupTitle',
+    (s) =>
+      s.dispatch(
+        updateChromeTabGroupTitle({
+          tabGroupId: 'tg',
+          windowId: 'w1',
+          groupId: 'grp',
+          editableTitle: 'Renamed',
+        })
+      ),
+  ],
+  [
+    'updateChromeTabGroupColor',
+    (s) =>
+      s.dispatch(
+        updateChromeTabGroupColor({
+          tabGroupId: 'tg',
+          windowId: 'w1',
+          groupId: 'grp',
+          color: 'purple',
+        })
+      ),
+  ],
+  [
+    'addCurrTabToChromeGroupInternal',
+    (s) =>
+      s.dispatch(
+        addCurrTabToChromeGroupInternal({
+          tabGroupId: 'tg',
+          windowId: 'w1',
+          groupId: 'grp',
+          tabData: {
+            tabId: 'g1',
+            favicon: '',
+            title: 'G',
+            url: 'https://g.co',
+          },
+        })
+      ),
+  ],
+  [
+    'ungroupChromeTabGroup',
+    (s) =>
+      s.dispatch(
+        ungroupChromeTabGroup({
+          tabGroupId: 'tg',
+          windowId: 'w1',
+          groupId: 'grp',
+        })
+      ),
+  ],
+  [
+    'deleteChromeTabGroupInternal',
+    (s) =>
+      s.dispatch(
+        deleteChromeTabGroupInternal({
+          tabGroupId: 'tg',
+          windowId: 'w1',
+          groupId: 'grp',
+        })
+      ),
+  ],
+  [
+    'deleteTabInternal',
+    (s) =>
+      s.dispatch(
+        deleteTabInternal({ tabGroupId: 'tg', windowId: 'w1', tabId: 't2' })
+      ),
+  ],
+  [
+    'deleteWindowInternal',
+    (s) =>
+      s.dispatch(deleteWindowInternal({ tabGroupId: 'tg', windowId: 'w2' })),
+  ],
+  [
+    'moveTabInternal',
+    (s) =>
+      s.dispatch(
+        moveTabInternal({
+          tabGroupId: 'tg',
+          windowId: 'w1',
+          tabId: 't2',
+          toIndex: 0,
+        })
+      ),
+  ],
+  [
+    'moveWindowInternal',
+    (s) =>
+      s.dispatch(
+        moveWindowInternal({ tabGroupId: 'tg', windowId: 'w2', toIndex: 0 })
+      ),
+  ],
+];
+
+describe('contentModified advances on every content edit', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('saving a session sets it', () => {
+    const store = seeded();
+    expect(contentModifiedOf(store)).toBe(T0);
+  });
+
+  test.each(CONTENT_EDITS)('%s advances it', (_name, edit) => {
+    const store = seeded();
+    const before = contentModifiedOf(store);
+
+    vi.setSystemTime(T0 + 5_000);
+    edit(store);
+
+    expect(contentModifiedOf(store)).toBe(T0 + 5_000);
+    expect(contentModifiedOf(store)).not.toBe(before);
+  });
+
+  // Guards the table itself. A content reducer added without a row above would
+  // otherwise be untested, which is the failure this whole file exists to stop.
+  test('the table covers every content reducer', () => {
+    expect(CONTENT_EDITS).toHaveLength(12);
+  });
+});
+
+// THE OTHER HALF, and the reason the field exists at all. Ordering a list is
+// not a change to what any session holds.
+describe('reordering leaves contentModified alone', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const twoSessions = () => {
+    const { store } = makeTestStore();
+    store.dispatch(saveToTabContainerInternal(build()));
+    const second = build();
+    second.tabGroupId = 'tg2';
+    second.title = 'Another';
+    store.dispatch(saveToTabContainerInternal(second));
+    return store;
+  };
+
+  test('dragging a session does not touch it', () => {
+    const store = twoSessions();
+    const before = contentModifiedOf(store);
+
+    vi.setSystemTime(T0 + 5_000);
+    store.dispatch(moveSessionInternal({ tabGroupId: 'tg', toIndex: 0 }));
+
+    expect(contentModifiedOf(store)).toBe(before);
+  });
+
+  test('and lastModified DOES move, or the reorder would not sync', () => {
+    const store = twoSessions();
+    const lastModified = () =>
+      store
+        .getState()
+        .tabContainerDataState.tabGroups.find((g) => g.tabGroupId === 'tg')
+        ?.lastModified;
+    const before = lastModified();
+
+    vi.setSystemTime(T0 + 5_000);
+    store.dispatch(moveSessionInternal({ tabGroupId: 'tg', toIndex: 0 }));
+
+    expect(lastModified()).toBe(T0 + 5_000);
+    expect(lastModified()).not.toBe(before);
+  });
+
+  test('clearing the order does not touch it either', () => {
+    const store = twoSessions();
+    store.dispatch(moveSessionInternal({ tabGroupId: 'tg', toIndex: 0 }));
+    const before = contentModifiedOf(store);
+
+    vi.setSystemTime(T0 + 9_000);
+    store.dispatch(clearSessionOrder());
+
+    expect(contentModifiedOf(store)).toBe(before);
+  });
+});


### PR DESCRIPTION
## What

Adds `contentModified` — bumped only by edits to what a session **holds**, never by where it sits in the list.

Groundwork so **KAN-136** can offer "sort by date modified" and have it mean something. **No UI in this PR.**

## Why `lastModified` cannot be that key

`lastModified` means *"this session differs from the cloud's copy"*. Everything that must sync has to bump it — **reordering included**, or the reorder is silently reverted by the next merge. That is KAN-80, KAN-83 and KAN-125, three times over.

Measured on a three-session list:

```
drag one session   ->  touches ["a"]            just the one moved
sort by name       ->  touches ["a","b","c"]    all of them
```

A whole-list sort assigns a rank to every session, so it flattens every `lastModified` to the same instant. Ordering by that afterwards returns something close to arbitrary, with nothing on screen to say it has gone stale.

**A correction to how I first put this.** I said "ordering rewrites the modified date", implying every session on every reorder. A **drag** touches only the session dragged, which is defensible on its own — you did just act on it. It is the whole-list sorts that flatten the field. The narrower claim is the true one.

## The split turned out clean

I expected this to be invasive, because the slice has two stamping helpers. It isn't: **every content-mutating reducer already calls `touch()` exactly once.** `stampCreated` appears alongside it in six of them, but never instead of it.

So the change is one helper swapped in at fourteen sites:

```ts
function touchContent(group: tabContainerData): void {
  touch(group);
  group.contentModified = Date.now();
}
```

Four keep plain `touch`:

| | why |
| --- | --- |
| `moveSessionInternal` | ordering, not content |
| `clearSessionOrder` | ordering |
| `renormalise` | ordering |
| `applyUndoSnapshot` | must restore `contentModified` from the snapshot, not set it to now |

Optional and back-compatible, like `createdAt` and `rank`: absent on every existing session, and readers fall back.

## Not in `sameSessionContent`, deliberately

The instinct after KAN-130 is to add every new field to that whitelist. Here it would be wrong.

That comparator already excludes `lastModified`, and its comment says why — *"It is the thing the caller is deciding whether to rewrite."* This is the same kind of value: a byproduct of an edit, not content.

More decisively: **no operation changes `contentModified` alone.** By construction it moves only alongside a field the comparator already reads, so that session is already seen as changed. Adding it would be redundant at best, and at worst would make an undo assert sessions it did not change — the KAN-55 / KAN-125 control case. The existing undo-survives-sync tests cover the consequence.

## Merge

No change. It is a field on the session, and the merge is session-granular last-writer-wins, so it rides along inside the winning copy exactly as `rank` does. Note `survivors` overwrites `lastModified` and leaves `contentModified` untouched — which is the correct behaviour, since only the former describes sync state.

## Evidence

**1072 tests pass**, tsc clean, lint 0 errors.

The new file is **table-driven on purpose**. The way this change goes wrong is missing one call site — a content edit that silently fails to update the field, invisible until someone sorts by it and a session sits in the wrong place. Enumerating the actions makes a missed site a test failure. The table's own length is asserted too, so adding a content reducer without a row also fails.

| mutation | what failed |
| --- | --- |
| one content site left as plain `touch` | that row, and only that row |
| an ordering reducer using `touchContent` | "dragging a session does not touch it" |
| `touchContent` no longer bumps `lastModified` | 16 tests across the suite |

The first is the one that matters: it proves the table catches a missed site rather than merely looking thorough.

## One fixture bug found on the way

The test fixture declared `windowCount: 1` while carrying two windows, so deleting one drove the count to zero and the documented cascade removed the whole session. The cascade was right; the fixture lied about its own shape. Fixed, with a comment, because the next person will write the same fixture.

## Known limitation, carried forward

The session row displays the **save** date. Ordering by content-modified still orders by something not on screen. This makes the sort *correct*; it does not make it *legible*. Recorded on KAN-138 and KAN-136 rather than silently accepted.

Closes KAN-138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
