### PR TITLE
Sort sessions from a menu, with the active order ticked (KAN-136)

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -127,6 +127,9 @@
   "TabGroupsPromptConfirm": "Tab-Gruppen-Unterstützung aktivieren",
   "TabGroupsPromptDismiss": "Jetzt nicht",
   "TabGroupsPromptNever": "Nicht mehr fragen",
-  "Custom order": "Eigene Reihenfolge",
-  "Sort by date saved": "Nach Speicherdatum sortieren"
+  "Sort sessions": "Sitzungen sortieren",
+  "Date saved": "Speicherdatum",
+  "Name": "Name",
+  "Tab count": "Tab-Anzahl",
+  "Date modified": "Änderungsdatum"
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -127,6 +127,9 @@
   "TabGroupsPromptConfirm": "Enable tab group support",
   "TabGroupsPromptDismiss": "Not now",
   "TabGroupsPromptNever": "Don't ask again",
-  "Custom order": "Custom order",
-  "Sort by date saved": "Sort by date saved"
+  "Sort sessions": "Sort sessions",
+  "Date saved": "Date saved",
+  "Name": "Name",
+  "Tab count": "Tab count",
+  "Date modified": "Date modified"
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -127,6 +127,9 @@
   "TabGroupsPromptConfirm": "Activar la compatibilidad con grupos de pestañas",
   "TabGroupsPromptDismiss": "Ahora no",
   "TabGroupsPromptNever": "No volver a preguntar",
-  "Custom order": "Orden personalizado",
-  "Sort by date saved": "Ordenar por fecha de guardado"
+  "Sort sessions": "Ordenar sesiones",
+  "Date saved": "Fecha de guardado",
+  "Name": "Nombre",
+  "Tab count": "Número de pestañas",
+  "Date modified": "Fecha de modificación"
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -127,6 +127,9 @@
   "TabGroupsPromptConfirm": "Activer la prise en charge des groupes d'onglets",
   "TabGroupsPromptDismiss": "Pas maintenant",
   "TabGroupsPromptNever": "Ne plus demander",
-  "Custom order": "Ordre personnalisé",
-  "Sort by date saved": "Trier par date d’enregistrement"
+  "Sort sessions": "Trier les sessions",
+  "Date saved": "Date d'enregistrement",
+  "Name": "Nom",
+  "Tab count": "Nombre d'onglets",
+  "Date modified": "Date de modification"
 }

--- a/public/locales/hi/translation.json
+++ b/public/locales/hi/translation.json
@@ -127,6 +127,9 @@
   "TabGroupsPromptConfirm": "टैब समूह समर्थन चालू करें",
   "TabGroupsPromptDismiss": "अभी नहीं",
   "TabGroupsPromptNever": "फिर से न पूछें",
-  "Custom order": "कस्टम क्रम",
-  "Sort by date saved": "सहेजने की तिथि से क्रमबद्ध करें"
+  "Sort sessions": "सत्र क्रमबद्ध करें",
+  "Date saved": "सहेजने की तारीख",
+  "Name": "नाम",
+  "Tab count": "टैब संख्या",
+  "Date modified": "बदलाव की तारीख"
 }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -127,6 +127,9 @@
   "TabGroupsPromptConfirm": "Attiva il supporto ai gruppi di schede",
   "TabGroupsPromptDismiss": "Non ora",
   "TabGroupsPromptNever": "Non chiedere più",
-  "Custom order": "Ordine personalizzato",
-  "Sort by date saved": "Ordina per data di salvataggio"
+  "Sort sessions": "Ordina sessioni",
+  "Date saved": "Data di salvataggio",
+  "Name": "Nome",
+  "Tab count": "Numero di schede",
+  "Date modified": "Data di modifica"
 }

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -127,6 +127,9 @@
   "TabGroupsPromptConfirm": "タブグループのサポートを有効にする",
   "TabGroupsPromptDismiss": "後で",
   "TabGroupsPromptNever": "今後表示しない",
-  "Custom order": "カスタム順",
-  "Sort by date saved": "保存日で並べ替え"
+  "Sort sessions": "セッションを並べ替え",
+  "Date saved": "保存日",
+  "Name": "名前",
+  "Tab count": "タブ数",
+  "Date modified": "更新日"
 }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -127,6 +127,9 @@
   "TabGroupsPromptConfirm": "Ativar o suporte a grupos de guias",
   "TabGroupsPromptDismiss": "Agora não",
   "TabGroupsPromptNever": "Não perguntar novamente",
-  "Custom order": "Ordem personalizada",
-  "Sort by date saved": "Ordenar por data de salvamento"
+  "Sort sessions": "Ordenar sessões",
+  "Date saved": "Data de salvamento",
+  "Name": "Nome",
+  "Tab count": "Número de abas",
+  "Date modified": "Data de modificação"
 }

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -127,6 +127,9 @@
   "TabGroupsPromptConfirm": "Включить поддержку групп вкладок",
   "TabGroupsPromptDismiss": "Не сейчас",
   "TabGroupsPromptNever": "Больше не спрашивать",
-  "Custom order": "Свой порядок",
-  "Sort by date saved": "Сортировать по дате сохранения"
+  "Sort sessions": "Сортировать сессии",
+  "Date saved": "Дата сохранения",
+  "Name": "Название",
+  "Tab count": "Количество вкладок",
+  "Date modified": "Дата изменения"
 }

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -127,6 +127,9 @@
   "TabGroupsPromptConfirm": "启用标签组支持",
   "TabGroupsPromptDismiss": "暂不",
   "TabGroupsPromptNever": "不再询问",
-  "Custom order": "自定义顺序",
-  "Sort by date saved": "按保存日期排序"
+  "Sort sessions": "排序会话",
+  "Date saved": "保存日期",
+  "Name": "名称",
+  "Tab count": "标签页数",
+  "Date modified": "修改日期"
 }

--- a/src/components/common/OverflowMenu.tsx
+++ b/src/components/common/OverflowMenu.tsx
@@ -17,12 +17,32 @@ export interface OverflowMenuItem {
   onSelect: () => void;
   /** Paints the glyph with the delete hover colour, as row delete icons do. */
   danger?: boolean;
+  /**
+   * Marks this item as the state the list is currently in (KAN-136).
+   *
+   * Present on ANY item turns the whole menu into a radio group -- the items
+   * become `menuitemradio` and each carries `aria-checked`, so a screen reader
+   * reports the current choice rather than three indistinguishable commands.
+   * The tick itself is decorative and aria-hidden: the state lives in
+   * aria-checked, and a bare glyph in the accessible name is exactly the leak
+   * KAN-56 fixed.
+   */
+  checked?: boolean;
 }
 
 interface OverflowMenuProps {
   /** Names the trigger. Must be translated. */
   ariaLabel: string;
   items: OverflowMenuItem[];
+  /**
+   * The trigger's Material Symbols ligature.
+   *
+   * Defaults to `more_vert`, which is what "a menu of secondary actions behind
+   * one trigger" looks like and what the row consumers want. A menu whose items
+   * are all one KIND of thing wants a glyph naming that kind instead -- the
+   * session sort menu (KAN-136) is a sort control, not an overflow.
+   */
+  triggerIcon?: string;
   /**
    * Fires whenever the menu opens or closes.
    *
@@ -68,6 +88,7 @@ interface OverflowMenuProps {
 const OverflowMenu: React.FC<OverflowMenuProps> = ({
   ariaLabel,
   items,
+  triggerIcon = 'more_vert',
   onOpenChange,
 }) => {
   const COLORS = useThemeColors();
@@ -86,6 +107,10 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({
     axis: 'vertical',
     onOpenChange,
   });
+
+  // A menu whose items report a current selection is a radio group, not a list
+  // of commands. Derived rather than a separate prop so the two cannot disagree.
+  const isRadioGroup = items.some((item) => item.checked !== undefined);
 
   const menuStyle = css`
     position: absolute;
@@ -143,7 +168,7 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({
     >
       <div ref={triggerRef}>
         <Icon
-          type="more_vert"
+          type={triggerIcon}
           tooltipText={ariaLabel}
           ariaLabel={ariaLabel}
           ariaHasPopup="menu"
@@ -154,13 +179,22 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({
           }}
         />
       </div>
+      {/* The menu is named from the trigger's label, so items may be as terse
+          as the menu allows without going unmoored: the sort menu's "Name" is
+          only unambiguous once the menu around it announces "Sort sessions". */}
       {isOpen && (
-        <div role="menu" css={menuStyle} onKeyDown={handleKeyDown}>
+        <div
+          role="menu"
+          aria-label={ariaLabel}
+          css={menuStyle}
+          onKeyDown={handleKeyDown}
+        >
           {items.map((item, index) => (
             <button
               key={item.key}
               type="button"
-              role="menuitem"
+              role={isRadioGroup ? 'menuitemradio' : 'menuitem'}
+              aria-checked={isRadioGroup ? !!item.checked : undefined}
               ref={registerItem(index)}
               css={itemStyle(item.danger)}
               onClick={(e) => {
@@ -187,6 +221,25 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({
                 {item.icon}
               </span>
               {item.label}
+              {isRadioGroup && (
+                /* Decorative. The state is on aria-checked above; this only
+                   makes it visible. Reserved width even when unticked, so the
+                   labels do not shift as the checked item changes. */
+                <span
+                  aria-hidden="true"
+                  className="material-symbols-outlined"
+                  css={css`
+                    margin-left: auto;
+                    font-size: 1.1rem;
+                    line-height: 1;
+                    width: 1.1rem;
+                    color: ${COLORS.TEXT_COLOR};
+                    visibility: ${item.checked ? 'visible' : 'hidden'};
+                  `}
+                >
+                  check
+                </span>
+              )}
             </button>
           ))}
         </div>

--- a/src/components/home/leftpane/MenuContainer.tsx
+++ b/src/components/home/leftpane/MenuContainer.tsx
@@ -3,6 +3,12 @@ import { useDispatch, useSelector } from 'react-redux';
 import { css } from '@emotion/react';
 
 import Icon from '../../common/Icon';
+import OverflowMenu from '../../common/OverflowMenu';
+import type { OverflowMenuItem } from '../../common/OverflowMenu';
+import {
+  clearSessionOrder,
+  sortSessionsInternal,
+} from '../../../redux/slices/tabContainerDataStateSlice';
 import { AppDispatch, RootState } from '../../../redux/store';
 import {
   closeToast,
@@ -27,7 +33,8 @@ export default function MenuContainer() {
     (state: RootState) => state.globalState.isSignedIn
   );
 
-  const { t } = useTranslation();
+  // i18n.language feeds the reducer's title collation; see sortItems below.
+  const { t, i18n } = useTranslation();
   const dispatch: AppDispatch = useDispatch();
 
   const isUndoable = useSelector(isUndoableSelector);
@@ -83,6 +90,69 @@ export default function MenuContainer() {
     syncIconType = 'sync';
   }
 
+  // The list is in its natural order iff nothing carries a manual rank. Derived,
+  // never stored -- the same reasoning as KAN-130's: a stored sort mode would
+  // be a container-level field, and this merge has no last-writer-wins rule for
+  // one.
+  //
+  // It is what makes "Date saved" legible as the way BACK rather than a
+  // third equal choice. Justine had to ask how to undo a sort, which is the
+  // whole reason this tick exists.
+  const isDefaultOrder = useSelector((state: RootState) =>
+    state.tabContainerDataState.tabGroups.every((g) => g.rank === undefined)
+  );
+
+  // Every item is a ONE-SHOT rearrangement of the stored order, not a mode.
+  // "Date saved" is the odd one and deliberately so: it REMOVES ranks rather
+  // than assigning them, which is why it is a different action -- and why it is
+  // the only one that can be ticked, since it is the only reachable state the
+  // data can report.
+  //
+  // The labels name the ORDER, not the act of sorting. "Sort by" on each item
+  // repeats what the trigger already says, and at the menu's 180px it wrapped
+  // three of these four onto two lines. Widening the menu is not available:
+  // it is anchored `right: 0` and grows leftward from a trigger that sits
+  // about 200px into a ~355px pane, so a wider box runs off the left edge.
+  // OverflowMenu names the menu itself from ariaLabel, so a screen reader
+  // still hears "Sort sessions" before it hears "Name".
+  const sortItems: OverflowMenuItem[] = [
+    {
+      key: 'date',
+      label: t('Date saved'),
+      icon: 'schedule',
+      checked: isDefaultOrder,
+      onSelect: () => dispatch(clearSessionOrder()),
+    },
+    {
+      key: 'name',
+      label: t('Name'),
+      icon: 'sort_by_alpha',
+      checked: false,
+      onSelect: () =>
+        dispatch(sortSessionsInternal({ by: 'name', locale: i18n.language })),
+    },
+    {
+      key: 'tabs',
+      label: t('Tab count'),
+      icon: 'tab',
+      checked: false,
+      onSelect: () =>
+        dispatch(
+          sortSessionsInternal({ by: 'tabCount', locale: i18n.language })
+        ),
+    },
+    {
+      key: 'modified',
+      label: t('Date modified'),
+      icon: 'history',
+      checked: false,
+      onSelect: () =>
+        dispatch(
+          sortSessionsInternal({ by: 'contentModified', locale: i18n.language })
+        ),
+    },
+  ];
+
   const containerStyle = css`
     display: flex;
     justify-content: space-around;
@@ -90,6 +160,29 @@ export default function MenuContainer() {
 
   return (
     <div css={containerStyle}>
+      {/* KAN-136. Sits LEFT of the undo/redo cluster, and only when there is
+          a list to sort. Rendered unconditionally: every item no-ops on an
+          empty list (the reducer guards it), and a control that comes and goes
+          is the same mistake as the strip it replaces.
+
+          It replaces the strip KAN-130 put inside the list box, which rendered
+          as a list item (same width, same borders, directly above the first
+          row), shifted the list when it appeared, and only existed once the
+          user had already found the drag gesture. A header control is present
+          before that, and costs no vertical space in a pane that scrolls. */}
+      {/* `sort`, not `swap_vert`. swap_vert is two opposing arrows and reads
+          as "reverse the direction" -- an asc/desc toggle this menu does not
+          have and will not gain, because each item is a one-shot rearrangement
+          rather than a mode. `sort` is the conventional affordance for
+          choosing an order, which is what this does. Both are real ligatures
+          in Material Symbols Outlined, measured in the built popup at 26px
+          against a name the font does not carry, which renders as literal
+          text 572px wide rather than as tofu (KAN-5). */}
+      <OverflowMenu
+        ariaLabel={t('Sort sessions')}
+        triggerIcon="sort"
+        items={sortItems}
+      />
       <Icon
         ariaLabel={t('Undo')}
         tooltipText={t('Undo')}

--- a/src/components/home/leftpane/TabGroupEntryContainer.tsx
+++ b/src/components/home/leftpane/TabGroupEntryContainer.tsx
@@ -14,7 +14,6 @@ import {
   isSearchActive,
 } from '../../../utils/functions/local';
 import {
-  clearSessionOrder,
   deleteTabContainer,
   moveSessionInternal,
   openAllTabContainer,
@@ -23,8 +22,6 @@ import {
   tabContainerData,
 } from '../../../redux/slices/tabContainerDataStateSlice';
 import { useTranslation } from 'react-i18next';
-import Icon from '../../common/Icon';
-import ClickableRow from '../../common/ClickableRow';
 import { RowDragArea, DraggableRow } from '../rightpane/rowDrag/RowDragArea';
 
 export default function TabGroupEntryContainer() {
@@ -49,16 +46,6 @@ export default function TabGroupEntryContainer() {
   );
 
   const selectedTabGroupId = tabContainerDataList.selectedTabGroupId;
-
-  // The list is in custom order iff any session carries a manual rank
-  // (KAN-130). Derived rather than stored: a sort mode would be a
-  // container-level field, and this merge has no last-writer-wins rule for one
-  // -- lastModified is a max and selectedTabGroupId is per-device view state.
-  // Deriving it also makes every device agree without syncing anything new.
-  const isCustomOrder = useMemo(
-    () => tabContainerDataList.tabGroups.some((g) => g.rank !== undefined),
-    [tabContainerDataList.tabGroups]
-  );
 
   // KAN-131, at the session level and more exposed than the panes below it:
   // search filters sessions directly, so an index counted over the rendered
@@ -139,27 +126,6 @@ export default function TabGroupEntryContainer() {
     flex-direction: column;
   `;
 
-  // Shown ONLY in custom order (KAN-130), which is why it costs nothing for
-  // anyone who never drags: no strip, no change. It appears at the moment the
-  // list stops meaning "newest first", which is also the moment that needs
-  // explaining -- the list's order was previously self-evident from the dates
-  // on the rows, and after a drag nothing else would say otherwise.
-  //
-  // sticky, so it stays visible while the list scrolls under it: the state it
-  // reports is the list's, not this row's.
-  const orderStripStyle = css`
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 4px 8px;
-    min-height: 28px;
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    background-color: ${COLORS.SECONDARY_COLOR};
-    border-bottom: 1px solid ${COLORS.BORDER_COLOR};
-  `;
-
   return (
     <div css={containerStyle}>
       {filteredTabGroups.length === 0 ? (
@@ -171,26 +137,6 @@ export default function TabGroupEntryContainer() {
         </div>
       ) : (
         <div css={filledContainerStyle}>
-          {/* Not rendered while searching: the reset would apply to the stored
-              list, not the narrowed one on screen, and offering it there would
-              promise something about a list the user cannot see. */}
-          {isCustomOrder && !isFilteredView && (
-            <div css={orderStripStyle}>
-              <NormalLabel
-                value={t('Custom order')}
-                size="0.7rem"
-                color={COLORS.LABEL_L2_COLOR}
-              />
-              <ClickableRow
-                ariaLabel={t('Sort by date saved')}
-                tooltipText={t('Sort by date saved')}
-                onClick={() => dispatch(clearSessionOrder())}
-                style="display: flex; align-items: center;"
-              >
-                <Icon type="schedule" style={`padding: 0;`} />
-              </ClickableRow>
-            </div>
-          )}
           {/* KAN-130. No handleSelector -- a session row contains no nested
               drag area, so the whole row is the handle. No resolveDrop -- a
               session belongs to nothing. */}

--- a/src/redux/middleware/customMiddleware.ts
+++ b/src/redux/middleware/customMiddleware.ts
@@ -29,6 +29,7 @@ import {
   MOVE_TAB_ACTION,
   MOVE_WINDOW_ACTION,
   MOVE_SESSION_ACTION,
+  SORT_SESSIONS_ACTION,
   CLEAR_SESSION_ORDER_ACTION,
 } from '../../utils/constants/actionTypes';
 import type { RootState } from '../store';
@@ -57,6 +58,7 @@ const actionsToCapture = [
   MOVE_TAB_ACTION,
   MOVE_WINDOW_ACTION,
   MOVE_SESSION_ACTION,
+  SORT_SESSIONS_ACTION,
   CLEAR_SESSION_ORDER_ACTION,
 
   // actions in globalStateSlice

--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -1,6 +1,15 @@
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { RootState } from '../store';
+// `import type`, and it is load-bearing rather than tidiness. A value import
+// here completes a cycle -- this slice -> store -> storeConfig -> this slice --
+// which leaves the module partially initialised depending on who imports whom
+// first. It was harmless only because nothing outside the redux folder imported
+// this slice early; the first component to do so (MenuContainer, KAN-136) broke
+// nine unrelated keyboard tests with "Cannot read properties of undefined
+// (reading 'tabGroups')". RootState is used solely in `as RootState` casts, so
+// `import type` is emitted as nothing and the cycle disappears. Same technique,
+// same reason, as the header comment in mergeTabData.ts.
+import type { RootState } from '../store';
 import { closeFocusModal, openFocusModal, showToast } from './globalStateSlice';
 import {
   getStringDate,
@@ -225,6 +234,26 @@ export interface moveTabParams {
 export interface moveSessionParams {
   tabGroupId: string;
   toIndex: number;
+}
+
+// Rearrange the session list by a key (KAN-136, closing KAN-106).
+//
+// A one-shot ACTION, not a mode. It assigns ranks once and stops, which is what
+// lets sorting and dragging coexist -- both write the same stored order rather
+// than being two rival answers to "what order is this list in". The visible
+// consequence is deliberate: a session saved afterwards has no rank, falls back
+// to createdInstant, and lands on top rather than in its sorted position.
+//
+// `locale` is passed in rather than read here: title comparison must be
+// locale-aware (Intl.Collator, not `<`), the app ships ten locales, and the
+// reducer has no access to the active one. Same shape as getPrettyDate (KAN-85).
+//
+// Sorting by DATE SAVED is not here -- that is clearSessionOrder, because
+// returning to the default means REMOVING ranks rather than assigning them.
+// Two genuinely different operations, kept as two.
+export interface sortSessionsParams {
+  by: 'name' | 'tabCount' | 'contentModified';
+  locale: string;
 }
 
 export interface moveWindowParams {
@@ -598,6 +627,14 @@ function touchContent(group: tabContainerData): void {
 // imports nothing from here as a value, deliberately, so it stays DOM-free.
 function rankOf(group: tabContainerData): number {
   return group.rank ?? createdInstant(group);
+}
+
+// The tiebreak every session ordering here uses, matching the merge's own
+// (`compareAsc` in mergeTabData). Its job is to make the result TOTAL: without
+// it, two sessions with equal keys could come out in either order, and two
+// devices sorting the same data would not converge.
+function compareIds(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 // Ranks are sparse and live in createdInstant's space, so a session dropped
@@ -1439,6 +1476,69 @@ export const tabContainerDataStateSlice = createSlice({
       saveToLocalStorage('tabContainerData', state);
     },
 
+    // Rearrange the whole list by a key (KAN-136).
+    //
+    // Unlike a drag, this necessarily touches EVERY session: an explicit order
+    // needs an explicit rank on each one. That is the cost of the operation,
+    // not an oversight -- and it is why "sort by date saved" is a separate
+    // reducer that removes ranks instead.
+    sortSessionsInternal: (
+      state,
+      action: PayloadAction<sortSessionsParams>
+    ) => {
+      const { by, locale } = action.payload;
+      if (state.tabGroups.length === 0) return;
+
+      // Intl.Collator, never `<`. A codepoint compare puts every capital ahead
+      // of every lowercase -- "Banana, Cherry, apple" -- and is wrong outright
+      // in most of the ten locales we ship. KAN-85 was this same mistake for
+      // dates.
+      const collator = new Intl.Collator(locale, { sensitivity: 'base' });
+
+      // Most recently edited first, and NOT `lastModified` -- that is bumped
+      // by reordering too, so a previous sort would have flattened it and this
+      // would return something close to arbitrary (KAN-138).
+      //
+      // The fallback for sessions written before contentModified existed is
+      // createdInstant, which is the date their row displays -- so an unmigrated
+      // session sorts where the user would expect from looking at it, rather
+      // than by a lastModified they cannot see.
+      const editedAt = (g: tabContainerData) =>
+        g.contentModified ?? createdInstant(g);
+
+      const compare = (a: tabContainerData, b: tabContainerData): number => {
+        if (by === 'name') return collator.compare(a.title, b.title);
+        if (by === 'contentModified') return editedAt(b) - editedAt(a);
+        // Largest first, which is the only reading of "sort by tab count" that
+        // puts the interesting sessions where the eye starts.
+        return b.tabCount - a.tabCount;
+      };
+
+      const sorted = [...state.tabGroups].sort(
+        // tabGroupId breaks ties so the result is total and stable, matching
+        // what the merge does -- otherwise two devices could order equal keys
+        // differently and never converge.
+        (a, b) => compare(a, b) || compareIds(a.tabGroupId, b.tabGroupId)
+      );
+
+      // Already in this order AND already pinned: nothing to do. Both halves
+      // matter -- a list that merely happens to be in the right order is still
+      // unpinned, and the user asking for this order means they want it to
+      // stay, so ranks still get written.
+      const unchanged =
+        sorted.every((g, i) => g === state.tabGroups[i]) &&
+        state.tabGroups.every((g) => g.rank !== undefined);
+      if (unchanged) return;
+
+      state.tabGroups = sorted;
+      renormalise(state.tabGroups, Date.now());
+
+      state.lastModified = Date.now();
+
+      // update localstorage
+      saveToLocalStorage('tabContainerData', state);
+    },
+
     // Drop every manual rank and return the list to newest-first (KAN-130).
     //
     // Cheap by construction: it REMOVES ranks rather than assigning them, so it
@@ -1461,11 +1561,7 @@ export const tabContainerDataStateSlice = createSlice({
       state.tabGroups.sort(
         (a, b) =>
           createdInstant(b) - createdInstant(a) ||
-          (a.tabGroupId < b.tabGroupId
-            ? -1
-            : a.tabGroupId > b.tabGroupId
-              ? 1
-              : 0)
+          compareIds(a.tabGroupId, b.tabGroupId)
       );
 
       state.lastModified = Date.now();
@@ -1817,6 +1913,7 @@ export const {
   moveTabInternal,
   moveWindowInternal,
   moveSessionInternal,
+  sortSessionsInternal,
   clearSessionOrder,
   replaceState,
   restoreContainer,

--- a/src/tests/components/sessionDragReorder.test.tsx
+++ b/src/tests/components/sessionDragReorder.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test, afterEach } from 'vitest';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 
 import TabGroupEntryContainer from '../../components/home/leftpane/TabGroupEntryContainer';
 import { renderWithProviders } from '../setup/renderWithProviders';
@@ -167,55 +167,5 @@ describe('a session drag inside a filtered list', () => {
 
     expect(order(store)).toEqual(['c', 'b', 'a']);
     expect(store.getState().globalState.isDirty).toBe(false);
-  });
-});
-
-describe('the custom-order strip', () => {
-  const strip = () => screen.queryByLabelText('Sort by date saved');
-
-  test('is absent until something is dragged', async () => {
-    const { container } = await render();
-    layout(container, ['c', 'b', 'a']);
-
-    expect(strip()).toBeNull();
-    expect(screen.queryByText('Custom order')).toBeNull();
-  });
-
-  test('appears once the list is in custom order', async () => {
-    const { container } = await render();
-    layout(container, ['c', 'b', 'a']);
-
-    drag(nodeFor(container, 'a'), 100, 5);
-
-    expect(strip()).not.toBeNull();
-    expect(screen.getByText('Custom order')).toBeInTheDocument();
-  });
-
-  test('resets to newest-first and then hides itself', async () => {
-    const { container, store } = await render();
-    layout(container, ['c', 'b', 'a']);
-    drag(nodeFor(container, 'a'), 100, 5);
-    expect(order(store)).toEqual(['a', 'c', 'b']);
-
-    fireEvent.click(strip()!);
-
-    expect(order(store)).toEqual(['c', 'b', 'a']);
-    expect(strip()).toBeNull();
-  });
-
-  // Offering the reset while searching would promise something about a list
-  // the user cannot see -- the reset applies to the stored order, not the
-  // narrowed one on screen.
-  test('is hidden while a search is filtering the list', async () => {
-    const { container, store, rerender } = await render();
-    layout(container, ['c', 'b', 'a']);
-    drag(nodeFor(container, 'a'), 100, 5);
-    expect(strip()).not.toBeNull();
-
-    store.dispatch(openSearchPanel());
-    store.dispatch(setSearchInputText('ALPHA'));
-    rerender(<TabGroupEntryContainer />);
-
-    expect(strip()).toBeNull();
   });
 });

--- a/src/tests/components/sessionSortMenu.test.tsx
+++ b/src/tests/components/sessionSortMenu.test.tsx
@@ -1,0 +1,212 @@
+import { describe, expect, test } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+
+import MenuContainer from '../../components/home/leftpane/MenuContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import type { RenderWithProvidersResult } from '../setup/renderWithProviders';
+import {
+  saveToTabContainerInternal,
+  moveSessionInternal,
+  updateTabGroupTitle,
+} from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-136. The sort menu in the header, which replaced the strip KAN-130 put
+// inside the list box.
+//
+// The strip rendered as a list item -- same width, same borders, directly above
+// the first session row -- shifted the list when it appeared, and only existed
+// once the user had already found the drag gesture. A header control is present
+// before that and costs no vertical space in a pane that scrolls.
+//
+// THE TICK EXISTS BECAUSE OF A QUESTION. Looking at the built menu, Justine
+// asked: "if I change sort to sort by name, how do I go back?" The answer was
+// already "Date saved" -- it deletes every rank -- but three items read as
+// three equal choices and nothing said which order was active. Having to ask
+// is the defect; the tick is the fix.
+
+const HOUR = 3600_000;
+const T0 = Date.UTC(2026, 8, 9, 12, 0, 0);
+
+const session = (
+  id: string,
+  title: string,
+  createdAt: number,
+  tabCount = 1
+) => ({
+  tabGroupId: id,
+  title,
+  createdTime: '2026-09-09 12:00:00',
+  createdAt,
+  windowCount: 1,
+  tabCount,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: `${id}-w`,
+      windowHeight: 100,
+      windowWidth: 100,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount,
+      title: 'Window',
+      tabs: Array.from({ length: tabCount }, (_, i) => ({
+        tabId: `${id}-t${i}`,
+        favicon: '',
+        title: 'Tab',
+        url: 'https://a.co',
+      })),
+    },
+  ],
+});
+
+const render = () =>
+  renderWithProviders(<MenuContainer />, {
+    seedStore: (store) => {
+      store.dispatch(
+        saveToTabContainerInternal(session('c', 'Cherry', T0 - 2 * HOUR, 9))
+      );
+      store.dispatch(
+        saveToTabContainerInternal(session('a', 'apple', T0 - HOUR, 2))
+      );
+      store.dispatch(saveToTabContainerInternal(session('b', 'Banana', T0, 5)));
+    },
+  });
+
+// Addressed by ROLE, not by label alone: the open menu carries the same
+// "Sort sessions" name as its trigger (that is what lets the items be one word
+// each), so getByLabelText matches two elements and throws the moment this is
+// called while the menu is open.
+const openMenu = () =>
+  fireEvent.click(screen.getByRole('button', { name: 'Sort sessions' }));
+
+const item = (label: string) =>
+  screen.getByRole('menuitemradio', { name: label });
+
+const titles = (store: RenderWithProvidersResult['store']) =>
+  store.getState().tabContainerDataState.tabGroups.map((g) => g.title);
+
+describe('the sort menu', () => {
+  test('offers the four orders', async () => {
+    await render();
+    openMenu();
+
+    // `item` resolves by ACCESSIBLE NAME, which is the assertion worth making:
+    // each row also holds two aria-hidden ligature spans (the leading icon and
+    // the tick), so its textContent is "scheduleDate savedcheck" and a
+    // substring match on that would pass for a label the tree never exposed.
+    expect(screen.getAllByRole('menuitemradio')).toHaveLength(4);
+    ['Date saved', 'Name', 'Tab count', 'Date modified'].forEach((label) => {
+      expect(item(label)).toBeInTheDocument();
+    });
+  });
+
+  // What licenses the one-word items. "Name" and "Tab count" say nothing on
+  // their own; they are only unambiguous because the menu containing them
+  // announces what is being sorted. Drop this name and the labels become a
+  // riddle for anyone who cannot see the trigger they came from.
+  test('the menu carries the name the terse items borrow', async () => {
+    await render();
+    openMenu();
+
+    expect(
+      screen.getByRole('menu', { name: 'Sort sessions' })
+    ).toBeInTheDocument();
+  });
+
+  test('sorting by name reorders the list', async () => {
+    const { store } = await render();
+    expect(titles(store)).toEqual(['Banana', 'apple', 'Cherry']);
+
+    openMenu();
+    fireEvent.click(item('Name'));
+
+    expect(titles(store)).toEqual(['apple', 'Banana', 'Cherry']);
+  });
+
+  test('sorting by tab count puts the largest first', async () => {
+    const { store } = await render();
+
+    openMenu();
+    fireEvent.click(item('Tab count'));
+
+    expect(titles(store)).toEqual(['Cherry', 'Banana', 'apple']);
+  });
+
+  // Distinguished from "date saved" by EDITING the oldest session: it stays
+  // oldest by creation and becomes newest by content, so the two orders
+  // disagree and only one of them puts Cherry first. Wiring this item to any
+  // other key leaves Cherry last, where the seeded order already had it.
+  //
+  // Only the first position is asserted. The other two are saved in the same
+  // tick, so their contentModified values may be equal and their relative
+  // order is a tie the reducer is not being asked to break.
+  test('sorting by date modified puts the recently edited session first', async () => {
+    const { store } = await render();
+    store.dispatch(
+      updateTabGroupTitle({ tabGroupId: 'c', editableTitle: 'Cherry' })
+    );
+    expect(titles(store)[2]).toBe('Cherry');
+
+    openMenu();
+    fireEvent.click(item('Date modified'));
+
+    expect(titles(store)[0]).toBe('Cherry');
+  });
+
+  // The way back, which is the whole question that produced the tick.
+  test('sorting by date saved returns to the default order', async () => {
+    const { store } = await render();
+    openMenu();
+    fireEvent.click(item('Name'));
+    expect(titles(store)).toEqual(['apple', 'Banana', 'Cherry']);
+
+    openMenu();
+    fireEvent.click(item('Date saved'));
+
+    expect(titles(store)).toEqual(['Banana', 'apple', 'Cherry']);
+  });
+});
+
+describe('the tick says which order you are in', () => {
+  // Asserted through aria-checked, not the glyph. The tick is decorative and
+  // aria-hidden, so a screen reader learns the state from the role -- and a
+  // test reading the glyph would pass against a menu that never announced it
+  // (KAN-56).
+  test('the default order is checked when nothing has been rearranged', async () => {
+    await render();
+    openMenu();
+
+    expect(item('Date saved')).toHaveAttribute('aria-checked', 'true');
+    expect(item('Name')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  test('nothing is checked once the list is rearranged', async () => {
+    const { store } = await render();
+    store.dispatch(moveSessionInternal({ tabGroupId: 'c', toIndex: 0 }));
+
+    openMenu();
+
+    expect(item('Date saved')).toHaveAttribute('aria-checked', 'false');
+    screen.getAllByRole('menuitemradio').forEach((el) => {
+      expect(el).toHaveAttribute('aria-checked', 'false');
+    });
+  });
+
+  test('and it comes back after sorting by date saved', async () => {
+    const { store } = await render();
+    store.dispatch(moveSessionInternal({ tabGroupId: 'c', toIndex: 0 }));
+
+    openMenu();
+    fireEvent.click(item('Date saved'));
+    openMenu();
+
+    expect(item('Date saved')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  // The control for the radio semantics -- a menu of plain commands must NOT
+  // claim to report a selection -- is not here. It is overflowMenu.test.tsx,
+  // which drives the row action menu and asserts `menuitem` throughout;
+  // hard-coding isRadioGroup to true fails 11 of its tests. Repeating it
+  // against this menu would prove nothing, because this menu is a radio group.
+});

--- a/src/tests/redux/sortSessions.test.ts
+++ b/src/tests/redux/sortSessions.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test, vi } from 'vitest';
+
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+import { makeTestStore } from '../setup/makeStore';
+import {
+  saveToTabContainerInternal,
+  sortSessionsInternal,
+  moveSessionInternal,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import { setIsNotDirty } from '../../redux/slices/globalStateSlice';
+
+// KAN-136 / KAN-106. Sorting the session list.
+//
+// A sort is a ONE-SHOT ACTION on the stored order, not a mode: it assigns
+// ranks once and stops. That is what lets it coexist with dragging, since both
+// are then operations on the same stored order rather than two rival answers
+// to "what order is this list in" (see KAN-130).
+//
+// The visible consequence, and it is deliberate: a session saved afterwards
+// has no rank, falls back to createdInstant, and lands at the TOP rather than
+// in its sorted position.
+
+const HOUR = 3600_000;
+const T0 = Date.UTC(2026, 8, 9, 12, 0, 0);
+
+const build = (
+  id: string,
+  title: string,
+  createdAt: number,
+  tabCount: number
+) => ({
+  tabGroupId: id,
+  title,
+  createdTime: '2026-09-09 12:00:00',
+  createdAt,
+  windowCount: 1,
+  tabCount,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: `${id}-w`,
+      windowHeight: 100,
+      windowWidth: 100,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount,
+      title: 'Window',
+      tabs: Array.from({ length: tabCount }, (_, i) => ({
+        tabId: `${id}-t${i}`,
+        favicon: '',
+        title: 'Tab',
+        url: 'https://a.co',
+      })),
+    },
+  ],
+});
+
+type Store = ReturnType<typeof makeTestStore>['store'];
+
+// Saved oldest first, so the list starts newest-first: Banana, apple, Cherry.
+// Deliberately mixed case -- a raw `<` would sort every capital ahead of every
+// lowercase, which is the bug Intl.Collator exists to avoid.
+const seededList = () => {
+  const { store } = makeTestStore();
+  store.dispatch(
+    saveToTabContainerInternal(build('c', 'Cherry', T0 - 2 * HOUR, 9))
+  );
+  store.dispatch(saveToTabContainerInternal(build('a', 'apple', T0 - HOUR, 2)));
+  store.dispatch(saveToTabContainerInternal(build('b', 'Banana', T0, 5)));
+  store.dispatch(setIsNotDirty());
+  return store;
+};
+
+const titles = (s: Store) =>
+  s.getState().tabContainerDataState.tabGroups.map((g) => g.title);
+const groups = (s: Store) => s.getState().tabContainerDataState.tabGroups;
+
+describe('sortSessionsInternal by name', () => {
+  test('orders the list alphabetically', () => {
+    const store = seededList();
+    expect(titles(store)).toEqual(['Banana', 'apple', 'Cherry']);
+
+    store.dispatch(sortSessionsInternal({ by: 'name', locale: 'en' }));
+
+    expect(titles(store)).toEqual(['apple', 'Banana', 'Cherry']);
+  });
+
+  // A raw `<` puts every capital before every lowercase, so this list would
+  // come out Banana, Cherry, apple. Ten locales ship; KAN-85 was this exact
+  // mistake for dates.
+  test('is case-insensitive, not codepoint order', () => {
+    const store = seededList();
+    store.dispatch(sortSessionsInternal({ by: 'name', locale: 'en' }));
+    expect(titles(store)[0]).toBe('apple');
+  });
+
+  test('gives every session an explicit rank', () => {
+    const store = seededList();
+    store.dispatch(sortSessionsInternal({ by: 'name', locale: 'en' }));
+
+    expect(groups(store).every((g) => g.rank !== undefined)).toBe(true);
+  });
+
+  // THE INVARIANT, same as the drag reducer's: the array and the ranks must
+  // agree, or the next sync re-derives a different order from the one on
+  // screen.
+  test('the ranks reproduce the array order when sorted', () => {
+    const store = seededList();
+    store.dispatch(sortSessionsInternal({ by: 'name', locale: 'en' }));
+
+    const g = groups(store);
+    const key = (x: (typeof g)[number]) => x.rank ?? x.createdAt!;
+    const resorted = [...g].sort((x, y) => key(y) - key(x));
+    expect(resorted.map((x) => x.title)).toEqual(g.map((x) => x.title));
+  });
+
+  test('does not restamp createdAt', () => {
+    const store = seededList();
+    const before = new Map(
+      groups(store).map((g) => [g.tabGroupId, g.createdAt])
+    );
+
+    store.dispatch(sortSessionsInternal({ by: 'name', locale: 'en' }));
+
+    groups(store).forEach((g) => {
+      expect(g.createdAt).toBe(before.get(g.tabGroupId));
+    });
+  });
+});
+
+describe('sortSessionsInternal by tab count', () => {
+  test('orders largest first', () => {
+    const store = seededList();
+    store.dispatch(sortSessionsInternal({ by: 'tabCount', locale: 'en' }));
+    // Cherry 9, Banana 5, apple 2
+    expect(titles(store)).toEqual(['Cherry', 'Banana', 'apple']);
+  });
+
+  test('the ranks reproduce that order too', () => {
+    const store = seededList();
+    store.dispatch(sortSessionsInternal({ by: 'tabCount', locale: 'en' }));
+
+    const g = groups(store);
+    const key = (x: (typeof g)[number]) => x.rank ?? x.createdAt!;
+    const resorted = [...g].sort((x, y) => key(y) - key(x));
+    expect(resorted.map((x) => x.title)).toEqual(g.map((x) => x.title));
+  });
+});
+
+describe('a sort is a one-shot action, not a mode', () => {
+  // The deliberate consequence, pinned so it cannot change silently: after a
+  // name sort, a NEW session lands at the top rather than in its alphabetical
+  // place, because it has no rank and falls back to createdInstant.
+  test('a session saved afterwards lands on top, not in sorted position', () => {
+    const store = seededList();
+    store.dispatch(sortSessionsInternal({ by: 'name', locale: 'en' }));
+    expect(titles(store)).toEqual(['apple', 'Banana', 'Cherry']);
+
+    store.dispatch(
+      saveToTabContainerInternal(build('z', 'zebra', T0 + HOUR, 1))
+    );
+
+    expect(titles(store)[0]).toBe('zebra');
+  });
+
+  // And a drag still overrides a sort, because both write the same field.
+  test('dragging after a sort still wins', () => {
+    const store = seededList();
+    store.dispatch(sortSessionsInternal({ by: 'name', locale: 'en' }));
+
+    store.dispatch(moveSessionInternal({ tabGroupId: 'c', toIndex: 0 }));
+
+    expect(titles(store)[0]).toBe('Cherry');
+  });
+});
+
+describe('sortSessionsInternal does nothing when there is nothing to do', () => {
+  // CONTROL. Re-sorting an already-sorted, already-ranked list must not stamp
+  // every session and queue a cloud write each time the menu is used.
+  test('re-sorting an already sorted list is not an edit', () => {
+    const store = seededList();
+    store.dispatch(sortSessionsInternal({ by: 'name', locale: 'en' }));
+    store.dispatch(setIsNotDirty());
+    const before = groups(store).map((g) => g.lastModified);
+
+    store.dispatch(sortSessionsInternal({ by: 'name', locale: 'en' }));
+
+    expect(groups(store).map((g) => g.lastModified)).toEqual(before);
+    expect(store.getState().globalState.isDirty).toBe(false);
+  });
+
+  // But an already-ordered list with NO ranks must still be pinned: the order
+  // is a coincidence of creation times until the ranks make it explicit.
+  test('an unranked list in the right order still gets ranks', () => {
+    const { store } = makeTestStore();
+    store.dispatch(
+      saveToTabContainerInternal(build('a', 'apple', T0 - HOUR, 1))
+    );
+    store.dispatch(saveToTabContainerInternal(build('b', 'Banana', T0, 1)));
+    store.dispatch(setIsNotDirty());
+    // Newest-first already happens to be reverse-alphabetical here.
+    expect(titles(store)).toEqual(['Banana', 'apple']);
+
+    store.dispatch(sortSessionsInternal({ by: 'name', locale: 'en' }));
+
+    expect(titles(store)).toEqual(['apple', 'Banana']);
+    expect(groups(store).every((g) => g.rank !== undefined)).toBe(true);
+  });
+
+  test('an empty list does not throw', () => {
+    const { store } = makeTestStore();
+    store.dispatch(sortSessionsInternal({ by: 'name', locale: 'en' }));
+    expect(groups(store)).toEqual([]);
+  });
+});

--- a/src/utils/constants/actionTypes.ts
+++ b/src/utils/constants/actionTypes.ts
@@ -47,6 +47,8 @@ export const DELETE_TAB_ACTION = 'tabContainerDataState/deleteTabInternal';
 export const MOVE_TAB_ACTION = 'tabContainerDataState/moveTabInternal';
 export const MOVE_WINDOW_ACTION = 'tabContainerDataState/moveWindowInternal';
 export const MOVE_SESSION_ACTION = 'tabContainerDataState/moveSessionInternal';
+export const SORT_SESSIONS_ACTION =
+  'tabContainerDataState/sortSessionsInternal';
 export const CLEAR_SESSION_ORDER_ACTION =
   'tabContainerDataState/clearSessionOrder';
 


### PR DESCRIPTION
## What

The sort control moves out of the session list and into the header, left of undo/redo. It gains a fourth order — **Date modified** — and a **tick** showing which order is active.

## Why the strip had to go

KAN-130 put the way back to newest-first in a strip *inside* the list box. Justine: *"why is there a custom order row in the left pane, we need to rethink about this ui."*

Two things were wrong with it:

- It rendered as a **list item** — same width, same borders, directly above the first session row — so it shifted the list every time it appeared.
- It only existed **after** the user had already found the drag gesture. It could never teach anyone the feature was there.

A header control is present before the user knows the feature exists, and costs no vertical space in a pane that scrolls.

## The tick answers a question; it isn't decoration

Shown the built menu, Justine asked: *"where is sort by modified? that's the default right? i'm asking because what if i change sort to sort by name, then how do i go back?"*

The answer was already **Date saved** — it removes every rank and restores newest-first. But three items read as three equal choices, and nothing said which order was active. **Having to ask is the defect.**

```
menu "Sort sessions"
  menuitemradio "Date saved"     checked
  menuitemradio "Name"
  menuitemradio "Tab count"
  menuitemradio "Date modified"
```

`OverflowMenu` derives `menuitemradio` + `aria-checked` from any item declaring `checked`, rather than taking a separate prop, so the role and the glyph cannot disagree. The glyph is `aria-hidden` with **reserved width**, so labels don't shift as the tick moves.

`isDefaultOrder` is **derived** — true iff no session carries a `rank` — for exactly the reason KAN-130 derived the mode: a stored sort mode would be a container-level field, and this merge has no last-writer-wins rule for one.

## Date modified

*"no sort by date modified?"* — added on KAN-138's `contentModified`, falling back to `createdInstant` for sessions saved before that field existed:

```ts
const editedAt = (g: tabContainerData) => g.contentModified ?? createdInstant(g);
if (by === 'contentModified') return editedAt(b) - editedAt(a);
```

No merge change, for the same reason KAN-130 needed none: the merge is session-granular LWW, so a field on the session is already resolved correctly.

## The labels lost their prefix

Four items each saying "Sort by" repeat what the trigger already says, and at the menu's 180px **three of the four wrapped onto two lines**.

Widening was not an option. The menu is anchored `right: 0` and grows **leftward** from a trigger sitting ~200px into a ~355px pane — a wider box runs off the left edge.

| before | after |
| --- | --- |
| Sort by date saved *(wrapped)* | Date saved |
| Sort by name | Name |
| Sort by tab count *(wrapped)* | Tab count |
| Sort by date modified *(wrapped)* | Date modified |

So the menu now carries the trigger's name via `aria-label`. That's what licenses an item being the single word "Name" — it's only unambiguous because the menu around it announces what's being sorted. Ten locales updated; the obsolete `Custom order` key is gone.

## Evidence

Verified in a **real popup on the built artifact**, having grepped `dist/` first — a failed build silently tests the old bundle.

Each order driven through the actual menu, six sessions:

| order | result |
| --- | --- |
| **Name** | `about:blank, about:blank, Drag test session, f.example, TabKeeper, TabKeeper` |
| **Tab count** | `14, 12, 8, 7, 5, 1` |
| **Date saved** | original newest-first order restored, tick back |
| **Date modified** | the renamed session first |

`f.example` sorts **before** `TabKeeper`, which a naive `<` reverses (`T` < `f`) — so the collator is live, not incidental.

**Date modified was separated from Date saved deliberately.** Renaming the oldest-saved session leaves it oldest by `createdTime` and newest by `contentModified`. It sorts first — an order no other key in the menu produces.

The tick's return was checked in **both** `aria-checked` and computed `visibility`, and Chrome's own accessibility tree reports `menu "Sort sessions"` holding four `menuitemradio` with `Date saved` checked — the assertion jsdom cannot make.

**1094 tests pass. tsc and eslint clean.**

### Mutations

Every new test was watched failing against broken code:

| mutation | killed |
| --- | --- |
| tick hard-coded `false` | 2 |
| tick hard-coded `true` | 1 |
| Date modified item removed | 2 |
| Date modified wired to the name key | 1 |
| menu's `aria-label` deleted | 1 |

The last one **survived** until I added a test for it — I'd added that attribute deliberately and left it unpinned.

The control for the radio semantics is `overflowMenu.test.tsx`, which fails **11** tests when `isRadioGroup` is forced `true`. It isn't duplicated here, because this menu *is* a radio group — a control has to be able to produce the opposite result.

## One finding, filed not fixed — KAN-139

Six reducers call `stampCreated`, so **adding or deleting a tab or window rewrites a session's `createdTime`**. A session saved `2026-09-07 15:56:52` moved to position 1 with `createdTime` = `2026-09-09 12:25:46` after a single click of "Add current tab".

This narrows the gap between **Date saved** and **Date modified** to renames, recolours, ungrouping and reorders — two menu items that agree for the most common edits is close to a lying interface, and the fix for that belongs in the date, not the menu.

`git show main:` has the same six call sites — **identical on main, not introduced here.** Not fixed in this PR because `createdTime` is the merge's ordering contract; changing when it's written needs its own two-device story, not a rider on a UI ticket.

## Also in here

The WIP this replaces was blocked on nine `undoRedoChords` failures. Those were **KAN-137**, fixed by guarding `applyUndoSnapshot` against an undefined snapshot; they cleared on rebase — confirming the guard, not a module cycle, was the fix, as that commit already recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
