### PR TITLE
Stop rewriting createdAt on content edits (KAN-139)

### DIFF
--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -12,7 +12,6 @@ import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from '../store';
 import { closeFocusModal, openFocusModal, showToast } from './globalStateSlice';
 import {
-  getStringDate,
   isBlankTitle,
   normalizeTitle,
   saveToLocalStorage,
@@ -736,6 +735,24 @@ function sameSessionContent(a: tabContainerData, b: tabContainerData): boolean {
     // `undefined === undefined` is the common case and is correct: a session
     // that has never been dragged compares equal to itself.
     a.rank === b.rank &&
+    // `contentModified` (KAN-138) is deliberately NOT compared, which is the
+    // opposite call from `rank` above, so the reasoning is recorded here
+    // rather than left to be re-derived.
+    //
+    // It is synced, so by the rule stated above it looks like a hole. It is
+    // not reachable as one: `touchContent` is the only writer, and every call
+    // site sits beside a change this comparator already sees -- a title, a
+    // tab, a window, a Chrome group. No reducer can move it alone, so adding
+    // it here would never change an answer.
+    //
+    // What it WOULD change is the reverse case. A session edited and then
+    // manually edited back -- rename A->B->A -- has identical content and two
+    // advanced timestamps; comparing them would report it changed and stamp a
+    // session that is byte-identical to its snapshot. That is the direction
+    // the control in undoWindowReorderSurvivesSync.test.ts exists to catch.
+    //
+    // So: add it the moment a reducer touches `contentModified` without
+    // touching anything else, and not before (KAN-139).
     a.isAutoSave === b.isAutoSave &&
     a.windowCount === b.windowCount &&
     a.tabCount === b.tabCount &&
@@ -803,16 +820,22 @@ function sameChromeTabGroups(
   );
 }
 
-// createdTime and createdAt are the same moment in two formats - a local wall
-// clock for display, and the instant the merge orders on. They are written
-// together, through this, so a reader can never catch them describing
-// different moments.
-function stampCreated(group: tabContainerData): void {
-  const now = new Date();
-  group.createdTime = getStringDate(now);
-  group.createdAt = now.getTime();
-}
-
+// `stampCreated` used to live here, rewriting createdTime and createdAt to now
+// from the six structural-edit reducers -- add window, add tab, add tab to a
+// Chrome group, delete Chrome group, delete window, delete tab (KAN-139).
+//
+// It was not a stray bug. Those six are exactly the edits that change what a
+// session HOLDS, and re-stamping them made the left pane resurface a session
+// you had just added tabs to. That is "recently changed first" ordering,
+// implemented by overwriting the creation date because until KAN-136 there was
+// no other way to ask for recency. KAN-136 shipped a Date modified sort on
+// KAN-138's `contentModified`, so the impersonation is redundant -- and it was
+// actively lying: a session saved in July claimed today's date because one tab
+// was deleted from it.
+//
+// createdTime/createdAt are now written exactly once, at capture
+// (capture.ts:255-261, one `now` for both so the string and the instant cannot
+// disagree). Nothing rewrites them afterwards.
 // A removed session has to leave a trace, or the device that still holds it
 // re-adds it on the next merge and the user can never delete it anywhere.
 // Re-deleting an id refreshes its timestamp rather than appending a duplicate.
@@ -884,7 +907,6 @@ export const tabContainerDataStateSlice = createSlice({
       if (tabGroupIndex !== -1) {
         state.tabGroups[tabGroupIndex].windowCount += 1;
         state.tabGroups[tabGroupIndex].tabCount += window.tabCount;
-        stampCreated(state.tabGroups[tabGroupIndex]);
         state.tabGroups[tabGroupIndex].windows.unshift(window);
         touchContent(state.tabGroups[tabGroupIndex]);
       }
@@ -911,7 +933,6 @@ export const tabContainerDataStateSlice = createSlice({
         if (windowIndex !== -1) {
           // increment tab count of tabGroup and windowGroup
           state.tabGroups[tabGroupIndex].tabCount += 1;
-          stampCreated(state.tabGroups[tabGroupIndex]);
           state.tabGroups[tabGroupIndex].windows[windowIndex].tabCount += 1;
           // add to windowGroup
           state.tabGroups[tabGroupIndex].windows[windowIndex].tabs.unshift(
@@ -1083,7 +1104,6 @@ export const tabContainerDataStateSlice = createSlice({
 
       container.tabCount += 1;
       window.tabCount += 1;
-      stampCreated(container);
       touchContent(container);
       state.lastModified = Date.now();
       saveToLocalStorage('tabContainerData', state);
@@ -1186,7 +1206,6 @@ export const tabContainerDataStateSlice = createSlice({
 
       window.tabCount -= removed;
       container.tabCount -= removed;
-      stampCreated(container);
 
       // The same cascade deleteTabInternal runs, for the same reason: an empty
       // window is not a thing, and an empty session needs a tombstone rather
@@ -1245,7 +1264,6 @@ export const tabContainerDataStateSlice = createSlice({
         if (windowIndex !== -1) {
           // decrement tabGroup's window count by 1
           state.tabGroups[tabGroupIndex].windowCount -= 1;
-          stampCreated(state.tabGroups[tabGroupIndex]);
           // decrement tabGroup's tab count by tab count of the window that's been deleted
           state.tabGroups[tabGroupIndex].tabCount -=
             state.tabGroups[tabGroupIndex].windows[windowIndex].tabCount;
@@ -1293,7 +1311,6 @@ export const tabContainerDataStateSlice = createSlice({
             // decrement window's and tabGroup's tab count by 1
             state.tabGroups[tabGroupIndex].windows[windowIndex].tabCount -= 1;
             state.tabGroups[tabGroupIndex].tabCount -= 1;
-            stampCreated(state.tabGroups[tabGroupIndex]);
 
             state.tabGroups[tabGroupIndex].windows[windowIndex].tabs.splice(
               tabIndex,

--- a/src/tests/redux/structuralEditsSurviveSync.test.ts
+++ b/src/tests/redux/structuralEditsSurviveSync.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Inlined rather than imported: a vi.hoisted block runs before the module
+// graph is evaluated, and common.ts reads window.screen at module load.
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+const mocks = vi.hoisted(() => ({
+  loadFromFirestore: vi.fn(async (): Promise<unknown> => undefined),
+  saveToFirestore: vi.fn<(userId: string, data: unknown) => Promise<void>>(
+    async () => undefined
+  ),
+}));
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: mocks.loadFromFirestore,
+  saveToFirestore: mocks.saveToFirestore,
+  displayToast: vi.fn(),
+}));
+
+import {
+  setSignedIn,
+  setUserId,
+  syncStateWithFirestore,
+} from '../../redux/slices/globalStateSlice';
+import {
+  saveToTabContainerInternal,
+  addCurrWindowToTabGroupInternal,
+  addCurrTabToWindowInternal,
+  addCurrTabToChromeGroupInternal,
+  deleteChromeTabGroupInternal,
+  deleteWindowInternal,
+  deleteTabInternal,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import { undo } from '../../redux/slices/undoRedoSlice';
+import { makeTestStore } from '../setup/makeStore';
+import type {
+  tabContainerData,
+  TabMasterContainer,
+} from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-139. The six STRUCTURAL edits -- add or remove a window or tab -- must
+// stay visible to `sameSessionContent` on their own merits.
+//
+// WHY THIS FILE EXISTS. Those six reducers call `stampCreated`, which rewrites
+// `createdAt` and `createdTime` to now. That means they are currently visible
+// to the comparator TWICE OVER: once through the structure they changed, and
+// once through the timestamps. KAN-139 removes the second, on the grounds that
+// re-stamping a *creation* date on a delete is a lie. The question this file
+// answers is whether the first was ever load-bearing, or whether `createdAt`
+// has been quietly carrying all six.
+//
+// The stakes are the usual ones for this comparator. reconcileAssertedContainer
+// only stamps a restored session it can SEE has changed; a session it thinks is
+// unchanged is handed back with its snapshot timestamp and loses the next merge
+// to the cloud copy that still holds the edit. The undo applies, then sync
+// silently puts the edit back. That is KAN-80, KAN-83 and KAN-125, three times.
+//
+// So each test below undoes one structural edit and syncs against a cloud that
+// still holds it. Passing means the comparator saw the change.
+//
+// Written and run against main BEFORE the stampCreated calls were removed, so
+// that a pass after their removal is a statement about the removal rather than
+// about a test authored to suit it.
+
+const tab = (id: string, chromeGroupId?: string) => ({
+  tabId: id,
+  favicon: '',
+  title: `tab ${id}`,
+  url: `https://${id}.test`,
+  ...(chromeGroupId ? { chromeGroupId } : {}),
+});
+
+const win = (id: string, tabs: ReturnType<typeof tab>[]) => ({
+  windowId: id,
+  windowHeight: 100,
+  windowWidth: 100,
+  windowOffsetTop: 0,
+  windowOffsetLeft: 0,
+  tabCount: tabs.length,
+  title: `window ${id}`,
+  tabs,
+});
+
+// Two windows, four tabs, one Chrome group -- enough that every one of the six
+// reducers has something real to act on, and enough that deleting any single
+// thing never empties the session (an emptied session is removed outright by
+// the cascade, which would pass these assertions for the wrong reason).
+function seed(overrides: Partial<tabContainerData> = {}): tabContainerData {
+  return {
+    tabGroupId: 's1',
+    title: 'Alpha',
+    createdTime: '2026-09-07 00:00:00',
+    createdAt: Date.UTC(2026, 8, 7, 0, 0, 0),
+    windowCount: 2,
+    tabCount: 4,
+    isAutoSave: false,
+    isSelected: false,
+    windows: [
+      {
+        ...win('w1', [tab('t1', 'grp'), tab('t2', 'grp'), tab('t3')]),
+        chromeTabGroups: [{ groupId: 'grp', title: 'Research', color: 'blue' }],
+      },
+      win('w2', [tab('t4')]),
+    ],
+    ...overrides,
+  };
+}
+
+const shapeOf = (state: { tabGroups: tabContainerData[] }, id = 's1') => {
+  const g = state.tabGroups.find((x) => x.tabGroupId === id);
+  if (!g) return 'SESSION GONE';
+  return g.windows
+    .map(
+      (w) =>
+        `${w.windowId}[${w.tabs.map((t) => t.tabId).join(',')}]` +
+        `{${(w.chromeTabGroups ?? []).map((c) => c.groupId).join(',')}}`
+    )
+    .join(' ');
+};
+
+type Store = ReturnType<typeof makeTestStore>['store'];
+
+// Each entry: apply one structural edit to the seeded session.
+const STRUCTURAL_EDITS: [string, (s: Store) => void][] = [
+  [
+    'addCurrWindowToTabGroupInternal',
+    (s) =>
+      s.dispatch(
+        addCurrWindowToTabGroupInternal({
+          tabGroupId: 's1',
+          window: win('w3', [tab('t9')]),
+        })
+      ),
+  ],
+  [
+    'addCurrTabToWindowInternal',
+    (s) =>
+      s.dispatch(
+        addCurrTabToWindowInternal({
+          tabGroupId: 's1',
+          windowId: 'w2',
+          tabData: tab('t9'),
+        })
+      ),
+  ],
+  [
+    'addCurrTabToChromeGroupInternal',
+    (s) =>
+      s.dispatch(
+        addCurrTabToChromeGroupInternal({
+          tabGroupId: 's1',
+          windowId: 'w1',
+          groupId: 'grp',
+          tabData: tab('t9', 'grp'),
+        })
+      ),
+  ],
+  [
+    'deleteChromeTabGroupInternal',
+    (s) =>
+      s.dispatch(
+        deleteChromeTabGroupInternal({
+          tabGroupId: 's1',
+          windowId: 'w1',
+          groupId: 'grp',
+        })
+      ),
+  ],
+  [
+    'deleteWindowInternal',
+    (s) =>
+      s.dispatch(deleteWindowInternal({ tabGroupId: 's1', windowId: 'w2' })),
+  ],
+  [
+    'deleteTabInternal',
+    (s) =>
+      s.dispatch(
+        deleteTabInternal({ tabGroupId: 's1', windowId: 'w1', tabId: 't3' })
+      ),
+  ],
+];
+
+describe('undoing a structural edit survives the next sync (KAN-139)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mocks.loadFromFirestore.mockReset();
+    mocks.saveToFirestore.mockReset().mockResolvedValue(undefined);
+  });
+
+  it.each(STRUCTURAL_EDITS)('%s', async (_name, edit) => {
+    const { store } = makeTestStore();
+    store.dispatch(setSignedIn());
+    store.dispatch(setUserId('u1'));
+    store.dispatch(saveToTabContainerInternal(seed()));
+
+    const before = shapeOf(store.getState().tabContainerDataState);
+
+    edit(store);
+    const after = shapeOf(store.getState().tabContainerDataState);
+    // The edit did something. Without this an inert dispatch would sail
+    // through every assertion below, since undoing nothing trivially survives.
+    expect(after).not.toBe(before);
+
+    // The cloud received the edit exactly as auto-sync would have pushed it.
+    const cloud = JSON.parse(
+      JSON.stringify(store.getState().tabContainerDataState)
+    );
+
+    store.dispatch(undo());
+    expect(shapeOf(store.getState().tabContainerDataState)).toBe(before);
+
+    const afterUndo = store.getState().tabContainerDataState;
+    mocks.loadFromFirestore.mockResolvedValue(cloud);
+    localStorage.setItem('tabContainerData', JSON.stringify(afterUndo));
+    await store.dispatch(syncStateWithFirestore() as never);
+
+    // The assertion that depends on the comparator. If it could not see this
+    // edit, the merge hands back the cloud's copy and this reads `after`.
+    expect(shapeOf(store.getState().tabContainerDataState)).toBe(before);
+  });
+
+  it('covers every reducer that re-stamps createdAt', () => {
+    expect(STRUCTURAL_EDITS).toHaveLength(6);
+  });
+});
+
+// THE CONTROL. Reporting MORE sessions as changed makes every assertion above
+// easier to pass, and turns an undo into an assertion over the whole container
+// -- overwriting edits another device made to sessions the user never touched
+// here. A comparator "fixed" by returning false unconditionally would pass all
+// six tests above and fail this one.
+describe('and does not clobber an unrelated session edited elsewhere', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mocks.loadFromFirestore.mockReset();
+    mocks.saveToFirestore.mockReset().mockResolvedValue(undefined);
+  });
+
+  it.each(STRUCTURAL_EDITS)('%s leaves s2 alone', async (_name, edit) => {
+    const T0 = Date.UTC(2026, 8, 7, 12, 0, 0);
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(T0);
+
+      const { store } = makeTestStore();
+      store.dispatch(setSignedIn());
+      store.dispatch(setUserId('u1'));
+      store.dispatch(saveToTabContainerInternal(seed()));
+      store.dispatch(
+        saveToTabContainerInternal(seed({ tabGroupId: 's2', title: 'Bravo' }))
+      );
+
+      vi.setSystemTime(T0 + 1_000);
+      edit(store);
+
+      // The laptop renamed s2 half a second after the save -- newer than this
+      // device's copy, so the merge should keep it.
+      const cloud: TabMasterContainer = JSON.parse(
+        JSON.stringify(store.getState().tabContainerDataState)
+      );
+      const s2 = cloud.tabGroups.find((g) => g.tabGroupId === 's2')!;
+      s2.title = 'EDITED ON LAPTOP';
+      s2.lastModified = T0 + 500;
+
+      vi.setSystemTime(T0 + 2_000);
+      store.dispatch(undo());
+
+      mocks.loadFromFirestore.mockResolvedValue(cloud);
+      localStorage.setItem(
+        'tabContainerData',
+        JSON.stringify(store.getState().tabContainerDataState)
+      );
+      await store.dispatch(syncStateWithFirestore() as never);
+
+      expect(
+        store
+          .getState()
+          .tabContainerDataState.tabGroups.find((g) => g.tabGroupId === 's2')!
+          .title
+      ).toBe('EDITED ON LAPTOP');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/tests/redux/tabContainerReducers.test.ts
+++ b/src/tests/redux/tabContainerReducers.test.ts
@@ -33,6 +33,7 @@ import reducer, {
   deleteTabInternal,
   restoreContainer,
 } from '../../redux/slices/tabContainerDataStateSlice';
+import { getStringDate } from '../../utils/functions/local';
 import type {
   tabContainerData,
   TabMasterContainer,
@@ -320,15 +321,32 @@ describe('restoreContainer produces a Firestore-writable container', () => {
   });
 });
 
-// KAN-25. Four reducers restamp createdTime to "now". Each has to restamp
-// createdAt too, or the instant drifts away from the wall clock beside it and
-// the merge orders the session by a moment that has already passed.
-describe('createdAt restamping', () => {
+// KAN-25, then KAN-139. This block used to assert that these reducers restamp
+// createdTime and createdAt to "now", and its real claim was COHERENCE: if one
+// is rewritten the other must be too, or the instant drifts away from the wall
+// clock beside it and the merge orders the session by a moment that has
+// already passed.
+//
+// KAN-139 removed the restamping outright -- a session saved in July should
+// not claim today's date because one tab was deleted from it. The coherence
+// claim survives that change and is asserted more strongly here: neither field
+// moves, so they cannot drift apart at all. Written this way rather than
+// deleted, because "these two must agree" is still the property worth pinning,
+// and a future reintroduction of restamping on one field alone should fail
+// here.
+describe('createdTime and createdAt stay put after a content edit', () => {
   beforeEach(() => localStorage.clear());
+
+  // Both fields derived from ONE instant, so they are coherent by
+  // construction in whatever timezone the suite runs in. getStringDate formats
+  // local time, so hardcoding a matching string alongside an epoch would make
+  // this test's meaning depend on $TZ -- which is the KAN-25 trap itself.
+  const CREATED = new Date(Date.UTC(2026, 7, 31, 12, 0, 0));
 
   const seeded = (): TabMasterContainer => {
     const g = group('a');
-    g.createdAt = 1_000;
+    g.createdAt = CREATED.getTime();
+    g.createdTime = getStringDate(CREATED);
     g.windows.push({
       windowId: 'w2',
       windowHeight: 100,
@@ -402,14 +420,21 @@ describe('createdAt restamping', () => {
     ],
   ];
 
-  it.each(cases)('%s restamps createdAt', (_label, act) => {
-    const before = Date.now();
-    const after = act();
-    const stamped = byId(after, 'a').createdAt;
+  it.each(cases)('%s leaves both alone', (_label, act) => {
+    const after = byId(act(), 'a');
 
-    expect(stamped).not.toBe(1_000);
-    expect(typeof stamped).toBe('number');
-    expect(stamped!).toBeGreaterThanOrEqual(before);
-    expect(stamped!).toBeLessThanOrEqual(Date.now());
+    expect(after.createdAt).toBe(CREATED.getTime());
+    expect(after.createdTime).toBe(getStringDate(CREATED));
+  });
+
+  // The coherence claim the old version of this block was really making, kept
+  // because it is the part that still matters: the wall clock and the instant
+  // must describe the same moment. Restamping one field and not the other
+  // fails here even though both assertions above would still pass for the
+  // untouched one.
+  it.each(cases)('%s keeps the two describing one moment', (_label, act) => {
+    const after = byId(act(), 'a');
+
+    expect(getStringDate(new Date(after.createdAt!))).toBe(after.createdTime);
   });
 });


### PR DESCRIPTION
## What

Six reducers called `stampCreated`, rewriting `createdTime` and `createdAt` to *now*. A session saved in July claimed today's date because one tab was deleted from it, and jumped to the top of the default order.

Those two fields are now written **once**, at capture, and never again.

```
addCurrWindowToTabGroupInternal   deleteChromeTabGroupInternal
addCurrTabToWindowInternal        deleteWindowInternal
addCurrTabToChromeGroupInternal   deleteTabInternal
```

## The six were not arbitrary, which is why the ticket was rewritten before this was built

They are **exactly** the edits that change what a session holds. No metadata edit — rename, recolour, ungroup, reorder — re-stamps anything.

That is *"recently changed first"* ordering, implemented by overwriting the creation date, because until KAN-136 there was no other way to ask for recency. #232 ships a **Date modified** sort on KAN-138's `contentModified`, so the impersonation is now redundant as well as untrue.

The merge's ordering key is deliberately **unchanged** — still `rank ?? createdInstant`. It now sorts on a value that never moves, which is strictly more convergent than before. No migration: stored rows keep whatever `createdAt` they have.

## The risk was real, and it is now measured rather than argued

`reconcileAssertedContainer` only stamps a restored session `sameSessionContent` can *see* has changed. A session it thinks is unchanged loses the next merge to the cloud copy still holding the edit — the undo applies, then sync silently reverts it. That is KAN-80, KAN-83 and KAN-125, three times over.

These six were visible to that comparator **twice over**: through the structure they changed, and through the timestamps. Removing one leg had to leave the other load-bearing. I said as much on the ticket and marked it *reasoned, not proven*. Here is the proof.

`structuralEditsSurviveSync.test.ts` undoes each of the six against a cloud that still holds the edit. It was **written and run against `main` before this change**, so a pass afterwards is a statement about the change rather than about a test authored to suit it.

| | comparator intact | comparator blind to structure |
| --- | --- | --- |
| **`stampCreated` present (main)** | 13 pass | **13 pass** ← the finding |
| **`stampCreated` removed (this PR)** | **13 pass** ← the claim | **6 fail** ← the control |

**The top-right cell is the reason this could not have been tested after the fact.** With the comparator blinded to `windowCount`, `tabCount`, `windows.length` and the `windows.every` walk, *every test still passed on main*. `createdAt` was carrying all six single-handed, and those structural comparisons were dead weight for these reducers. The bottom-right cell shows they are load-bearing now.

("Blinded" = deleting those four comparisons from `sameSessionContent`.)

The control against the **opposite** failure is there too, per reducer: a comparator "fixed" by reporting everything as changed passes all six and turns an undo into an assertion over the whole container. Each of the six is checked not to clobber a second session edited on another device.

## Four tests asserted the old behaviour by name

Rewritten, not deleted. Reading the block comment, their real claim was **coherence** — *"if one of the pair is rewritten the other must be too, or the wall clock and the instant describe different moments."*

That claim survives this change and is now asserted more strongly, since neither field moves at all. Both fixtures derive from a single instant so the assertion cannot depend on `$TZ` — which is the KAN-25 trap itself.

Mutation: restamping `createdAt` alone in one reducer fails both the equality test and the coherence test.

## contentModified stays out of the comparator, with the reasoning recorded in place

`touchContent` is its only writer, and every call site sits beside a change the comparator already sees. No reducer can move it alone, so adding it would never change an answer.

It *would* change the reverse case: a rename A→B→A leaves identical content with an advanced timestamp, and comparing it would stamp a session byte-identical to its snapshot — the direction the existing control exists to catch. So: add it the moment a reducer touches it alone, and not before.

## Evidence

Verified in a real popup on the built artifact. Session saved `2026-09-07 21:21:58`, one click of **Add current tab**:

| | before | after |
| --- | --- | --- |
| `tabCount` | 8 | **9** ← the edit happened |
| `contentModified` | — | **advanced** |
| `createdTime` | `2026-09-07 21:21:58` | **unchanged** |
| `createdAt` | `1788841318446` | **unchanged** |
| position in list | 7 | **7** |

The same click measured on `main` moved a session from last place to first and rewrote its date by two days.

**1094 tests pass, tsc clean, lint clean** (25 warnings, all pre-existing and in files this branch does not touch).

## Not decided here

What the session row's date *should show* is a product decision, recorded on KAN-139 rather than settled by this change. This PR only makes the field honest about what it already claims to be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
