### PR TITLE
Guard dragging on search mode, not on the search box's contents (KAN-140)

### DIFF
--- a/src/components/home/leftpane/TabGroupEntryContainer.tsx
+++ b/src/components/home/leftpane/TabGroupEntryContainer.tsx
@@ -50,7 +50,6 @@ export default function TabGroupEntryContainer() {
   // KAN-131, at the session level and more exposed than the panes below it:
   // search filters sessions directly, so an index counted over the rendered
   // list would be applied to a longer stored one.
-  const isFilteredView = isSearchActive(isSearchPanel, searchInputText);
 
   const handleMoveSession = useCallback(
     (tabGroupId: string, toIndex: number) => {
@@ -140,10 +139,24 @@ export default function TabGroupEntryContainer() {
           {/* KAN-130. No handleSelector -- a session row contains no nested
               drag area, so the whole row is the handle. No resolveDrop -- a
               session belongs to nothing. */}
+          {/* Guarded on the MODE, not on whether the box currently holds
+              text (KAN-140). `isFilteredView` would leave dragging live while
+              the panel is open and empty, then silently kill it on the first
+              keystroke -- the same gesture on the same rows, decided by a
+              transient value, with rows rendering `cursor: pointer` either way
+              so nothing tells the user which state they are in.
+
+              KAN-131 argued the other way and was right about safety: an empty
+              box filters nothing, so the rendered list IS the stored one and
+              the index cannot cross between two arrays. It was wrong about
+              what the guard is for. Search is a mode entered to FIND
+              something, and a value guard also makes the safety property
+              depend on the ordering of a keystroke against a pointer gesture,
+              which a mode guard removes entirely. */}
           <RowDragArea
             rowIds={sessionIds}
             onMove={handleMoveSession}
-            disabled={isFilteredView}
+            disabled={isSearchPanel}
           >
             {filteredTabGroups.map((tabGroupData, index) => {
               return (

--- a/src/components/home/rightpane/TabGroupDetailsContainer.tsx
+++ b/src/components/home/rightpane/TabGroupDetailsContainer.tsx
@@ -11,7 +11,6 @@ import { AppDispatch, RootState } from '../../../redux/store';
 import {
   resolveTabUrl,
   isEmptyObject,
-  isSearchActive,
   selectVisibleTabGroups,
 } from '../../../utils/functions/local';
 import {
@@ -92,8 +91,9 @@ export default function TabGroupDetailsContainer() {
 
   // KAN-131, one level up from the tab list. A live search narrows windows[]
   // as well as a window's tabs, so a drop index counted over the rendered
-  // windows would be applied to a longer stored array.
-  const isFilteredView = isSearchActive(isSearchPanel, searchInputText);
+  // windows would be applied to a longer stored array. KAN-140 widened the
+  // guard from "a query is narrowing something" to "the search panel is open"
+  // -- see TabGroupEntryContainer for why.
 
   async function handleAddCurrTabToWindowClick(
     tabGroupId: string,
@@ -160,7 +160,9 @@ export default function TabGroupDetailsContainer() {
             rowIds={windowIds}
             onMove={handleMoveWindow}
             handleSelector="[data-window-drag-handle]"
-            disabled={isFilteredView}
+            // The mode, not the box's contents -- see KAN-140 on
+            // TabGroupEntryContainer for why this is not isFilteredView.
+            disabled={isSearchPanel}
           >
             {selectedTabGroup.windows.map(
               ({ windowId, title, tabs, chromeTabGroups }, windowIndex) => {

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -20,7 +20,6 @@ import { AppDispatch, RootState } from '../../../redux/store';
 import {
   resolveTabUrl,
   resolveFaviconUrl,
-  isSearchActive,
 } from '../../../utils/functions/local';
 import { NON_INTERACTIVE_ICON_STYLE } from '../../../utils/constants/common';
 import {
@@ -98,10 +97,6 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
     (state: RootState) => state.globalState.isSearchPanel
   );
 
-  const searchInputText = useSelector(
-    (state: RootState) => state.globalState.searchInputText
-  );
-
   // KAN-131. `tabs` here is whatever the pane handed down, and under a live
   // search that is a SUBSET of the stored window -- filterTabGroups narrows a
   // window's tabs, not just which windows are shown. A drag reports an index
@@ -109,10 +104,13 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
   // array, so in a narrowed list the tab lands somewhere the user never
   // pointed at, silently, and the session is dirtied for a cloud write.
   //
-  // isSearchActive, not isSearchPanel: an open panel with an empty box filters
-  // nothing, so the two lists agree and dragging is safe. That is the same
-  // distinction the count label turns on (KAN-60).
-  const isFilteredView = isSearchActive(isSearchPanel, searchInputText);
+  // isSearchPanel, not isSearchActive (KAN-140). This comment used to argue
+  // the opposite -- an open panel with an empty box filters nothing, so the
+  // two lists agree and dragging is safe -- which is true and is not the
+  // point. Guarding on the box's contents means the same gesture on the same
+  // rows works or does nothing depending on a transient value, with no visible
+  // tell, and makes the safety property depend on a keystroke racing a pointer
+  // gesture. The mode is the stable thing to ask about.
 
   // Gates rendering on the LIVE permission, not on whether the data is
   // present. A session synced from a device that had the permission still
@@ -693,7 +691,9 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
             rowIds={tabIds}
             onMove={handleMove}
             resolveDrop={bandAt}
-            disabled={isFilteredView}
+            // The mode, not the box's contents -- see KAN-140 on
+            // TabGroupEntryContainer for why this is not isFilteredView.
+            disabled={isSearchPanel}
           >
             {partitionTabsIntoRuns(
               tabs,

--- a/src/tests/components/dragIsDisabledWhileSearching.test.tsx
+++ b/src/tests/components/dragIsDisabledWhileSearching.test.tsx
@@ -1,11 +1,12 @@
 import { describe, expect, test, afterEach } from 'vitest';
-import { fireEvent } from '@testing-library/react';
+import { act, fireEvent } from '@testing-library/react';
 
 import TabGroupDetailsContainer from '../../components/home/rightpane/TabGroupDetailsContainer';
 import { renderWithProviders } from '../setup/renderWithProviders';
 import type { RenderWithProvidersResult } from '../setup/renderWithProviders';
 import {
   openSearchPanel,
+  closeSearchPanel,
   setSearchInputText,
   setHasTabGroupsPermission,
   setIsNotDirty,
@@ -166,15 +167,66 @@ describe('a tab drag inside a filtered list', () => {
     expect(store.getState().globalState.isDirty).toBe(false);
   });
 
-  // An open search panel with an empty box filters nothing, so the rendered
-  // list IS the stored one and dragging is safe. `isSearchActive` is the
-  // predicate that already draws this line everywhere else (KAN-60); a guard
-  // on `isSearchPanel` alone would disable a feature that works.
-  test('an open search panel with an empty box still allows dragging', async () => {
+  // KAN-140, and this assertion is the exact inverse of what it used to be.
+  //
+  // The old version allowed the drag, reasoning that an empty box filters
+  // nothing, so the rendered list IS the stored one and nothing can go wrong.
+  // That reasoning is still true -- KAN-131's index-crossing defect genuinely
+  // cannot occur here -- and it is not what decides this.
+  //
+  // What decides it is that the box's contents are a terrible thing to hang an
+  // affordance on. The same gesture on the same rows worked or did nothing
+  // depending on whether a character had been typed, with rows rendering
+  // `cursor: pointer` in both states (KAN-134), so nothing told the user which
+  // one they were in. It also made the safety property depend on a keystroke
+  // racing a pointer gesture; asking about the mode removes the timing
+  // dimension rather than betting there is no race today.
+  //
+  // Note this file's OTHER tests still pass a query, so they continue to cover
+  // KAN-131's actual subject -- a narrowed list -- which this change does not
+  // touch. And the CONTROL above still reorders, so the harness is not simply
+  // failing to deliver pointer events.
+  test('an open search panel with an empty box does not allow dragging', async () => {
     const { container, store } = await render('');
+    const rows = layoutTabRows(container);
+    // The premise: nothing is filtered, so all four rows are on screen and the
+    // drag below is the one that used to commit.
+    expect(rows).toHaveLength(4);
+
+    dragToTop(rows[3], 3 * ROW_H + 15);
+
+    expect(storedTabIds(store)).toEqual(['t1', 't2', 't3', 't4']);
+  });
+
+  // The mode, not the query, all the way down: clearing the box mid-search
+  // must not hand the gesture back.
+  test('clearing the box does not re-enable dragging', async () => {
+    const { container, store } = await render('match');
+    // act, because a bare dispatch after render does not flush: the rows would
+    // still be the two matching ones and this would assert against a list the
+    // component has not caught up with.
+    act(() => {
+      store.dispatch(setSearchInputText(''));
+    });
+
     const rows = layoutTabRows(container);
     expect(rows).toHaveLength(4);
 
+    dragToTop(rows[3], 3 * ROW_H + 15);
+
+    expect(storedTabIds(store)).toEqual(['t1', 't2', 't3', 't4']);
+  });
+
+  // And leaving search restores it, so the guard is a mode rather than a
+  // one-way door. Without this, disabling dragging permanently would pass
+  // every other test in this file.
+  test('CONTROL: closing the search panel allows dragging again', async () => {
+    const { container, store } = await render('');
+    act(() => {
+      store.dispatch(closeSearchPanel());
+    });
+
+    const rows = layoutTabRows(container);
     dragToTop(rows[3], 3 * ROW_H + 15);
 
     expect(storedTabIds(store)).toEqual(['t4', 't1', 't2', 't3']);

--- a/src/tests/components/sessionDragReorder.test.tsx
+++ b/src/tests/components/sessionDragReorder.test.tsx
@@ -169,3 +169,49 @@ describe('a session drag inside a filtered list', () => {
     expect(store.getState().globalState.isDirty).toBe(false);
   });
 });
+
+// KAN-140. The session list is the third drag area, and the guard here asks
+// about the MODE rather than about whether the search box holds text.
+//
+// Added because mutation testing found this level unguarded: replacing the
+// session area's `disabled` with a literal `false` broke nothing in the suite,
+// so KAN-131's guard here had never been pinned by a test.
+describe('dragging sessions while the search panel is open', () => {
+  test('does nothing, even with an empty box', async () => {
+    const { container, store } = await render('');
+    // The premise: an empty query filters nothing, so all three sessions are
+    // on screen and this is exactly the drag the unfiltered tests commit.
+    layout(container, ['c', 'b', 'a']);
+
+    drag(nodeFor(container, 'a'), 100, 5);
+
+    expect(order(store)).toEqual(['c', 'b', 'a']);
+    expect(store.getState().globalState.isDirty).toBe(false);
+  });
+
+  test('does nothing with a query narrowing the list', async () => {
+    const { container, store } = await render('ALPHA');
+
+    const rendered = [
+      ...container.querySelectorAll<HTMLElement>('[data-drag-row-id]'),
+    ];
+    expect(rendered.map((r) => r.dataset.dragRowId)).toEqual(['a']);
+    rendered[0].getBoundingClientRect = () => box(0, ROW_H);
+
+    drag(rendered[0], 15, 200);
+
+    expect(order(store)).toEqual(['c', 'b', 'a']);
+    expect(store.getState().globalState.isDirty).toBe(false);
+  });
+
+  // THE CONTROL. Without it a session area that never dragged at all would
+  // satisfy both tests above while proving nothing.
+  test('CONTROL: the same drag with no search panel does reorder', async () => {
+    const { container, store } = await render();
+    layout(container, ['c', 'b', 'a']);
+
+    drag(nodeFor(container, 'a'), 100, 5);
+
+    expect(order(store)).toEqual(['a', 'c', 'b']);
+  });
+});

--- a/src/tests/components/windowDragReorder.test.tsx
+++ b/src/tests/components/windowDragReorder.test.tsx
@@ -295,4 +295,36 @@ describe('a window drag inside a filtered list', () => {
     expect(windowIds(store)).toEqual(['w1', 'w2', 'w3']);
     expect(store.getState().globalState.isDirty).toBe(false);
   });
+
+  // KAN-140. The guard asks about the MODE, so an empty box blocks the drag
+  // too -- all three windows are on screen and unfiltered, and it still does
+  // not commit. Before KAN-140 this reordered.
+  //
+  // Added because mutation testing found this level unguarded by any test:
+  // replacing the window area's `disabled` with a literal `false` broke
+  // nothing in the suite, so KAN-131's guard here was never actually pinned.
+  test('an open panel with an empty box does not allow dragging either', async () => {
+    const { container, store } = await render('');
+    const windows = layout(container);
+    // The premise: nothing is filtered, so this is the same drag the
+    // unfiltered tests above commit.
+    expect(windows.map((r) => r.dataset.dragRowId)).toEqual(['w1', 'w2', 'w3']);
+
+    drag(handleIn(nodeFor(container, 'w1')), 20, 170);
+
+    expect(windowIds(store)).toEqual(['w1', 'w2', 'w3']);
+    expect(store.getState().globalState.isDirty).toBe(false);
+  });
+
+  // THE CONTROL for the two above. Without it, a window area that never
+  // dragged at all -- a broken handleSelector, a harness whose pointer events
+  // miss the handle -- would satisfy both while proving nothing.
+  test('CONTROL: the same drag with no search panel does reorder', async () => {
+    const { container, store } = await render();
+    layout(container);
+
+    drag(handleIn(nodeFor(container, 'w1')), 20, 170);
+
+    expect(windowIds(store)).not.toEqual(['w1', 'w2', 'w3']);
+  });
 });


### PR DESCRIPTION
## What

Reported from the UI: *"you shouldn't be able to drag anywhere in search mode."*

All three drag areas guarded on `isFilteredView`:

```ts
const isFilteredView = isSearchActive(isSearchPanel, searchInputText);
// isSearchActive = isSearchPanel && searchInputText !== ''
```

So the guard only engaged **once you typed**. Open the search panel and drag before typing, and the drag ran normally.

Measured on the built artifact:

| state | drag starts | list reorders |
| --- | --- | --- |
| search open, box empty | **yes** | **yes** |
| search open, box = `"a"` | no | no |

Same gesture, same rows, opposite outcome — decided by whether the box held a character. And there was **no visible tell**: rows render `cursor: pointer` in both states, by KAN-134's decision to keep `pointer` at rest.

## This overturns a deliberate decision

KAN-131 shipped a test called *"an open search panel with an empty box still allows dragging"*, whose comment argued:

> An empty box filters nothing, so the rendered list IS the stored one and dragging is safe. `isSearchActive` is the predicate that already draws this line everywhere else (KAN-60); a guard on `isSearchPanel` alone would disable a feature that works.

**That is correct about safety, and it is not what decides this.** KAN-131's index-crossing defect genuinely cannot occur with an empty box. Two things outweigh it:

1. **Search is a mode.** It is entered to *find* something. Whether a gesture exists shouldn't depend on the transient contents of a text box.
2. **A value guard races; a mode guard doesn't.** Hanging the safety property on `searchInputText !== ''` makes it depend on the ordering of a keystroke against a pointer gesture. Guarding on `isSearchPanel` removes the timing dimension rather than betting no race exists today.

`isSearchActive` **itself is unchanged** — it's right for its other callers. The "Matches: N Windows - M Tabs" summary must say "Matches" only when a query is actually narrowing something (KAN-60), and `filterTabGroups` must not filter on an empty string. This changes what the *drag guard* asks, not what "search is active" means. Two components no longer need the helper at all.

## Mutation testing found two of the three guards completely untested

Replacing the window area's `disabled` with a literal `false` broke **nothing** in the suite. Same for the session area. Only the tab level was pinned.

That gap **predates this PR** — KAN-131 guarded all three levels and only ever tested one. So tests were added at the other two, in the drag files where the fixtures already live:

| guard removed | tests that fail (before → after) |
| --- | --- |
| tabs (`WindowEntryContainer`) | 4 → 4 |
| windows (`TabGroupDetailsContainer`) | **0 → 1** |
| sessions (`TabGroupEntryContainer`) | **0 → 1** |

Every new test ships with a **control**, because "nothing moved" is exactly what a drag area that never worked also reports. Closing the search panel must hand the gesture back — asserted at each level.

The inverted test keeps its place rather than being deleted: the empty box is still the interesting case, now with the opposite expectation and the reasoning above in place of the old comment. The typed-query tests are untouched — they're KAN-131's actual subject and this doesn't affect them.

## One thing worth flagging for the next person

Two dispatches in the new tests are wrapped in `act`. Without it the component hasn't re-rendered when the rows are queried, and the assertion reads a list one state behind. It surfaced as `expected 4 rows, got 2` — nothing resembling the real cause.

## Evidence

Verified in a real popup on the built artifact:

| state | drag flag set | order changed |
| --- | --- | --- |
| search open, empty box — **session** drag | no | no |
| search open, empty box — **tab** drag | no | no |
| search **closed** — same session drag | **yes** | **yes** |

That last row is the control that matters: dragging is *gated*, not broken.

**1084 tests pass, tsc clean, lint clean** (25 warnings, all pre-existing and in files this branch does not touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
