### PR TITLE
Follow the selected session when the list rearranges under it (KAN-143)

### DIFF
--- a/src/components/home/leftpane/TabGroupEntryContainer.tsx
+++ b/src/components/home/leftpane/TabGroupEntryContainer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -28,6 +28,10 @@ export default function TabGroupEntryContainer() {
   const COLORS = useThemeColors();
   const { t } = useTranslation();
   const dispatch: AppDispatch = useDispatch();
+
+  // The scrolling element, so KAN-143's effect scopes its lookup to this list
+  // rather than searching the whole document.
+  const listRef = useRef<HTMLDivElement>(null);
 
   const tabContainerDataList = useSelector(
     (state: RootState) => state.tabContainerDataState
@@ -103,6 +107,54 @@ export default function TabGroupEntryContainer() {
     dispatch(selectTabContainer(filteredTabGroups[0].tabGroupId));
   }, [searchInputText, isSearchPanel]);
 
+  // KAN-143. Follow the selected session when the list rearranges under it.
+  //
+  // Editing a session moves it to the top (KAN-141), and the edit is made in
+  // the RIGHT pane -- a rename, adding a tab -- so the user is not watching the
+  // left pane when it happens. Select a session, scroll the list to look at
+  // others, edit it, and the row simply vanishes with nothing to say where it
+  // went.
+  //
+  // IT ONLY REPRODUCES WHILE THE ROW IS OFF SCREEN, and that is worth knowing
+  // before you test this. When the row is visible, Chrome's scroll anchoring
+  // has already picked it as the anchor and follows it to its new position by
+  // itself -- measured, with no script writing scrollTop at all -- so both a
+  // fixed and an unfixed build keep it in view and this effect looks like a
+  // no-op. Off screen it anchors nothing: measured on an unfixed build, a row
+  // 201px above the fold moved to the top and the pane did not budge, leaving
+  // it 886px away.
+  //
+  // KEYED ON WHERE THE SELECTED ROW IS, not on every render. That is what keeps
+  // it from fighting the user: scrolling the list by hand changes neither the
+  // index nor the id, so a hand-scrolled list is never yanked back. It re-runs
+  // on the id too, because the same index can hold a different session -- and
+  // that costs nothing, since a row the user just clicked is on screen already.
+  //
+  // `block: 'nearest'` is what makes that true: it scrolls the minimum needed
+  // and does nothing at all when the row is already visible, which is the
+  // common case for every re-run except the one this exists for. It is also
+  // what keeps this from second-guessing the browser -- in the visible case
+  // above, where anchoring has already done the right thing, 'nearest' has
+  // nothing left to do.
+  //
+  // -1 when nothing is selected, which deleting the selected session produces.
+  // It is a trigger and nothing else -- the lookup below goes by id, so this is
+  // read only as a dependency.
+  const selectedIndex =
+    selectedTabGroupId === null ? -1 : sessionIds.indexOf(selectedTabGroupId);
+  useEffect(() => {
+    if (selectedTabGroupId === null) return;
+    // Missing whenever the selection is not on screen -- filtered out by a
+    // search, or already gone. There is nothing to scroll to, and skipping is
+    // the whole handling. An index guard here would be dead code: it can only
+    // be out of range in the cases this lookup already misses (verified by
+    // mutation -- removing it failed nothing).
+    const row = listRef.current?.querySelector<HTMLElement>(
+      `[data-drag-row-id="${CSS.escape(selectedTabGroupId)}"]`
+    );
+    row?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex, selectedTabGroupId]);
+
   const containerStyle = css`
     display: flex;
     flex-direction: column;
@@ -126,7 +178,7 @@ export default function TabGroupEntryContainer() {
   `;
 
   return (
-    <div css={containerStyle}>
+    <div css={containerStyle} ref={listRef}>
       {filteredTabGroups.length === 0 ? (
         <div css={emptyContainerStyle}>
           {/* KAN-86. Was the bare literal "Empty", which rendered in English

--- a/src/tests/components/followTheMovedSession.test.tsx
+++ b/src/tests/components/followTheMovedSession.test.tsx
@@ -1,0 +1,282 @@
+import { describe, expect, test, afterEach, vi } from 'vitest';
+import { act } from '@testing-library/react';
+
+import TabGroupEntryContainer from '../../components/home/leftpane/TabGroupEntryContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  openSearchPanel,
+  setHasTabGroupsPermission,
+  setSearchInputText,
+} from '../../redux/slices/globalStateSlice';
+import {
+  deleteTabContainerInternal,
+  restoreContainer,
+  saveToTabContainerInternal,
+  selectTabContainer,
+  updateTabGroupTitle,
+} from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-143. Editing a session moves it to the top of the left pane (KAN-141),
+// but the edit is made in the RIGHT pane -- a rename, adding a tab -- so the
+// user is not watching the left pane when it happens. Scrolled down, the row
+// they just edited leaves the viewport with nothing to say where it went.
+//
+// WHAT THESE TESTS CAN AND CANNOT PROVE. jsdom implements no layout and no
+// scrolling (see the stub in componentSetup.ts), so the only observable here is
+// WHICH row was asked to scroll and WHEN. That "the row ends up visible", that
+// `block: 'nearest'` moves the minimum, and that it no-ops for an
+// already-visible row are real-browser claims and are checked there instead.
+// What is worth pinning in jsdom is the decision: the effect must fire when the
+// list rearranges under the selection, and must NOT fire when it did not.
+
+const HOUR = 3600_000;
+const T0 = Date.UTC(2026, 8, 9, 12, 0, 0);
+
+const session = (id: string, title: string, createdAt: number) => ({
+  tabGroupId: id,
+  title,
+  createdTime: '2026-09-09 12:00:00',
+  createdAt,
+  windowCount: 1,
+  tabCount: 1,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: `${id}-w`,
+      windowHeight: 100,
+      windowWidth: 100,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount: 1,
+      title: 'Window',
+      tabs: [
+        {
+          tabId: `${id}-t`,
+          favicon: '',
+          title: `${title} tab`,
+          url: 'https://a.co',
+        },
+      ],
+    },
+  ],
+});
+
+// Records every scrollIntoView the tree makes, by row id and argument.
+//
+// One recorder over the prototype rather than a spy per row, deliberately: a
+// per-row spy is installed on a specific DOM node, so a call landing on a node
+// React had recreated would be recorded by nothing and read as "it never
+// scrolled". This sees every call whatever element it lands on, which is what
+// makes `toEqual([])` in the control below mean what it says.
+type ScrollCall = {
+  rowId: string | undefined;
+  options: ScrollIntoViewOptions | boolean | undefined;
+};
+
+const scrollCalls: ScrollCall[] = [];
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+function recordScrolls(): void {
+  scrollCalls.length = 0;
+  Element.prototype.scrollIntoView = function scrollIntoView(
+    this: Element,
+    options?: ScrollIntoViewOptions | boolean
+  ) {
+    scrollCalls.push({
+      rowId: (this as HTMLElement).dataset?.dragRowId,
+      options,
+    });
+  };
+}
+
+afterEach(() => {
+  Element.prototype.scrollIntoView = originalScrollIntoView;
+  scrollCalls.length = 0;
+});
+
+// Saved oldest first, so the pane renders newest-first: CHARLIE, BRAVO, ALPHA.
+// The clock is pinned per save (KAN-141): saving stamps contentModified with
+// Date.now(), which is what the list is ordered by, so three saves in one tick
+// would tie and collapse onto the id tiebreak.
+const render = (selectedId: string) => {
+  recordScrolls();
+  return renderWithProviders(<TabGroupEntryContainer />, {
+    seedStore: (store) => {
+      store.dispatch(setHasTabGroupsPermission(false));
+      vi.useFakeTimers();
+      try {
+        for (const [id, title, at] of [
+          ['a', 'ALPHA', T0 - 2 * HOUR],
+          ['b', 'BRAVO', T0 - HOUR],
+          ['c', 'CHARLIE', T0],
+        ] as const) {
+          vi.setSystemTime(at);
+          store.dispatch(saveToTabContainerInternal(session(id, title, at)));
+        }
+      } finally {
+        vi.useRealTimers();
+      }
+      store.dispatch(selectTabContainer(selectedId));
+    },
+  });
+};
+
+const renderedOrder = (container: HTMLElement) =>
+  [...container.querySelectorAll<HTMLElement>('[data-drag-row-id]')].map(
+    (row) => row.dataset.dragRowId
+  );
+
+const rename = (
+  store: Awaited<ReturnType<typeof render>>['store'],
+  tabGroupId: string,
+  editableTitle: string
+) =>
+  act(() => {
+    store.dispatch(updateTabGroupTitle({ tabGroupId, editableTitle }));
+  });
+
+describe('following the selected session when the list rearranges', () => {
+  test('scrolls to the selected row when an edit moves it to the top', async () => {
+    const { container, store } = await render('a');
+    // The premise: ALPHA is selected and last, i.e. the row a scrolled-down
+    // user is looking at.
+    expect(renderedOrder(container)).toEqual(['c', 'b', 'a']);
+    scrollCalls.length = 0;
+
+    await rename(store, 'a', 'ALPHA RENAMED');
+
+    // The rearrangement this exists for, asserted before the consequence.
+    expect(renderedOrder(container)).toEqual(['a', 'c', 'b']);
+    expect(scrollCalls).toEqual([
+      { rowId: 'a', options: { block: 'nearest' } },
+    ]);
+  });
+
+  // The case that is easy to miss: the user did not touch the selected session
+  // at all, but it moved anyway because something else jumped over it. A sync
+  // arriving from another device does exactly this.
+  test('scrolls to the selected row when ANOTHER session moves past it', async () => {
+    const { container, store } = await render('b');
+    expect(renderedOrder(container)).toEqual(['c', 'b', 'a']);
+    scrollCalls.length = 0;
+
+    await rename(store, 'a', 'ALPHA RENAMED');
+
+    // BRAVO is still selected and untouched, but it is now index 2, not 1.
+    expect(renderedOrder(container)).toEqual(['a', 'c', 'b']);
+    expect(scrollCalls).toEqual([
+      { rowId: 'b', options: { block: 'nearest' } },
+    ]);
+  });
+
+  // The case where the INDEX alone is not enough to notice. An undo and a sync
+  // merge each replace the whole container in one action, so the order and the
+  // selection move together in a single commit -- and the newly selected
+  // session can land on the index the old one just vacated. Keyed on the index
+  // alone, the effect would see nothing change and leave the user looking at
+  // wherever they happened to be scrolled.
+  test('follows the selection when a restore moves the order AND the selection', async () => {
+    const { container, store } = await render('c');
+    expect(renderedOrder(container)).toEqual(['c', 'b', 'a']);
+    scrollCalls.length = 0;
+
+    const before = store.getState().tabContainerDataState;
+    // BRAVO takes index 0, which is where CHARLIE -- the current selection --
+    // is sitting right now.
+    const reordered = ['b', 'c', 'a'].flatMap((id) =>
+      before.tabGroups.filter((group) => group.tabGroupId === id)
+    );
+    expect(reordered).toHaveLength(before.tabGroups.length);
+
+    act(() => {
+      store.dispatch(
+        restoreContainer({
+          ...before,
+          tabGroups: reordered,
+          selectedTabGroupId: 'b',
+        })
+      );
+    });
+
+    expect(renderedOrder(container)).toEqual(['b', 'c', 'a']);
+    expect(scrollCalls).toEqual([
+      { rowId: 'b', options: { block: 'nearest' } },
+    ]);
+  });
+
+  test('scrolls to the selected row on mount, for a selection already off screen', async () => {
+    const { container } = await render('a');
+
+    expect(renderedOrder(container)).toEqual(['c', 'b', 'a']);
+    expect(scrollCalls).toEqual([
+      { rowId: 'a', options: { block: 'nearest' } },
+    ]);
+  });
+});
+
+describe('NOT following when nothing moved under the selection', () => {
+  // THE CONTROL. Without it, an effect that scrolled on every single render
+  // would satisfy all three tests above -- and it would be the bug this ticket
+  // is careful to avoid, because it would yank a hand-scrolled list back on any
+  // unrelated state change.
+  test('CONTROL: an edit that does not reorder the list scrolls nothing', async () => {
+    const { container, store } = await render('a');
+    expect(renderedOrder(container)).toEqual(['c', 'b', 'a']);
+    scrollCalls.length = 0;
+
+    // CHARLIE is already at the top, so touching it leaves every index alone.
+    await rename(store, 'c', 'CHARLIE RENAMED');
+
+    // The store really did change and the list really did re-render -- without
+    // this the test would pass against a component that ignored the dispatch,
+    // which proves nothing about the effect's dependencies.
+    expect(
+      store
+        .getState()
+        .tabContainerDataState.tabGroups.map((group) => group.title)
+    ).toEqual(['CHARLIE RENAMED', 'BRAVO', 'ALPHA']);
+    expect(renderedOrder(container)).toEqual(['c', 'b', 'a']);
+    expect(scrollCalls).toEqual([]);
+  });
+
+  // The other way the selection stops having a row: a search narrows the list
+  // past it. The effect re-runs mid-flight with an id that matches nothing in
+  // the DOM -- KAN-90's effect has not yet moved the selection to the surviving
+  // match -- so this is the path where a lookup that assumed a row would throw.
+  test('a search that filters the selection out scrolls to the new match, not the old one', async () => {
+    const { container, store } = await render('a');
+    scrollCalls.length = 0;
+
+    act(() => {
+      store.dispatch(openSearchPanel());
+      store.dispatch(setSearchInputText('CHARLIE'));
+    });
+
+    // ALPHA is gone from the list and KAN-90 has moved the selection onto the
+    // one match. Nothing was scrolled on ALPHA's behalf along the way.
+    expect(renderedOrder(container)).toEqual(['c']);
+    expect(store.getState().tabContainerDataState.selectedTabGroupId).toBe('c');
+    expect(scrollCalls).toEqual([
+      { rowId: 'c', options: { block: 'nearest' } },
+    ]);
+  });
+
+  // The worst path: there is no row to scroll to. Deleting the selected session
+  // nulls selectedTabGroupId, so the effect re-runs with a selection that
+  // matches nothing in the DOM.
+  test('deleting the selected session scrolls nothing and does not throw', async () => {
+    const { container, store } = await render('a');
+    scrollCalls.length = 0;
+
+    act(() => {
+      store.dispatch(deleteTabContainerInternal('a'));
+    });
+
+    expect(
+      store.getState().tabContainerDataState.selectedTabGroupId
+    ).toBeNull();
+    expect(renderedOrder(container)).toEqual(['c', 'b']);
+    expect(scrollCalls).toEqual([]);
+  });
+});

--- a/src/tests/setup/componentSetup.ts
+++ b/src/tests/setup/componentSetup.ts
@@ -30,6 +30,20 @@ vi.mock('../../utils/functions/external', () => ({
 // the dialog RENDERS and is wired up (role, labelling, handlers); it is not
 // evidence that the modal actually traps focus. That claim can only be made
 // against a real browser, and is checked there instead.
+// KAN-143. jsdom implements no layout and therefore no scrolling: every element
+// box is 0x0 and `Element.prototype.scrollIntoView` is not merely inert, it is
+// UNDEFINED, so any component that calls it throws on mount.
+//
+// WHAT THIS STUB DOES AND DOES NOT DO. It is a no-op, and the only thing a test
+// can learn from it is WHICH ELEMENT was asked to scroll and WHEN -- by spying
+// over it. It cannot tell you whether the row actually came into view, whether
+// `block: 'nearest'` scrolled the minimum, or whether it no-ops for an
+// already-visible row, because none of those exist here. Those are real-browser
+// claims and are checked there instead.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = function scrollIntoView() {};
+}
+
 if (typeof HTMLDialogElement !== 'undefined') {
   if (!HTMLDialogElement.prototype.showModal) {
     HTMLDialogElement.prototype.showModal = function showModal(


### PR DESCRIPTION
## What

Editing a session moves it to the top of the left pane (#235). The edit is made in the **right** pane, so the user is not watching the left pane when it happens. Select a session, scroll the list to look at others, rename it — and the row leaves the viewport with nothing to say where it went.

The selected row now gets `scrollIntoView({ block: 'nearest' })` when its place in the list changes.

## It only reproduces while the row is off screen

This is the part worth knowing before reviewing, because testing it the obvious way shows nothing.

**When the row is visible, Chrome's scroll anchoring has already anchored to it and follows it by itself.** On an unfixed build, renaming the selected bottom row moved it index 22 → 0 and the pane went `scrollTop` 1160.5 → **0** with no help — leaving it visible. Same from a mid-pane start (600 → 0). That is the browser, not the app: with a trapped `scrollTop` setter and a wrapped `Element.prototype.scrollIntoView` installed, **zero script writes and zero scrollIntoView calls** were recorded, `(scrollHeight, clientHeight, rowCount)` never changed (`1575/414/23` throughout, so not a clamp), and the scroller was the same tagged node afterwards (so not a remount).

**Off screen, nothing anchors to it.** Identical starting states — 20 unranked sessions, PROBE-11 selected at index 10, pane scrolled to the bottom so the row sits 201px above the fold:

| | control (effect disabled) | this branch |
| --- | --- | --- |
| index | 10 → 0 | 10 → 0 |
| `scrollTop` | 955 → **955** | 955 → **0** |
| visible afterwards | **no**, 886px above the fold | **yes** |
| `scrollIntoView` | 0 calls | 1, on `probe-11`, `{block:'nearest'}` |

Both builds are the real pruned artifact (`npm run build:e2e`), differing only in that one line, driven in the real popup and staged offline so nothing reached Firestore.

**I got this wrong first.** My first three live probes all had the row visible, all showed the two builds agreeing, and I reported that the premise did not reproduce. Justine said dig further, and the off-screen variant reproduced it immediately. The control was there the whole time — it was the scenarios that were wrong.

`block: 'nearest'` is what keeps the two from fighting: in the visible case, where anchoring has already done the right thing, it has nothing left to do.

## Keyed on where the row is, not on every render

```ts
const selectedIndex =
  selectedTabGroupId === null ? -1 : sessionIds.indexOf(selectedTabGroupId);
useEffect(() => {
  if (selectedTabGroupId === null) return;
  const row = listRef.current?.querySelector<HTMLElement>(
    `[data-drag-row-id="${CSS.escape(selectedTabGroupId)}"]`
  );
  row?.scrollIntoView({ block: 'nearest' });
}, [selectedIndex, selectedTabGroupId]);
```

Scrolling the list by hand changes neither the index nor the id, so a hand-scrolled list is never yanked back. Running on every render would do exactly that, and the `CONTROL` test below is what stops it.

The id is in the deps as well as the index, because one commit can change both together and land the new selection on the index the old one vacated — which is what undo and a sync merge do. Pinning that needed a test going through `restoreContainer`; without it the dependency survived mutation.

## Two casts removed from the WIP

`selectedTabGroupId!` and `scrollIntoView?.()` were both there for jsdom, which implements no scrolling and leaves `Element.prototype.scrollIntoView` **undefined** (probed). The gap is now stubbed in `componentSetup.ts` beside the existing `<dialog>` stub, with the same note about what a stub can and cannot prove — so the production call says what is true in a browser.

The `selectedIndex < 0` guard is gone too. Mutation-testing showed it is **dead code**: it can only be out of range in the cases the `querySelector` already misses, and lint does not flag a dependency that the body never reads, so it was not propping up `exhaustive-deps` either.

## Tests

7 new in `src/tests/components/followTheMovedSession.test.tsx`. They record every `scrollIntoView` by row id over the prototype rather than spying per row, so a call landing on a node React recreated is still seen — which is what makes `toEqual([])` in the control mean what it says.

Full suite **1153 passed** (was 1146), `tsc --noEmit` clean, `eslint` 0 errors.

Mutation results — 7 mutations, 6 caught:

```
effect never scrolls            → 4 failed   ✓
no dependency array             → 1 failed   ✓  (the CONTROL test)
drop selectedTabGroupId dep     → 1 failed   ✓
drop selectedIndex dep          → 2 failed   ✓
block:'start' not 'nearest'     → 4 failed   ✓
scroll the list, not the row    → 4 failed   ✓
document.querySelector          → 0 failed   ✗  survived
```

The survivor is honest: ids are all uuidv4 from one namespace, so scoping the lookup to `listRef` cannot change which element is found today. It is kept as a statement of intent, not claimed as load-bearing.

## Known gap, by design

On a **pinned** list — after an explicit sort every session carries a `rank` — an edit moves nothing, so the effect correctly does not fire and a row that was already off screen stays there. Verified live on both builds. Worth a separate ticket if we want "an edit always shows you the session", but that is a different rule from "follow the row when the list rearranges under it".
