### PR TITLE
Walk the whole tab order instead of a fixed number of stops (KAN-142)

### DIFF
--- a/e2e/a11y-controls.spec.ts
+++ b/e2e/a11y-controls.spec.ts
@@ -220,34 +220,70 @@ async function selectSession(page: Page): Promise<void> {
     .click({ position: { x: 20, y: 20 } });
 }
 
-// Walks the real tab order from the top of the document and returns the
-// accessible name of each stop. This is the only way to test reachability
-// honestly: `locator.focus()` succeeds on a tabindex=-1 element, so a test
-// that focuses a control directly proves nothing about whether a keyboard
-// user could ever have got there.
-async function tabOrderNames(page: Page, steps: number): Promise<string[]> {
+// A stop, not a distance. It exists so that a focus trap fails the test
+// instead of hanging it, and nothing in this app should come close to it.
+const TAB_WALK_LIMIT = 200;
+
+/**
+ * Walks the real tab order from the top of the document, once all the way
+ * around, and returns the accessible name of each stop.
+ *
+ * This is the only way to test reachability honestly: `locator.focus()`
+ * succeeds on a tabindex=-1 element, so a test that focuses a control directly
+ * proves nothing about whether a keyboard user could ever have got there.
+ *
+ * KAN-142. This used to take a step count, and every caller had to know how
+ * far its control sat from `<body>` -- 12, 20, 25, 30. So KAN-136 adding one
+ * header button pushed `Delete` from step 12 to step 13 and failed a test
+ * about whether a keyboard user can reach it, which they still could: a test
+ * red for the wrong reason, and four more waiting to go the same way. The
+ * distance was never the property any of these tests care about. Presence in
+ * the order is, and the order is a cycle, so it can be walked whole and the
+ * number dropped entirely.
+ *
+ * The loop is detected by ELEMENT rather than by name. A name is not an
+ * identity: a walk whose first stop's name recurs later would end early and
+ * silently return a partial order -- the same class of bug as the magic number
+ * it replaces, and just as invisible, since a partial order still contains
+ * whatever the assertion happens to look for. No walk in this file repeats its
+ * first name today, and swapping this for a name comparison passes the whole
+ * suite, so this is a guard rather than a fix. It costs one evaluate per stop.
+ */
+async function tabOrderNames(page: Page): Promise<string[]> {
   await page.locator('body').press('Tab');
-  const names: string[] = [];
-  for (let i = 0; i < steps; i++) {
-    names.push(
-      await page.evaluate(() => {
-        const el = document.activeElement;
-        if (!el || el === document.body) return '<body>';
-        // Accessible-name precedence, simplified to the three sources this app
-        // actually uses: aria-label, then content, then title. `title` is not
-        // decoration here -- the theme buttons carry no aria-label and no text,
-        // so it is the only name they have.
-        return (
-          el.getAttribute('aria-label') ||
-          el.textContent?.trim() ||
-          el.getAttribute('title') ||
-          '<unnamed>'
-        );
-      })
+  const start = await page.evaluateHandle(() => document.activeElement);
+  try {
+    const names: string[] = [];
+    for (let i = 0; i < TAB_WALK_LIMIT; i++) {
+      names.push(
+        await page.evaluate(() => {
+          const el = document.activeElement;
+          if (!el || el === document.body) return '<body>';
+          // Accessible-name precedence, simplified to the three sources this
+          // app actually uses: aria-label, then content, then title. `title` is
+          // not decoration here -- the theme buttons carry no aria-label and no
+          // text, so it is the only name they have.
+          return (
+            el.getAttribute('aria-label') ||
+            el.textContent?.trim() ||
+            el.getAttribute('title') ||
+            '<unnamed>'
+          );
+        })
+      );
+      await page.keyboard.press('Tab');
+      const focused = await page.evaluateHandle(() => document.activeElement);
+      const looped = await focused.evaluate((el, first) => el === first, start);
+      await focused.dispose();
+      if (looped) return names;
+    }
+    throw new Error(
+      `tab order did not return to its first stop within ${TAB_WALK_LIMIT} ` +
+        `stops -- focus is trapped, or the walk never left <body>`
     );
-    await page.keyboard.press('Tab');
+  } finally {
+    await start.dispose();
   }
-  return names;
 }
 
 /**
@@ -339,7 +375,7 @@ test.describe('controls are reachable by keyboard', () => {
   }) => {
     const page = await openPopup(context, extensionId);
 
-    const names = await tabOrderNames(page, 12);
+    const names = await tabOrderNames(page);
 
     expect(names).toContain('Open');
     expect(names).toContain('Switch');
@@ -359,7 +395,7 @@ test.describe('controls are reachable by keyboard', () => {
       page.getByRole('button', { name: 'Morning reading' })
     ).toBeVisible();
 
-    const names = await tabOrderNames(page, 20);
+    const names = await tabOrderNames(page);
 
     expect(names).toContain('Delete window group');
     expect(names).toContain('Delete tab');
@@ -413,7 +449,7 @@ test.describe('controls are reachable by keyboard', () => {
     const page = await openRatePrompt(context, extensionId);
     await expect(page.getByText(RATE_PROMPT_BODY)).toBeVisible();
 
-    const names = await tabOrderNames(page, 30);
+    const names = await tabOrderNames(page);
 
     expect(names).toContain('Maybe Later');
     expect(names).toContain('Never Remind Again');
@@ -506,7 +542,7 @@ test.describe('controls are reachable by keyboard', () => {
       page.getByRole('button', { name: 'Morning reading' })
     ).toBeVisible();
 
-    const names = await tabOrderNames(page, 20);
+    const names = await tabOrderNames(page);
 
     expect(names).toContain('Rename session: Research');
     // The positive control for that assertion: the pencil in the same row was
@@ -625,7 +661,7 @@ test.describe('controls are reachable by keyboard', () => {
     await page.getByRole('button', { name: 'Settings' }).click();
     await expect(page.getByText('Themes')).toBeVisible();
 
-    const names = await tabOrderNames(page, 25);
+    const names = await tabOrderNames(page);
 
     expect(names.join('|')).toMatch(/Light/);
   });


### PR DESCRIPTION
## What

`npm run test:e2e` has been red on `main` since #232 merged: **63 passed, 1 failed.**

```
e2e/a11y-controls.spec.ts:336
  > session row actions are reachable by Tab (KAN-68)
```

Not an accessibility regression. The test walked a fixed **12** tab stops and asserted `Open`, `Switch` and `Delete` were among them. KAN-136 added the sort trigger at position 2 and pushed everything down one, so `Delete` sits at step 13 — one past the window. A keyboard user reaches it normally.

## The assertion style was the bug

`tabOrderNames(page, steps)` made every caller encode how far its control sat from `<body>`:

```
12  session row actions      20  window and tab actions
30  rate prompt dismissals   20  session title
25  settings buttons
```

Five hard-coded distances, so **any** new focusable control in the header breaks a test about something else. Four more were waiting to go the same way as the first.

The distance is not the property. Presence in the order is — and the tab order is a cycle, so it can be walked whole and the number dropped entirely:

```ts
const names = await tabOrderNames(page);
```

Measured on the home screen, the cycle is 14 stops and closes cleanly:

```
Search · Sort sessions · Undo · Redo · Sync now · Settings · <unnamed>
Save current window · Save all open windows · Research · Open · Switch · Delete · <body>
```

The one constant left, `TAB_WALK_LIMIT = 200`, is a stop rather than a distance: it turns a focus trap into a failure instead of a hang, and nothing in this app comes near it.

## Evidence

`npm run test:e2e` — **64 passed** (was 63 passed, 1 failed).

The proof that matters is the regression itself: I re-added the class of change that caused this — a sixth focusable control in the header — rebuilt, and the suite **stayed green at 64**. Before this change that same control pushed `Delete` to step 14, two past the window.

Mutations:

```
TAB_WALK_LIMIT = 5 (walk cannot reach the end)  → 4 failed  ✓
detect the loop by name instead of by element   → 0 failed  ✗ survived
```

The survivor is reported in the code comment rather than papered over: no walk in this file repeats its first name today, so element identity is a guard against a hazard, not a fix for a live bug. It is kept because a name is not an identity and a partial order still contains whatever the assertion looks for — the failure would be silent, which is the same reason the magic number was worth removing.

## Still undecided: this suite does not run in CI

`build_before_merge.yaml` runs lint, `npm run test`, and `build`. Nothing invokes Playwright. That is why `main` sat red in this suite for a day while every PR showed green — the failure was only ever found by running it by hand.

Left out of this PR deliberately, since it changes what every PR pays for. ~49s locally, plus a Chromium download on the runner.