### PR TITLE
Show the created date only when the sort is by created date (KAN-144)

### DIFF
--- a/src/components/home/leftpane/MenuContainer.tsx
+++ b/src/components/home/leftpane/MenuContainer.tsx
@@ -122,11 +122,24 @@ export default function MenuContainer() {
   // Listed first because it is the default, so the way back sits where the eye
   // starts rather than being hunted for.
   //
-  // The two date items also set which date the ROWS show, so the number on a
-  // row always describes the order the list is in (KAN-141). Name and tab
-  // count deliberately leave it alone: neither is a date order, so there is no
-  // date for them to be right about, and silently flipping the rows back to
-  // "Edited" would undo a choice the user made two clicks ago.
+  // Every item sets which date the ROWS show, so the number on a row always
+  // describes the order the list is in (KAN-141). The rule is one line: the
+  // created date is shown if and only if the sort IS by created date.
+  //
+  // KAN-144 replaced the earlier version, where name and tab count left the
+  // basis alone on the grounds that neither is a date order, so there was no
+  // date for them to be right about. That argues for the DEFAULT, not for
+  // keeping whatever was chosen before: sorting by Date saved and then by Name
+  // left every row reading "Created", including sessions edited since, in a
+  // list no longer in any date order at all. Justine: "the created date in
+  // general for all should be shown only for the sort by created date setting."
+  //
+  // It also removes a special case. The basis is now a function of the active
+  // sort rather than a fourth piece of state that drifts out of step with it.
+  //
+  // A session that has never been edited still reads "Created" whatever this
+  // says -- sessionDateLabel forces both the word and the value for those,
+  // because "Edited" would be a false statement about them.
   const sortItems: OverflowMenuItem[] = [
     {
       key: 'modified',
@@ -155,18 +168,22 @@ export default function MenuContainer() {
       label: t('Name'),
       icon: 'sort_by_alpha',
       checked: false,
-      onSelect: () =>
-        dispatch(sortSessionsInternal({ by: 'name', locale: i18n.language })),
+      onSelect: () => {
+        dispatch(sortSessionsInternal({ by: 'name', locale: i18n.language }));
+        dispatch(setSessionDateBasis('edited'));
+      },
     },
     {
       key: 'tabs',
       label: t('Tab count'),
       icon: 'tab',
       checked: false,
-      onSelect: () =>
+      onSelect: () => {
         dispatch(
           sortSessionsInternal({ by: 'tabCount', locale: i18n.language })
-        ),
+        );
+        dispatch(setSessionDateBasis('edited'));
+      },
     },
   ];
 

--- a/src/tests/components/sessionDateBasis.test.tsx
+++ b/src/tests/components/sessionDateBasis.test.tsx
@@ -2,9 +2,13 @@ import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { fireEvent, screen } from '@testing-library/react';
 
 import MenuContainer from '../../components/home/leftpane/MenuContainer';
+import TabGroupEntryContainer from '../../components/home/leftpane/TabGroupEntryContainer';
 import { renderWithProviders } from '../setup/renderWithProviders';
 import type { RenderWithProvidersResult } from '../setup/renderWithProviders';
-import { saveToTabContainerInternal } from '../../redux/slices/tabContainerDataStateSlice';
+import {
+  restoreContainer,
+  saveToTabContainerInternal,
+} from '../../redux/slices/tabContainerDataStateSlice';
 
 // KAN-141. Which date the rows show follows the date order the user chose, so
 // the number on a row always describes the order the list is in.
@@ -98,30 +102,33 @@ describe('the date basis follows the chosen date order', () => {
     expect(basisOf(store)).toBe('edited');
   });
 
-  // Name and tab count are not date orders, so there is no date for them to be
-  // right about -- and silently flipping the rows back to "Edited" would undo a
-  // choice the user made two clicks ago. Both directions are checked, because
-  // "leaves it alone" is only meaningful if it can be observed not moving from
-  // a non-default value.
-  test('sorting by name leaves the basis alone', async () => {
-    const { store } = await render();
-    openMenu();
-    fireEvent.click(item('Date saved'));
+  // KAN-144. Name and tab count take the DEFAULT basis rather than keeping
+  // whatever was chosen before.
+  //
+  // This reverses KAN-141, which left the basis alone here on the grounds that
+  // neither is a date order, so there is no date for them to be right about.
+  // That argues for the default, not for keeping a stale one: it left every row
+  // reading "Created" after a trip through Date saved, including sessions
+  // edited since, in a list no longer in any date order at all. Justine:
+  // "the created date in general for all should be shown only for the sort by
+  // created date setting."
+  //
+  // Each starts from `created`, because starting from the default cannot tell
+  // "set to edited" apart from "left alone" -- which is exactly the shape of
+  // the old tab-count test, and why only one of the two ever had force.
+  for (const label of ['Name', 'Tab count'] as const) {
+    test(`sorting by ${label} returns the basis to edited`, async () => {
+      const { store } = await render();
+      openMenu();
+      fireEvent.click(item('Date saved'));
+      expect(basisOf(store)).toBe('created');
 
-    openMenu();
-    fireEvent.click(item('Name'));
+      openMenu();
+      fireEvent.click(item(label));
 
-    expect(basisOf(store)).toBe('created');
-  });
-
-  test('sorting by tab count leaves the basis alone', async () => {
-    const { store } = await render();
-
-    openMenu();
-    fireEvent.click(item('Tab count'));
-
-    expect(basisOf(store)).toBe('edited');
-  });
+      expect(basisOf(store)).toBe('edited');
+    });
+  }
 });
 
 // It has to survive the popup closing, or the label would drift away from the
@@ -168,5 +175,78 @@ describe('the basis is remembered on this device', () => {
     const reloaded = await import('../../redux/slices/settingsDataStateSlice');
 
     expect(reloaded.initialState.sessionDateBasis).toBe('edited');
+  });
+});
+
+// KAN-144, asserted where the user actually sees it. The store-level tests
+// above pin the basis; this pins that the basis reaches the row, and that the
+// never-edited fallback is not collateral damage of changing it.
+describe('the word on the row after a non-date sort', () => {
+  // A session with no contentModified at all -- the state legacy data is in,
+  // since every reducer that writes content has stamped it since KAN-141. It
+  // cannot be produced by saving, which stamps it, so the container is handed
+  // over whole the way a merge or an undo hands one over.
+  const renderRows = () =>
+    renderWithProviders(
+      <>
+        <MenuContainer />
+        <TabGroupEntryContainer />
+      </>,
+      {
+        seedStore: (store) => {
+          const edited = { ...session('edited-one', T0), contentModified: T0 };
+          const untouched = session('never-edited', T0 - 3600_000);
+          delete (untouched as { contentModified?: number }).contentModified;
+          store.dispatch(
+            restoreContainer({
+              lastModified: T0,
+              selectedTabGroupId: 'edited-one',
+              tabGroups: [edited, untouched],
+              deletedTabGroups: [],
+            })
+          );
+        },
+      }
+    );
+
+  // The label's own element, found by its whole text rather than by searching
+  // the row's. A row's textContent runs its parts together -- "...1 TabCreated
+  // Sep 9..." -- so there is no word boundary in front of the word and a
+  // /\bCreated\b/ over the row matches nothing at all. Anchoring at ^ on each
+  // descendant also keeps a session TITLED "Edited something" from answering
+  // for the date.
+  const wordOn = (id: string) => {
+    const row = document.querySelector<HTMLElement>(
+      `[data-drag-row-id="${id}"]`
+    );
+    const label = [...(row?.querySelectorAll<HTMLElement>('div') ?? [])]
+      .map((el) => el.textContent ?? '')
+      .find((text) => /^(Edited|Created) /.test(text));
+    return label?.split(' ')[0];
+  };
+
+  test('an edited session reads Edited once the sort is by name', async () => {
+    await renderRows();
+    // The premise: Date saved really does put it in the state being fixed.
+    openMenu();
+    fireEvent.click(item('Date saved'));
+    expect(wordOn('edited-one')).toBe('Created');
+
+    openMenu();
+    fireEvent.click(item('Name'));
+
+    expect(wordOn('edited-one')).toBe('Edited');
+  });
+
+  // THE CONTROL. "Edited" is a false statement about a session that never was,
+  // so this row must keep saying Created through the same sort -- otherwise the
+  // fix would be indistinguishable from hard-coding the word.
+  test('CONTROL: a never-edited session still reads Created', async () => {
+    await renderRows();
+    openMenu();
+    fireEvent.click(item('Name'));
+
+    expect(wordOn('never-edited')).toBe('Created');
+    expect(wordOn('edited-one')).toBe('Edited');
   });
 });


### PR DESCRIPTION
## What

Justine:

> sorting by tab number or name - the entries still show created date even for the ones that are edited. i think the date for those sorts should show edited date since thats the default view unless its not edited. the created date in general for all should be shown only for the sort by created date setting.

Sort by **Date saved**, then by **Name**, and every row still reads `Created …` — including sessions edited since, in a list that is no longer in any date order at all.

`sessionDateBasis` (#235) was set by the two date items and left alone by the other two, so it simply persisted from a date order the user had already left.

## The rule

**The created date is shown if and only if the sort IS by created date.**

| sort | basis |
| --- | --- |
| Date modified | `edited` |
| Date saved | `created` |
| Name | `edited` ← was: whatever was set before |
| Tab count | `edited` ← was: whatever was set before |

This reverses a decision #235 wrote into the comment there:

> Name and tab count deliberately leave it alone: neither is a date order, so there is no date for them to be right about, and silently flipping the rows back to "Edited" would undo a choice the user made two clicks ago.

"There is no date for them to be right about" argues for the **default**, not for keeping a stale one — and the choice it was protecting was a choice about a date order the user has since left. The comment is rewritten, since it documented the opposite.

It also deletes a special case. The basis is now a function of the active sort rather than a fourth piece of state that drifts out of step with it.

## The never-edited fallback is untouched, and is the control

`sessionDateLabel` already forces both the word and the value to `Created` when `contentModified` is undefined, whatever the basis says, because "Edited" would be a false statement about such a session. That covers Justine's "unless its not edited" without any new code.

It is also what makes the new tests mean something: without it, a fix that hard-coded the word would pass. Mutating the fallback away (`showCreated = basis === 'created'`) breaks the control test and nothing else.

Those sessions cannot be produced by saving — `saveToTabContainerInternal` calls `touchContent`, which stamps `contentModified` — so the fixture hands the container over whole through `restoreContainer`, the way a merge or an undo does. This is legacy data, which is exactly who the fallback is for.

## Tests

`sessionDateBasis.test.tsx`, 10 tests. The two that encoded the old rule are replaced; two are new at the store level and two at the rendered row, which is where the report is.

Both new store-level tests start from `created`, because starting from the default cannot tell "set to edited" apart from "left alone" — the shape of the old tab-count test, which is why only one of that pair ever had force.

```
revert the name dispatch                → 2 failed  ✓
revert the tabCount dispatch            → 1 failed  ✓
name sets 'created' instead             → 3 failed  ✓
Date saved also sets 'edited'           → 7 failed  ✓
sessionDateLabel ignores neverEdited    → 1 failed  ✓ (the control)
```

Full suite **1155 passed**, `tsc --noEmit` clean, `eslint` 0 errors.

One probe I got wrong on the way, since it would have read as a broken fix: matching `/\bCreated\b/` on the row's `textContent` finds nothing, because the row's text runs together as `…1 TabCreated Sep 9…` and there is no word boundary in front of the word. The test now reads the label's own element, anchored at `^`.

## Verified in the real popup

Built with `npm run build:e2e`, confirmed the rule reached the bundle, driven offline so nothing synced:

```
Date saved            → basis 'created', every row "Created"
then Name             → basis 'edited',  every row "Edited", list alphabetical
Tab count from created → basis 'edited',  every row "Edited"
```