### PR TITLE
Pin the clock in the "same instant" fixture (KAN-145)

### DIFF
--- a/src/tests/redux/moveSession.test.ts
+++ b/src/tests/redux/moveSession.test.ts
@@ -239,11 +239,30 @@ describe('moveSessionInternal does nothing when there is nothing to do', () => {
 // a rank that sorts ambiguously -- an ambiguous rank means two devices can
 // disagree about the order, which is the one thing the merge must never allow.
 describe('moveSessionInternal when there is no gap to land in', () => {
+  // PINNED, not hoped for -- the same way `seeded` above does it, which this
+  // fixture was simply missing.
+  //
+  // `touchContent` stamps contentModified with Date.now() on every save, so
+  // three unpinned dispatches land on one instant only while the machine is
+  // fast enough to run them inside a single millisecond. On a slower one they
+  // straddle a boundary, the neighbours are no longer equal, rankBetween finds
+  // a midpoint, and renormalise -- the whole point of this describe block -- is
+  // never reached. It failed exactly that way on CI (KAN-145, 2026-09-10)
+  // having passed on every local run, including five in a row.
+  //
+  // The premise is the fixture's name, so it has to be guaranteed by the
+  // fixture rather than by how quickly the test happens to run.
   const seededSameInstant = () => {
     const { store } = makeTestStore();
-    store.dispatch(saveToTabContainerInternal(build('a', T0)));
-    store.dispatch(saveToTabContainerInternal(build('b', T0)));
-    store.dispatch(saveToTabContainerInternal(build('c', T0)));
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(T0);
+      store.dispatch(saveToTabContainerInternal(build('a', T0)));
+      store.dispatch(saveToTabContainerInternal(build('b', T0)));
+      store.dispatch(saveToTabContainerInternal(build('c', T0)));
+    } finally {
+      vi.useRealTimers();
+    }
     store.dispatch(setIsNotDirty());
     return store;
   };


### PR DESCRIPTION
## What

CI went red on #238 in a file that PR does not touch:

```
src/tests/redux/moveSession.test.ts
  > moveSessionInternal when there is no gap to land in
  > a drop between two equal neighbours rebuilds every rank
AssertionError: expected false to be true   (:266)
```

`seededSameInstant()` saved three sessions and relied on them landing in the **same millisecond**:

```ts
store.dispatch(saveToTabContainerInternal(build('a', T0)));
store.dispatch(saveToTabContainerInternal(build('b', T0)));
store.dispatch(saveToTabContainerInternal(build('c', T0)));
```

`T0` only sets `createdAt`. `touchContent` stamps `contentModified` with the **real** `Date.now()` on every save, and `rankOf` reads `rank ?? contentInstant` — so the ordering key is wall-clock time, not `T0`. Three unpinned dispatches share a millisecond only while the machine is fast enough to run them inside one.

On a slower runner they straddle a boundary, the neighbours are no longer equal, `rankBetween` finds a midpoint, and `renormalise` is never reached — so not every session gets a rank and the assertion fails.

## Worse than flaky

On a slow enough machine this test stops exercising the path it exists for **and still passes** most of the time. The describe block's own comment says so:

> THE ONE THAT ACTUALLY REACHES renormalise, and it took a mutation to find out that nothing did.

A fixture that reaches it only by winning a race gives that back.

## The fix

Pin the clock — which the sibling fixture `seeded()` in the same file already does (`:79`). `seededSameInstant` simply missed it. The premise is the fixture's *name*, so it should be guaranteed by the fixture rather than by how fast the test happens to run.

## Evidence

| | result |
| --- | --- |
| unmodified, 5 consecutive local runs | 19 passed each time — the flake does not reproduce by waiting |
| unpinned + each save forced into its own millisecond | **fails the exact CI assertion** |
| pinned + that same forced skew | 19 passed |
| unpinned again + that same skew (control) | fails again |

The forced skew is `vi.spyOn(Date, 'now')` returning `t += 1`, which is what a slower machine does on its own.

## Note

#238 is red on this and only this. It goes green once this merges.

Worth a follow-up sweep for other fixtures whose premise is a timestamp relationship they never pin — this is the same class as the per-save clock pinning added in #235.