### PR TITLE
Run the E2E suite in CI (KAN-146)

### DIFF
--- a/.github/workflows/build_before_merge.yaml
+++ b/.github/workflows/build_before_merge.yaml
@@ -34,5 +34,66 @@ jobs:
       - name: Run tests
         run: npm run test
 
+      # e2e/ sits outside tsconfig's `include` and has its own project file, so
+      # `npm run test` typechecks none of it -- and vitest does not typecheck at
+      # all. Without this a spec can be broken in a way no other step sees.
+      - name: Typecheck E2E specs
+        run: npm run typecheck:e2e
+
+      # `build:e2e`, not `build`: it chains the prune step, so CI now produces
+      # the artifact that actually ships (the release workflow strips remotely
+      # hosted Firebase URLs after building) and the suite below drives that
+      # same pruned bundle rather than one no user ever receives.
+      #
+      # THE ENV BLOCK IS LOAD-BEARING, and its absence is why this step used to
+      # produce a bundle that compiled and could not boot. `.env` is gitignored,
+      # so without SOMETHING here Vite inlines `undefined` for every
+      # Firebase value, `getAuth()` throws `auth/invalid-api-key` during module
+      # init, React never mounts and the popup renders a blank white page.
+      # Nothing caught it because nothing had ever RUN the artifact: vitest
+      # mocks utils/functions/external, and no other step opens the extension.
+      #
+      # THESE ARE DELIBERATELY FAKE, and must stay that way. The real values
+      # live in build_and_release_artifact.yaml's secrets and belong only to
+      # the build that ships; putting them here would expose the production key
+      # to every pull-request run and point the E2E suite's traffic at the real
+      # Firebase project on every push.
+      #
+      # Nothing here needs a working backend. Firebase only throws when the key
+      # is ABSENT -- any syntactically plausible string gets the app past init,
+      # and the suite never asserts on a real sync: "signed in" in these
+      # fixtures is a client uuid in chrome.storage.sync, with no Google account
+      # behind it. Measured: the full 64 pass against exactly these values.
       - name: Generate dist folder
-        run: npm run build
+        run: npm run build:e2e
+        env:
+          VITE_FIREBASE_API_KEY: AIzaSyCI-fake-key-for-e2e-only-000000000
+          VITE_FIREBASE_AUTH_DOMAIN: tab-keeper-e2e.firebaseapp.com
+          VITE_FIREBASE_PROJECT_ID: tab-keeper-e2e
+          VITE_FIREBASE_STORAGE_BUCKET: tab-keeper-e2e.appspot.com
+          VITE_FIREBASE_MESSAGING_SENDER_ID: '000000000000'
+          VITE_FIREBASE_APP_ID: '1:000000000000:web:0000000000000000000000'
+          VITE_FIREBASE_MEASUREMENT_ID: G-0000000000
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      # `playwright test` directly rather than `npm run test:e2e`, which would
+      # repeat the typecheck and the build above. That is safe ONLY because the
+      # step immediately above builds dist and nothing between them touches it
+      # -- run this locally without building first and it silently drives a
+      # stale dist, which is how KAN-142's first bisect went wrong.
+      - name: Run E2E tests
+        run: npx playwright test
+
+      # trace: 'retain-on-failure' produces nothing anyone can open unless the
+      # traces leave the runner.
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,13 +9,28 @@ export default defineConfig({
   // reach each other's specs.
   testDir: 'e2e',
 
+  // A hang must fail the job, not sit on it. Without this a fixture that never
+  // resolves burns the runner's whole budget: the first CI attempt at KAN-146
+  // sat in `Run E2E tests` for 13m51s printing nothing, which is 64 tests each
+  // waiting out the default 30s timeout one at a time.
+  globalTimeout: 12 * 60_000,
+
+  // `list`, explicitly. Playwright defaults to `dot` when CI is set, and dot
+  // writes no newline per test -- so a stuck run and a progressing one look
+  // identical in a GitHub Actions log. That is exactly how the 13m51s hang
+  // read as "still running".
+  reporter: 'list',
+
   // Every spec launches its own browser with the extension loaded. Serial
   // keeps those launches from fighting over profile directories.
   workers: 1,
   fullyParallel: false,
 
-  // This harness is invoked by hand, never by CI, so a retry would only hide a
-  // flake from the person watching it happen.
+  // Still zero now that CI runs this (KAN-146), and deliberately so. A retry
+  // turns a flake into a pass, and this repo has just paid for what a hidden
+  // flake costs: KAN-145 was a fixture racing the clock, green on every local
+  // run, red on a slower runner, and the only reason it was ever diagnosed is
+  // that it failed loudly. Green-on-retry would have buried it.
   retries: 0,
 
   // The trace is the point: it replaces the manual chrome-devtools MCP loop


### PR DESCRIPTION
## What

`npm run test:e2e` only ran when someone remembered to run it, which is why `main` sat red in it for a day after #232 while every PR showed green. This wires it into `build_before_merge`.

**Stacked on #237** — the suite is only green with that tab-order fix, so this branch carries it. Merge #237 first and this rebases to the workflow + config diff alone.

## Wiring it up found something bigger

`build_before_merge` **has never supplied the Firebase env vars**, so its `npm run build` produced a bundle that **compiles and cannot boot**. `.env` is gitignored, Vite inlines `undefined` for every value, `getAuth()` throws `auth/invalid-api-key` during module init, React never mounts, and the popup is a blank white page.

Nothing caught it because nothing had ever *run* the artifact — vitest mocks `utils/functions/external`, and no other step opens the extension. `build_and_release_artifact.yaml` has always had these values; this workflow was simply never given them.

That is how the first attempt at this PR presented: `Run E2E tests` sat for **13m51s** printing nothing past `Running 64 tests using 1 worker`. The failure artifacts this PR adds are what diagnosed it — a blank screenshot, and in the trace:

```
PAGEERROR  Firebase: Error (auth/invalid-api-key)
```

Reproduced locally, with a control:

| | result |
| --- | --- |
| `.env` moved aside, rebuild | blank page, `0 elements` — identical to CI |
| `.env` restored, rebuild | 27 passed |

## The values are fake, deliberately

They must stay that way. The real ones are release secrets and belong to the build that ships — putting them here would expose the production key to every pull-request run and aim E2E traffic at the real Firebase project on every push.

Nothing in the suite needs a backend. Firebase only throws when the key is **absent**; any syntactically plausible string gets the app past init, and "signed in" in these fixtures is a client uuid in `chrome.storage.sync` with no Google account behind it.

**Measured: all 64 pass against exactly the values in this diff.**

## Also in this diff

- **`typecheck:e2e` runs.** `e2e/` sits outside `tsconfig`'s `include` and vitest does not typecheck, so nothing in CI had ever looked at those specs.
- **`build:e2e` replaces `build`.** CI now produces the **pruned** artifact that actually ships, and the suite drives that same bundle. Worth having on its own.
- **Traces upload on failure.** `trace: 'retain-on-failure'` produces nothing anyone can open unless they leave the runner — and they are what solved this.

In `playwright.config.ts`, both learned from the hang:

- **`globalTimeout`**, so a hang fails the job instead of sitting on it.
- **`reporter: 'list'`** explicitly. Playwright defaults to `dot` when `CI` is set, which writes no newline per test — so a stuck run and a progressing one look identical in an Actions log. That is exactly why 13m51s of nothing read as "still running".

`retries` stays **0**, and the comment justifying it is rewritten — it claimed this harness is never run by CI. #239 is the argument for keeping it there: a flake green on every local run, red on a slower runner, diagnosable only because it failed loudly.

## Cost

The Chromium download was **21s** on the runner. No caching added — worth reading a real number or two before deciding it needs any.