### PR TITLE
Ask for a review after the extension has paid off (KAN-149)

### DIFF
--- a/e2e/a11y-controls.spec.ts
+++ b/e2e/a11y-controls.spec.ts
@@ -44,19 +44,23 @@ async function openPopup(
 
 const RATE_PROMPT_BODY = 'Please consider helping me out with a good review!';
 
-// The rate-and-review prompt is gated entirely on localStorage (App.tsx:137):
-// installed more than a day ago, never rated, never opted out, and not asked
-// in the last three days. Seeding those opens it on the first render.
+// The rate-and-review prompt is gated entirely on localStorage: never rated,
+// never opted out, not asked in the last three days, and -- since KAN-149 --
+// something of VALUE has happened. Seeding those opens it on the first render.
 //
-// `extensionInstalledTime` is a NUMBER of milliseconds, not a date string --
-// see seedSettings, where getting that wrong fails silently as a modal that
-// never appears.
+// `lastValueMomentTime` is the one that does the work now. The install date
+// used to open this prompt and no longer does, so seeding only that gets a
+// modal that never appears.
+//
+// Both are NUMBERS of milliseconds, not date strings -- see seedSettings, where
+// getting that wrong fails the same silent way.
 async function openRatePrompt(
   context: BrowserContext,
   extensionId: string
 ): Promise<Page> {
   await seedSettings(context, {
     extensionInstalledTime: Date.now() - 2 * 24 * 60 * 60 * 1000,
+    lastValueMomentTime: Date.now() - 60 * 60 * 1000,
     // Reveals the second dismissal, which is earned rather than offered.
     isSkippedUserReviewOnce: true,
   });

--- a/e2e/i18n-layout.spec.ts
+++ b/e2e/i18n-layout.spec.ts
@@ -95,12 +95,13 @@ async function openPopupIn(
 }
 
 /**
- * Opens the rate-and-review prompt, which is gated entirely on localStorage
- * (`App.tsx`): installed more than a day ago, never rated, never opted out.
+ * Opens the rate-and-review prompt, which is gated entirely on localStorage:
+ * never rated, never opted out, and -- since KAN-149 -- something of VALUE has
+ * happened. The install date used to be what opened it and no longer is.
  *
- * `extensionInstalledTime` is a NUMBER of milliseconds -- `isValidDate`
- * (`local.ts:12`) only accepts `typeof param === 'number'`, so a plausible ISO
- * string reads as "never installed" and the modal silently never opens.
+ * `lastValueMomentTime` is a NUMBER of milliseconds, like the install date
+ * beside it: a plausible ISO string reads as "no such moment" and the modal
+ * silently never opens.
  */
 async function openRatePromptIn(
   context: BrowserContext,
@@ -110,6 +111,7 @@ async function openRatePromptIn(
   await seedSettings(context, {
     language: lang,
     extensionInstalledTime: Date.now() - 2 * 24 * 60 * 60 * 1000,
+    lastValueMomentTime: Date.now() - 60 * 60 * 1000,
     // Reveals the second dismissal, so the card is at its tallest.
     isSkippedUserReviewOnce: true,
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ import {
   isValidTabMasterContainer,
   loadFromLocalStorage,
 } from './utils/functions/local';
+import { shouldAskForReview } from './utils/functions/reviewAsk';
 
 function App() {
   const COLORS = useThemeColors();
@@ -135,45 +136,21 @@ function App() {
   // guarantee of having seen settle. Handing the decision over as a value
   // makes the coordination explicit instead of an accident of dispatch order.
   function askUserToRateAndReview(): boolean {
-    // load from localstorage to check if user has already rated and reviewed
-    const {
-      extensionInstalledTime = '',
-      isUserRatedAndReviewed = false,
-      isNeverAskAgainToRate = false,
-      lastReviewRequestTime = '',
-    } = asPartialSettings<SettingsData>(loadFromLocalStorage('settingsData'));
+    const settings = asPartialSettings<SettingsData>(
+      loadFromLocalStorage('settingsData')
+    );
 
-    // if user has already rated and reviewed, then don't ask again
-    if (isUserRatedAndReviewed || isNeverAskAgainToRate) {
-      return false;
-    }
-
-    // if user is first time user, then wait till he/she uses the extension for a day
-    if (!isValidDate(extensionInstalledTime)) {
+    // KAN-149. The install date is still recorded, because a fresh install has
+    // nothing else to stamp and other things may want it -- but it is no longer
+    // what opens the prompt. See shouldAskForReview: a value moment is.
+    if (!isValidDate(settings.extensionInstalledTime ?? '')) {
       dispatch(setExtensionInstalledTime());
-      return false;
     }
-    const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
-    const currentTimeInMs = new Date().getTime();
-    const extensionInstalledTimeInMs = new Date(
-      extensionInstalledTime
-    ).getTime();
-    if (currentTimeInMs - extensionInstalledTimeInMs < ONE_DAY_IN_MS) {
+
+    if (!shouldAskForReview(settings, Date.now())) {
       return false;
     }
 
-    // if user has already been asked to rate and review, then wait for 3 days to ask again
-    if (isValidDate(lastReviewRequestTime)) {
-      const lastReviewRequestTimeInMs = new Date(
-        lastReviewRequestTime
-      ).getTime();
-      const THREE_DAYS_IN_MS = 3 * ONE_DAY_IN_MS;
-      if (currentTimeInMs - lastReviewRequestTimeInMs < THREE_DAYS_IN_MS) {
-        return false;
-      }
-    }
-
-    // It's to ask the user to rate and review!
     dispatch(openRateAndReviewModal());
     return true;
   }

--- a/src/components/settings/rightpane/SettingsDetailsContainer.tsx
+++ b/src/components/settings/rightpane/SettingsDetailsContainer.tsx
@@ -26,6 +26,7 @@ import {
   Theme,
   setLanguage,
   setTheme,
+  setUserRatedAndReviewed,
   toggleAutoSync,
   toggleLazyLoad,
 } from '../../../redux/slices/settingsDataStateSlice';
@@ -854,7 +855,20 @@ const SettingsDetailsContainer: React.FC = () => {
         <Button
           text={t('Rate this app')}
           iconType="thumb_up"
-          onClick={() => window.open(APP_CHROME_WEBSTORE_LINK + '/reviews')}
+          onClick={() => {
+            window.open(APP_CHROME_WEBSTORE_LINK + '/reviews');
+            // KAN-149. The modal's own CTA has always recorded this; this
+            // button never did, so someone who rated from here kept being
+            // asked by the modal afterwards.
+            //
+            // It records INTENT, not a confirmed review -- the store tells us
+            // nothing about what the user does once they arrive, so a click is
+            // the only evidence available. Someone who clicks and then does not
+            // review is never asked again, which is the right way round: the
+            // cost of asking someone who already went is worse than the cost of
+            // missing a review we were never owed.
+            dispatch(setUserRatedAndReviewed());
+          }}
           style="width: 100%;
               max-width: 250px; justify-content: center; margin-top: 40px;"
         />

--- a/src/redux/slices/globalStateSlice.ts
+++ b/src/redux/slices/globalStateSlice.ts
@@ -20,6 +20,7 @@ import {
 } from '../../utils/functions/local';
 import { mergeTabContainers } from '../../utils/functions/mergeTabData';
 import { TOAST_MESSAGES } from '../../utils/constants/common';
+import { recordValueMoment } from './settingsDataStateSlice';
 
 export interface Global {
   hasSyncedBefore: boolean;
@@ -252,6 +253,21 @@ export const syncStateWithFirestore = createAsyncThunk(
         thunkAPI.dispatch(
           showToast({ toastText: TOAST_MESSAGES.SYNC_MERGED, duration: 3000 })
         );
+
+        // KAN-149. A value moment, but only when a SESSION arrived.
+        //
+        // `changedFromLocal` is deliberately not the test: it is also true for
+        // a tombstone propagating, a rank settling, or a timestamp moving --
+        // none of which the user can see, let alone be pleased by. "A session I
+        // saved elsewhere is now here" is the one that demonstrates sync works,
+        // and it is the only one worth spending a prompt on.
+        const localIds = new Set(
+          tabDataFromLocalStorage.tabGroups.map((group) => group.tabGroupId)
+        );
+        const arrived = merged.tabGroups.some(
+          (group) => !localIds.has(group.tabGroupId)
+        );
+        if (arrived) thunkAPI.dispatch(recordValueMoment());
       }
 
       if (!state.globalState.hasSyncedBefore) {

--- a/src/redux/slices/settingsDataStateSlice.ts
+++ b/src/redux/slices/settingsDataStateSlice.ts
@@ -37,6 +37,17 @@ export interface SettingsData {
   isUserRatedAndReviewed: boolean;
   isNeverAskAgainToRate: boolean;
   lastReviewRequestTime: number | '';
+  /**
+   * When the extension last visibly paid off for this user -- a session
+   * restored, a substantial save, sessions arriving from another device
+   * (KAN-149). It is what the review prompt waits for, in place of the install
+   * date it used to wait on.
+   *
+   * DEVICE-LOCAL, like everything else here: saveToFirestore sends
+   * tabContainerData and nothing else, so this needs no merge rule and cannot
+   * make one device's payoff into another device's prompt.
+   */
+  lastValueMomentTime: number | '';
   // KAN-74. The tab-groups permission offer. Two flags and no timestamp: the
   // offer fires on every popup open that finds groups open, so there is
   // nothing to schedule -- only an escalating opt-out to remember.
@@ -87,6 +98,7 @@ const defaultSettings: SettingsData = {
   isUserRatedAndReviewed: false,
   isNeverAskAgainToRate: false,
   lastReviewRequestTime: '',
+  lastValueMomentTime: '',
   isTabGroupsPromptAnsweredOnce: false,
   isNeverAskAgainForTabGroups: false,
   sessionDateBasis: 'edited',
@@ -157,6 +169,20 @@ export const settingsDataStateSlice = createSlice({
       saveToLocalStorage('settingsData', state);
     },
 
+    /**
+     * Record that the extension just did something worth being asked about.
+     *
+     * Deliberately last-write-wins on a single timestamp rather than a count:
+     * the prompt only ever asks "has anything happened since I last asked",
+     * so a tally would be state nothing reads.
+     */
+    recordValueMoment: (state) => {
+      state.lastValueMomentTime = Date.now();
+
+      // Save updated state to localStorage
+      saveToLocalStorage('settingsData', state);
+    },
+
     updateLastReviewRequestTime: (state) => {
       state.lastReviewRequestTime = Date.now();
 
@@ -204,6 +230,7 @@ export const {
   setSkippedUserReviewOnce,
   setExtensionInstalledTime,
   updateLastReviewRequestTime,
+  recordValueMoment,
   setTabGroupsPromptAnsweredOnce,
   setNeverAskAgainForTabGroups,
   setSessionDateBasis,

--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -37,7 +37,7 @@ import {
   DEFAULT_WINDOW_WIDTH,
   TOAST_MESSAGES,
 } from '../../utils/constants/common';
-import { SettingsData } from './settingsDataStateSlice';
+import { recordValueMoment, SettingsData } from './settingsDataStateSlice';
 import {
   TAB_GROUP_COLORS,
   type TabGroupColor,
@@ -333,6 +333,12 @@ export const openTabsInAWindow = createAsyncThunk(
       isLazyLoad: settingsDataState.isLazyLoad,
       closeOtherWindows: false,
     };
+    // KAN-149. The last instant the popup can record anything: sendMessage
+    // hands the restore to the worker, which creates focused windows, which
+    // closes this popup. Recording the INTENT rather than the confirmed
+    // restore is therefore not a shortcut -- there is no later moment, and the
+    // worker has no localStorage to write to.
+    thunkAPI.dispatch(recordValueMoment());
     chrome.runtime.sendMessage(request);
   }
 );
@@ -365,6 +371,9 @@ export const openAllTabContainer = createAsyncThunk(
       isLazyLoad: settingsDataState.isLazyLoad,
       closeOtherWindows: false,
     };
+    // KAN-149. Recorded here for the reason spelled out in openTabsInAWindow:
+    // this is the last instant the popup exists.
+    thunkAPI.dispatch(recordValueMoment());
     chrome.runtime.sendMessage(request);
   }
 );
@@ -487,6 +496,9 @@ export const focusTabContainer = createAsyncThunk(
       closeOtherWindows: true,
     };
 
+    // KAN-149. Recorded here for the reason spelled out in openTabsInAWindow:
+    // this is the last instant the popup exists.
+    thunkAPI.dispatch(recordValueMoment());
     chrome.runtime.sendMessage(request);
   }
 );
@@ -498,6 +510,12 @@ export interface saveToTabContainerParams {
 
 // save to tab container and display a toast message
 //
+// What counts as a save big enough to be worth being asked about (KAN-149).
+// Ten is a judgement, not a measurement: it is comfortably more than the
+// two-or-three-tab save that is routine, and comfortably less than the
+// session-full-of-research the feature exists for.
+export const VALUE_MOMENT_MIN_TABS = 10;
+
 // The scope is carried here only to name the action in the toast. It is not
 // re-derived from the captured data: a one-window 'all-windows' save is a real
 // case (the user has one window open), and reporting it as "current window
@@ -506,6 +524,17 @@ export const saveToTabContainer = createAsyncThunk(
   'global/saveToTabContainer',
   async (params: saveToTabContainerParams, thunkAPI) => {
     thunkAPI.dispatch(saveToTabContainerInternal(params.container));
+
+    // KAN-149. A SUBSTANTIAL save only. Every save is a save, but banking one
+    // stray tab is not the moment the extension has visibly earned anything,
+    // and counting it would make the prompt fire on ordinary housekeeping --
+    // which is the nagging this ticket exists to avoid.
+    //
+    // Counted on tabs rather than windows: one window of thirty tabs is the
+    // case the product is for, and it would score 1 on any window count.
+    if (params.container.tabCount >= VALUE_MOMENT_MIN_TABS) {
+      thunkAPI.dispatch(recordValueMoment());
+    }
 
     thunkAPI.dispatch(
       showToast({

--- a/src/tests/components/modalCoordination.test.tsx
+++ b/src/tests/components/modalCoordination.test.tsx
@@ -35,10 +35,17 @@ const twoGroupsUngranted = {
 // argument -- a hardcoded `false` would satisfy every other test in the suite.
 describe('modal coordination on popup open', () => {
   test('the rate request wins, and the tab-groups offer stands down', async () => {
-    // Installed two days ago, never rated, never asked -> the rate modal fires.
+    // A session restored an hour ago, never rated, never asked -> the rate
+    // modal fires. KAN-149: the install date used to be what opened it, and no
+    // longer is -- a value moment is. The install age stays in the fixture
+    // because it is part of a realistic settings blob, not because it decides
+    // anything.
     localStorage.setItem(
       'settingsData',
-      JSON.stringify({ extensionInstalledTime: Date.now() - 2 * DAY })
+      JSON.stringify({
+        extensionInstalledTime: Date.now() - 2 * DAY,
+        lastValueMomentTime: Date.now() - 60 * 60 * 1000,
+      })
     );
 
     const { store } = await renderWithProviders(<App />, {
@@ -53,7 +60,7 @@ describe('modal coordination on popup open', () => {
     expect(store.getState().globalState.tabGroupsPromptCount).toBeNull();
   });
 
-  // The control. Same seed, same install age -- only the rate modal is taken
+  // The control. Same seed, same value moment -- only the rate modal is taken
   // out of the running. Without this, the test above passes just as well
   // against an App that never opens the tab-groups offer at all.
   test('with the rate request silenced, the tab-groups offer opens', async () => {
@@ -61,6 +68,7 @@ describe('modal coordination on popup open', () => {
       'settingsData',
       JSON.stringify({
         extensionInstalledTime: Date.now() - 2 * DAY,
+        lastValueMomentTime: Date.now() - 60 * 60 * 1000,
         isNeverAskAgainToRate: true,
       })
     );

--- a/src/tests/components/rateFromAbout.test.tsx
+++ b/src/tests/components/rateFromAbout.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+
+import SettingsDetailsContainer from '../../components/settings/rightpane/SettingsDetailsContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  SettingsCategory,
+  selectCategory,
+} from '../../redux/slices/settingsCategoryStateSlice';
+import { shouldAskForReview } from '../../utils/functions/reviewAsk';
+
+// KAN-149. Rating from the About screen has to stop the prompt, the same way
+// rating from the modal always has.
+//
+// The modal's CTA has dispatched setUserRatedAndReviewed since it shipped; this
+// button only opened the store URL and recorded nothing, so a user who rated
+// here kept being asked by the modal afterwards -- asked to do a thing they had
+// already done, by an app that had watched them do it.
+//
+// It records INTENT, not a confirmed review: the Web Store reports nothing back
+// about what happens once the tab opens, so a click is the only evidence there
+// is. Someone who clicks and never reviews is never asked again, which is the
+// right way round -- pestering someone who already went is worse than missing a
+// review that was never owed.
+
+beforeEach(() => localStorage.clear());
+
+// Restored here rather than at the end of each test. An inline mockRestore is
+// skipped when the assertion above it throws, and vi.spyOn on an
+// already-spied function hands back the SAME mock -- so one failing test made
+// the next one see its predecessor's call and fail for a reason that had
+// nothing to do with the code. Found while mutation-testing this very file.
+afterEach(() => vi.restoreAllMocks());
+
+const spyOnOpen = () => vi.spyOn(window, 'open').mockImplementation(() => null);
+
+const renderAbout = () =>
+  renderWithProviders(<SettingsDetailsContainer />, {
+    seedStore: (store) => {
+      store.dispatch(selectCategory(SettingsCategory.ABOUT));
+    },
+  });
+
+const rateButton = () =>
+  screen.getByRole('button', { name: /Rate this extension/i });
+
+describe('rating from the About screen', () => {
+  test('records that the user has rated', async () => {
+    spyOnOpen();
+    const { store } = await renderAbout();
+    expect(store.getState().settingsDataState.isUserRatedAndReviewed).toBe(
+      false
+    );
+
+    fireEvent.click(rateButton());
+
+    expect(store.getState().settingsDataState.isUserRatedAndReviewed).toBe(
+      true
+    );
+  });
+
+  test('still opens the store reviews page', async () => {
+    const openSpy = spyOnOpen();
+    await renderAbout();
+
+    fireEvent.click(rateButton());
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(String(openSpy.mock.calls[0][0])).toContain(
+      'chromewebstore.google.com'
+    );
+    expect(String(openSpy.mock.calls[0][0])).toContain('/reviews');
+  });
+
+  // The consequence, asserted through the gate rather than the flag, because
+  // the flag is only worth writing if the prompt actually reads it. A value
+  // moment is present, so this would ask were it not for the rating.
+  test('and the review prompt goes quiet afterwards', async () => {
+    spyOnOpen();
+    const { store } = await renderAbout();
+    const now = Date.now();
+
+    // The control: before the click, this user WOULD be asked.
+    expect(
+      shouldAskForReview(
+        { ...store.getState().settingsDataState, lastValueMomentTime: now - 1 },
+        now
+      )
+    ).toBe(true);
+
+    fireEvent.click(rateButton());
+
+    expect(
+      shouldAskForReview(
+        { ...store.getState().settingsDataState, lastValueMomentTime: now - 1 },
+        now
+      )
+    ).toBe(false);
+  });
+});

--- a/src/tests/redux/valueMoment.test.ts
+++ b/src/tests/redux/valueMoment.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+import { makeTestStore } from '../setup/makeStore';
+import {
+  openAllTabContainer,
+  openTabsInAWindow,
+  saveToTabContainer,
+  VALUE_MOMENT_MIN_TABS,
+} from '../../redux/slices/tabContainerDataStateSlice';
+
+// KAN-149. What counts as the extension having visibly paid off.
+//
+// These are the writes the review prompt reads. Each is asserted at the store,
+// because the prompt's own decision (reviewAsk.test.ts) is pure and cannot see
+// whether anything ever calls it -- a trigger that never fires would leave that
+// suite entirely green.
+
+const HOUR = 3600_000;
+const T0 = Date.UTC(2026, 8, 10, 12, 0, 0);
+
+const session = (id: string, tabCount: number) => ({
+  tabGroupId: id,
+  title: id.toUpperCase(),
+  createdTime: '2026-09-10 12:00:00',
+  createdAt: T0,
+  windowCount: 1,
+  tabCount,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: `${id}-w`,
+      windowHeight: 100,
+      windowWidth: 100,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount,
+      title: 'Window',
+      tabs: Array.from({ length: tabCount }, (_, i) => ({
+        tabId: `${id}-t${i}`,
+        favicon: '',
+        title: `Tab ${i}`,
+        url: 'https://a.co',
+      })),
+    },
+  ],
+});
+
+const momentOf = (store: ReturnType<typeof makeTestStore>['store']) =>
+  store.getState().settingsDataState.lastValueMomentTime;
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+  // The restore thunks hand off to the service worker, which does not exist
+  // here. Only the dispatch before it is under test.
+  globalThis.chrome = {
+    ...(globalThis.chrome ?? {}),
+    runtime: { sendMessage: vi.fn() },
+  } as unknown as typeof chrome;
+});
+
+describe('restoring a session is a value moment', () => {
+  test('opening every window records one', async () => {
+    const { store } = makeTestStore();
+    store.dispatch({
+      type: 'tabContainerDataState/saveToTabContainerInternal',
+      payload: session('a', 3),
+    });
+    expect(momentOf(store)).toBe('');
+
+    await store.dispatch(
+      openAllTabContainer({ tabGroupId: 'a', goToURLText: 'Go to URL' })
+    );
+
+    expect(typeof momentOf(store)).toBe('number');
+  });
+
+  test('opening a single window records one', async () => {
+    const { store } = makeTestStore();
+    store.dispatch({
+      type: 'tabContainerDataState/saveToTabContainerInternal',
+      payload: session('a', 3),
+    });
+
+    await store.dispatch(
+      openTabsInAWindow({
+        tabGroupId: 'a',
+        windowId: 'a-w',
+        goToURLText: 'Go to URL',
+      })
+    );
+
+    expect(typeof momentOf(store)).toBe('number');
+  });
+
+  // The guard clause above the dispatch has to hold: a restore of something
+  // that is not there did nothing for the user and must not be spent.
+  test('a restore of a session that does not exist records nothing', async () => {
+    const { store } = makeTestStore();
+
+    await store.dispatch(
+      openAllTabContainer({ tabGroupId: 'missing', goToURLText: 'Go to URL' })
+    );
+
+    expect(momentOf(store)).toBe('');
+  });
+});
+
+describe('a save is a value moment only when it is substantial', () => {
+  test(`a save of ${VALUE_MOMENT_MIN_TABS} tabs records one`, async () => {
+    const { store } = makeTestStore();
+
+    await store.dispatch(
+      saveToTabContainer({
+        container: session('big', VALUE_MOMENT_MIN_TABS),
+        scope: 'all-windows',
+      })
+    );
+
+    expect(typeof momentOf(store)).toBe('number');
+  });
+
+  // THE CONTROL, and the reason the threshold exists at all. Banking a couple
+  // of tabs is housekeeping; if it counted, the prompt would ride on ordinary
+  // use and become the nagging this ticket set out to avoid.
+  test('a small save records nothing', async () => {
+    const { store } = makeTestStore();
+
+    await store.dispatch(
+      saveToTabContainer({
+        container: session('small', VALUE_MOMENT_MIN_TABS - 1),
+        scope: 'current-window',
+      })
+    );
+
+    expect(momentOf(store)).toBe('');
+  });
+});
+
+describe('the recorded moment', () => {
+  test('is written to localStorage, since the popup is about to close', async () => {
+    const { store } = makeTestStore();
+    store.dispatch({
+      type: 'tabContainerDataState/saveToTabContainerInternal',
+      payload: session('a', 3),
+    });
+
+    await store.dispatch(
+      openAllTabContainer({ tabGroupId: 'a', goToURLText: 'Go to URL' })
+    );
+
+    const stored = JSON.parse(localStorage.getItem('settingsData') ?? '{}');
+    expect(typeof stored.lastValueMomentTime).toBe('number');
+    expect(stored.lastValueMomentTime).toBe(momentOf(store));
+  });
+
+  test('moves forward when a newer moment happens', async () => {
+    const { store } = makeTestStore();
+    store.dispatch({
+      type: 'tabContainerDataState/saveToTabContainerInternal',
+      payload: session('a', 3),
+    });
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(T0);
+      await store.dispatch(
+        openAllTabContainer({ tabGroupId: 'a', goToURLText: 'Go to URL' })
+      );
+      const first = momentOf(store);
+
+      vi.setSystemTime(T0 + HOUR);
+      await store.dispatch(
+        openAllTabContainer({ tabGroupId: 'a', goToURLText: 'Go to URL' })
+      );
+
+      expect(momentOf(store)).toBe(T0 + HOUR);
+      expect(momentOf(store)).toBeGreaterThan(first as number);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/tests/utils/functions/reviewAsk.test.ts
+++ b/src/tests/utils/functions/reviewAsk.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+import { shouldAskForReview } from '../../../utils/functions/reviewAsk';
+import type { SettingsData } from '../../../redux/slices/settingsDataStateSlice';
+
+// KAN-149. The review prompt is asked after the user has FELT the value, not
+// after a clock has run down.
+//
+// The old gate was "installed more than a day ago", which asks a stranger: it
+// fires on the first popup open after 24 hours whether the extension has done
+// anything for them or not. Restoring a session is the moment the product
+// actually pays off, so that is the moment worth spending.
+//
+// It is asked on the NEXT open rather than at the moment itself, and that is
+// forced rather than chosen: restoring a session creates focused windows, which
+// CLOSES the popup, so the modal and the payoff can never be on screen
+// together. The trigger records; the next open asks.
+
+const HOUR = 3600_000;
+const NOW = Date.UTC(2026, 8, 10, 12, 0, 0);
+
+const settings = (over: Partial<SettingsData> = {}) =>
+  ({
+    isUserRatedAndReviewed: false,
+    isNeverAskAgainToRate: false,
+    lastReviewRequestTime: '',
+    lastValueMomentTime: NOW - HOUR,
+    ...over,
+  }) as Partial<SettingsData>;
+
+beforeEach(() => localStorage.clear());
+
+describe('asking for a review after a value moment', () => {
+  test('asks when a value moment has happened', () => {
+    expect(shouldAskForReview(settings(), NOW)).toBe(true);
+  });
+
+  // THE POINT OF THE TICKET. Time passing is not a reason to ask; the old gate
+  // would have said yes here on the strength of the install date alone.
+  test('does NOT ask when nothing of value has happened yet', () => {
+    expect(shouldAskForReview(settings({ lastValueMomentTime: '' }), NOW)).toBe(
+      false
+    );
+  });
+
+  test('does not ask once the user has rated', () => {
+    expect(
+      shouldAskForReview(settings({ isUserRatedAndReviewed: true }), NOW)
+    ).toBe(false);
+  });
+
+  test('does not ask once the user has said never again', () => {
+    expect(
+      shouldAskForReview(settings({ isNeverAskAgainToRate: true }), NOW)
+    ).toBe(false);
+  });
+});
+
+describe('the backoff between asks', () => {
+  // Kept from the old gate. A value moment is a reason to ask, not a licence to
+  // ask on every restore -- without this, someone who restores sessions daily
+  // would be asked daily.
+  test('does not ask again within three days of the last ask', () => {
+    expect(
+      shouldAskForReview(
+        settings({ lastReviewRequestTime: NOW - 2 * 24 * HOUR }),
+        NOW
+      )
+    ).toBe(false);
+  });
+
+  test('asks again once three days have passed AND value was felt since', () => {
+    expect(
+      shouldAskForReview(
+        settings({ lastReviewRequestTime: NOW - 4 * 24 * HOUR }),
+        NOW
+      )
+    ).toBe(true);
+  });
+
+  // The two conditions are AND, not OR. Three days of silence is not itself a
+  // reason -- otherwise this decays straight back into the time-based gate the
+  // ticket exists to remove.
+  test('stays silent after three days if no value was felt since', () => {
+    expect(
+      shouldAskForReview(
+        settings({
+          lastReviewRequestTime: NOW - 4 * 24 * HOUR,
+          lastValueMomentTime: NOW - 10 * 24 * HOUR,
+        }),
+        NOW
+      )
+    ).toBe(false);
+  });
+});
+
+describe('malformed stored values', () => {
+  // Settings come from localStorage, which anything can write. A garbage
+  // timestamp must not open the prompt, and must not throw on the popup's
+  // mount path either.
+  test('a non-date value moment is treated as no value moment', () => {
+    expect(
+      shouldAskForReview(
+        settings({ lastValueMomentTime: 'yesterday' as unknown as number }),
+        NOW
+      )
+    ).toBe(false);
+  });
+
+  test('a non-date last-request is treated as never asked', () => {
+    expect(
+      shouldAskForReview(
+        settings({ lastReviewRequestTime: 'soon' as unknown as number }),
+        NOW
+      )
+    ).toBe(true);
+  });
+
+  test('an empty settings object never asks and does not throw', () => {
+    expect(shouldAskForReview({}, NOW)).toBe(false);
+  });
+});

--- a/src/utils/functions/reviewAsk.ts
+++ b/src/utils/functions/reviewAsk.ts
@@ -1,0 +1,76 @@
+import type { SettingsData } from '../../redux/slices/settingsDataStateSlice';
+
+const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
+export const REVIEW_ASK_BACKOFF_MS = 3 * ONE_DAY_IN_MS;
+
+/**
+ * Whether to ask the user to rate the extension on this popup open (KAN-149).
+ *
+ * Extracted from App.tsx and made pure, the way shouldOfferTabGroups already
+ * is: the decision is the part worth testing, and inside a component closure it
+ * could only be reached through a mount.
+ *
+ * WHAT CHANGED, AND WHY. The old gate asked once the extension had been
+ * INSTALLED for a day -- which asks a stranger, since nothing about a date says
+ * the product has done anything for them yet. This asks after a value moment:
+ * a session restored, a substantial save, sessions arriving from another
+ * device. Those are the points where the extension has just visibly paid off.
+ *
+ * The ask lands on the open AFTER the moment, and that is forced rather than
+ * chosen -- restoring a session creates focused windows, which closes the
+ * popup, so the modal and the payoff can never share a screen. Recording the
+ * moment and asking on return is the only shape available. It also asks
+ * someone who came back, which is its own small signal.
+ *
+ * The three-day backoff is kept. A value moment is a reason to ask, not a
+ * licence to ask on every restore.
+ *
+ * `now` is a parameter rather than a Date.now() call so the caller's clock is
+ * the only one in play and the tests need no fake timers.
+ */
+export function shouldAskForReview(
+  settings: Partial<SettingsData>,
+  now: number
+): boolean {
+  const {
+    isUserRatedAndReviewed = false,
+    isNeverAskAgainToRate = false,
+    lastReviewRequestTime = '',
+    lastValueMomentTime = '',
+  } = settings;
+
+  // Both are permanent. "Rated" is set by the modal's own CTA and by the About
+  // screen's Rate button -- neither can confirm a review was actually left, so
+  // both record the INTENT and stop asking. Asking again someone who already
+  // went to the store is the outcome worth avoiding.
+  if (isUserRatedAndReviewed || isNeverAskAgainToRate) return false;
+
+  const valueMomentAt = asTimestamp(lastValueMomentTime);
+  // The whole point: no payoff, no ask. Time alone is never a reason.
+  if (valueMomentAt === null) return false;
+
+  const lastAskedAt = asTimestamp(lastReviewRequestTime);
+  if (lastAskedAt !== null) {
+    if (now - lastAskedAt < REVIEW_ASK_BACKOFF_MS) return false;
+    // AND, not OR. Without this the backoff expiring would itself open the
+    // prompt, which is the time-based gate coming back in through the side
+    // door: the moment has to be NEWER than the last ask, or it is a moment
+    // we have already spent.
+    if (valueMomentAt <= lastAskedAt) return false;
+  }
+
+  return true;
+}
+
+/**
+ * A finite epoch milliseconds value, or null.
+ *
+ * Settings are read back from localStorage, where the value is whatever was
+ * last written -- including by an older build, or by a hand edit. Anything that
+ * is not a usable number reads as "no such moment", which fails closed: the
+ * prompt stays shut rather than opening on a garbage timestamp.
+ */
+function asTimestamp(value: number | ''): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return value;
+}


### PR DESCRIPTION
## What

The prompt opened once the extension had been **installed** for a day. Nothing in that says the product has done anything for the user yet — install it, save nothing, come back tomorrow, get asked.

It now waits for a **value moment**: a session restored, a substantial save, or sessions arriving from another device.

Stacked on **#241** (KAN-148), which is still open.

## The popup dies on a restore, and that shapes everything

Restoring a session creates focused windows, which **closes the popup**. The payoff and the modal can never be on screen together, so "ask at the moment of success" is not available in the literal sense.

What is: the trigger **records**, the next open **asks**. That turns out to be better than a consolation prize — it asks someone who came back, and it doesn't interrupt what they were doing. It also reuses the existing mount-time slot, which already has one-modal-at-a-time coordination with the tab-groups offer.

## The four triggers, all assessed

| trigger | where | popup alive? | shipped |
| --- | --- | --- | --- |
| Restore a session | `openAllTabContainer`, `openTabsInAWindow`, `focusTabContainer` | dies right after | ✅ |
| A substantial save | `saveToTabContainer`, `tabCount >= 10` | yes | ✅ |
| A session arrives from another device | the `changedFromLocal` branch, narrowed | yes | ✅ |
| Nth session saved | would need a new counter | yes | ❌ dropped |

Two decisions worth flagging:

**`requestFocusTabContainer` is not a trigger.** It only opens the confirmation dialog; `focusTabContainer` is where the restore happens. Wiring the former would have recorded a payoff for a dialog the user might cancel.

**The sync trigger is narrowed, not `changedFromLocal` as-is.** That flag is also true for a tombstone propagating, a rank settling, or a timestamp moving — none of which a user can see, let alone be pleased by. It fires only when a session id arrives that wasn't there before.

**Nth-save was dropped** after assessment: a usage count is not a felt moment, and it would need a counter to exist at all.

## The gate

Out of `App.tsx` and into a pure `shouldAskForReview(settings, now)`, mirroring `shouldOfferTabGroups` — inside a component closure it could only be reached through a mount.

Every existing guard is kept. One is new and load-bearing: **the value moment must also be newer than the last ask.** Without it, the three-day backoff expiring would itself open the prompt — the time gate coming straight back in through the side door.

## Rating from About never stopped the prompt

Justine asked for this, and the gap wasn't where it looked. `RateAndReviewModal` has always dispatched `setUserRatedAndReviewed` from its CTA. The **About screen's Rate button never did** — it only opened the store URL, so someone who rated from Settings kept being asked afterwards.

Both record **intent**, not a confirmed review; the Web Store reports nothing back about what happens after the tab opens. Someone who clicks and doesn't review is never asked again — the right way round, since pestering someone who already went is worse than missing a review that was never owed.

## Evidence

24 new tests across three files. **1201 pass**, `tsc` clean, `eslint` 0 errors.

```
save threshold never met            → 1 failed  ✓
every save counts (no threshold)    → 1 failed  ✓
restore records nothing             → 4 failed  ✓
gate ignores the value moment       → 4 failed  ✓
gate drops the 3-day backoff        → 1 failed  ✓
gate drops moment-newer-than-ask    → 1 failed  ✓
gate ignores isUserRatedAndReviewed → 1 failed  ✓
About button records nothing        → 2 failed  ✓
```

Mutation-testing also caught a flaw in my own test file: an inline `mockRestore` is skipped when the assertion above it throws, and `vi.spyOn` on an already-spied function hands back the *same* mock — so one failing test made the next fail for an unrelated reason. Moved to `afterEach`, and the note is in the file.

`modalCoordination.test.tsx` needed its precondition updated — it seeded "installed two days ago" and expected the prompt, which is exactly the premise this removes. Its failure was the change working.

## Verified live, end to end

1. Installed 5 days ago, never rated, **no value moment** → **silent**. Under the old rule this alone opened it.
2. Restore a session → `lastValueMomentTime` written (4s before the check).
3. Reopen the popup → **"Enjoying Tab Keeper?"** appears.
4. Rate from About → flag set. With the backoff cleared and a fresh value moment present — so only that flag can explain it — → **silent**.