### PR TITLE
Boot without a cloud instead of rendering nothing (KAN-147)

### DIFF
--- a/.github/workflows/build_before_merge.yaml
+++ b/.github/workflows/build_before_merge.yaml
@@ -44,36 +44,15 @@ jobs:
       # the artifact that actually ships (the release workflow strips remotely
       # hosted Firebase URLs after building) and the suite below drives that
       # same pruned bundle rather than one no user ever receives.
+      # NO Firebase env, deliberately (KAN-147). It used to need fake values
+      # because an absent config threw during module init and left the popup
+      # blank; the app now boots without a cloud and disables sync instead.
       #
-      # THE ENV BLOCK IS LOAD-BEARING, and its absence is why this step used to
-      # produce a bundle that compiled and could not boot. `.env` is gitignored,
-      # so without SOMETHING here Vite inlines `undefined` for every
-      # Firebase value, `getAuth()` throws `auth/invalid-api-key` during module
-      # init, React never mounts and the popup renders a blank white page.
-      # Nothing caught it because nothing had ever RUN the artifact: vitest
-      # mocks utils/functions/external, and no other step opens the extension.
-      #
-      # THESE ARE DELIBERATELY FAKE, and must stay that way. The real values
-      # live in build_and_release_artifact.yaml's secrets and belong only to
-      # the build that ships; putting them here would expose the production key
-      # to every pull-request run and point the E2E suite's traffic at the real
-      # Firebase project on every push.
-      #
-      # Nothing here needs a working backend. Firebase only throws when the key
-      # is ABSENT -- any syntactically plausible string gets the app past init,
-      # and the suite never asserts on a real sync: "signed in" in these
-      # fixtures is a client uuid in chrome.storage.sync, with no Google account
-      # behind it. Measured: the full 64 pass against exactly these values.
+      # So this step is also the regression test for that: if the crash ever
+      # comes back, the E2E suite below goes red here rather than in a user's
+      # popup. The real values stay where they belong, in the release workflow.
       - name: Generate dist folder
         run: npm run build:e2e
-        env:
-          VITE_FIREBASE_API_KEY: AIzaSyCI-fake-key-for-e2e-only-000000000
-          VITE_FIREBASE_AUTH_DOMAIN: tab-keeper-e2e.firebaseapp.com
-          VITE_FIREBASE_PROJECT_ID: tab-keeper-e2e
-          VITE_FIREBASE_STORAGE_BUCKET: tab-keeper-e2e.appspot.com
-          VITE_FIREBASE_MESSAGING_SENDER_ID: '000000000000'
-          VITE_FIREBASE_APP_ID: '1:000000000000:web:0000000000000000000000'
-          VITE_FIREBASE_MEASUREMENT_ID: G-0000000000
 
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium

--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -27,12 +27,45 @@ const firebaseConfig = {
   measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 };
 
+/**
+ * Whether this build was given a cloud to talk to (KAN-147).
+ *
+ * `.env` is gitignored, so a build made without it inlines `undefined` for
+ * every value above. That used to be fatal rather than degrading: `getAuth()`
+ * validates the key and throws `auth/invalid-api-key` during MODULE INIT, which
+ * took React down with it and left the popup a blank white rectangle with no
+ * message at all. Nothing caught it because nothing had ever run the artifact.
+ *
+ * Cloud sync is optional here -- a signed-out user has a fully working local
+ * extension -- so an absent config disables sync and leaves everything else
+ * working, which is what going offline already does.
+ *
+ * Two fields, not seven: the key is what `getAuth` rejects and the project id
+ * is what Firestore addresses. A build carrying those and missing a
+ * measurement id is misconfigured, but it is not BROKEN, and refusing to start
+ * sync over it would be this bug in a smaller costume.
+ */
+export const isCloudConfigured = Boolean(
+  firebaseConfig.apiKey && firebaseConfig.projectId
+);
+
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
-const auth = getAuth(app);
-const db = getFirestore(app);
+
+// NULL rather than a half-built handle, so the type carries the fact and every
+// call site is made to say what it does without a cloud. A non-null type here
+// would put that back on whoever remembers.
+const auth = isCloudConfigured ? getAuth(app) : null;
+const db = isCloudConfigured ? getFirestore(app) : null;
 
 export { auth, db };
+
+/** Thrown rather than returned: every caller is already inside a try/catch that
+ * turns a failed sync into the `sync_problem` state, so this reuses the path
+ * a network failure takes instead of inventing a second one. */
+export function cloudUnavailable(): Error {
+  return new Error('Firebase is not configured in this build');
+}
 
 // Writes ONLY the Firebase auth flag. It used to write isSignedIn, which the
 // chrome.storage.sync token read also writes - so a local lookup and a network
@@ -40,6 +73,11 @@ export { auth, db };
 // Firestore calls were authorised. The token read always wins that race, so
 // every cold start issued requests the rules then denied (KAN-70).
 export const observeAuthState = (dispatch: AppDispatch) => {
+  // Silence, not setFirebaseUnauthed(): "not signed in" is a claim about an
+  // auth system that exists. With no cloud there is nothing to be signed out
+  // OF, and the flag stays at its initial false either way.
+  if (auth === null) return;
+
   onAuthStateChanged(auth, (user) => {
     if (user) {
       dispatch(setFirebaseAuthed());
@@ -53,6 +91,8 @@ export const observeAuthState = (dispatch: AppDispatch) => {
 };
 
 export const signInUserAnonymously = () => {
+  if (auth === null) return Promise.resolve(undefined);
+
   return signInAnonymously(auth)
     .then((userCredential) => {
       // Signed in successfully
@@ -129,6 +169,8 @@ async function readTabGroups(data: {
 export const fetchDataFromFirestore = async (
   userId: string
 ): Promise<CloudCandidate> => {
+  if (db === null) throw cloudUnavailable();
+
   try {
     // Fetch your data based on the signed-in user's ID
     const tabData = await getDoc(doc(db, 'tabGroupData', userId));

--- a/src/tests/components/firebaseConfigGuard.test.tsx
+++ b/src/tests/components/firebaseConfigGuard.test.tsx
@@ -1,0 +1,109 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { deleteApp, getApps } from 'firebase/app';
+
+// KAN-147. A missing Firebase config must not take the whole app down.
+//
+// `getAuth()` validates the key and throws `auth/invalid-api-key` during MODULE
+// INITIALISATION, so with no config the import itself fails, React never
+// mounts, and the popup is a blank white rectangle with no message. Measured
+// from a Playwright trace: one `pageError`, and a screenshot of nothing.
+//
+// Cloud sync is optional in this product -- a signed-out user has a fully
+// working local extension -- so a config failure should disable sync and leave
+// everything else alone, the way going offline already does.
+//
+// RE-IMPORTED rather than merely re-rendered, and that is the whole point: the
+// config is read once, at module load, to build `firebaseConfig`. Only
+// resetModules plus a fresh import exercises the path that actually breaks.
+
+const CONFIG_KEYS = [
+  'VITE_FIREBASE_API_KEY',
+  'VITE_FIREBASE_AUTH_DOMAIN',
+  'VITE_FIREBASE_PROJECT_ID',
+  'VITE_FIREBASE_STORAGE_BUCKET',
+  'VITE_FIREBASE_MESSAGING_SENDER_ID',
+  'VITE_FIREBASE_APP_ID',
+  'VITE_FIREBASE_MEASUREMENT_ID',
+] as const;
+
+const withConfig = () => {
+  vi.stubEnv('VITE_FIREBASE_API_KEY', 'AIzaSyTestKeyForUnitTests0000000000000');
+  vi.stubEnv('VITE_FIREBASE_AUTH_DOMAIN', 'unit-test.firebaseapp.com');
+  vi.stubEnv('VITE_FIREBASE_PROJECT_ID', 'unit-test');
+  vi.stubEnv('VITE_FIREBASE_STORAGE_BUCKET', 'unit-test.appspot.com');
+  vi.stubEnv('VITE_FIREBASE_MESSAGING_SENDER_ID', '000000000000');
+  vi.stubEnv('VITE_FIREBASE_APP_ID', '1:0:web:0');
+  vi.stubEnv('VITE_FIREBASE_MEASUREMENT_ID', 'G-0');
+};
+
+const withoutConfig = () => {
+  for (const key of CONFIG_KEYS) vi.stubEnv(key, '');
+};
+
+beforeEach(() => vi.resetModules());
+
+// Firebase keeps its app registry in a GLOBAL that vi.resetModules does not
+// touch -- it resets the ES module cache, not the state a dependency has
+// already stashed. So a second initializeApp with different options throws
+// `app/duplicate-app`, and the configured case below could never run after the
+// unconfigured one. Tearing the app down is what makes these independent.
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await Promise.all(getApps().map((app) => deleteApp(app)));
+});
+
+describe('the app with no Firebase config', () => {
+  test('imports without throwing', async () => {
+    withoutConfig();
+
+    // The bug, in one line: this used to reject with auth/invalid-api-key, and
+    // every module importing it went down with it.
+    await expect(import('../../config/firebase')).resolves.toBeDefined();
+  });
+
+  test('reports the cloud as unconfigured and hands back no handles', async () => {
+    withoutConfig();
+
+    const mod = await import('../../config/firebase');
+
+    expect(mod.isCloudConfigured).toBe(false);
+    // Null rather than a half-built handle: the type is what forces every call
+    // site to say what it does without a cloud.
+    expect(mod.auth).toBeNull();
+    expect(mod.db).toBeNull();
+  });
+
+  test('observing auth state does nothing rather than throwing', async () => {
+    withoutConfig();
+    const mod = await import('../../config/firebase');
+    const dispatch = vi.fn();
+
+    expect(() => mod.observeAuthState(dispatch as never)).not.toThrow();
+    // Silence, not a false "unauthed" claim -- there is no auth to be un of.
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  test('a cloud read fails with a named error instead of a crash', async () => {
+    withoutConfig();
+    const mod = await import('../../config/firebase');
+
+    await expect(mod.fetchDataFromFirestore('anyone')).rejects.toThrow(
+      /not configured/i
+    );
+  });
+});
+
+// THE CONTROL. Every assertion above would pass against a module that had
+// simply been broken into inertness, so the configured path has to be shown
+// working in the same file.
+describe('CONTROL: the app with a Firebase config', () => {
+  test('reports the cloud as configured and builds real handles', async () => {
+    withConfig();
+
+    const mod = await import('../../config/firebase');
+
+    expect(mod.isCloudConfigured).toBe(true);
+    expect(mod.auth).not.toBeNull();
+    expect(mod.db).not.toBeNull();
+  });
+});

--- a/src/utils/functions/external.ts
+++ b/src/utils/functions/external.ts
@@ -2,6 +2,7 @@
 // there, since db is created by that module's getFirestore.
 import { doc, setDoc } from 'firebase/firestore/lite';
 import {
+  cloudUnavailable,
   db,
   fetchDataFromFirestore,
   CloudCandidate,
@@ -85,6 +86,11 @@ export async function saveToFirestore(
   userId: string,
   data: TabMasterContainer
 ): Promise<void> {
+  // KAN-147. Thrown, not silently skipped: the caller keeps isDirty set and the
+  // header reports the real state. Returning quietly here would claim a write
+  // that never happened -- the exact failure the catch below exists to prevent.
+  if (db === null) throw cloudUnavailable();
+
   try {
     await setDoc(doc(db, 'tabGroupData', userId), {
       ...stripEmbeddedFavicons(data),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,29 @@ export default defineConfig({
     // project at all: vitest reported success having silently run none of it,
     // so a failing test could not turn CI red. configIncludes.test.ts guards
     // both dimensions.
+    // A configured cloud, for the tests that presuppose one.
+    //
+    // KAN-147 made `isCloudConfigured` read import.meta.env at module load, and
+    // the suites that exercise the Firestore reader mock the SDK but still go
+    // through that gate. Without this they pass on a machine holding a .env and
+    // fail on CI, which is exactly what happened -- 13 tests, green locally,
+    // red on the runner.
+    //
+    // Fake values on purpose: every one of those suites mocks firebase/app,
+    // firebase/auth and firebase/firestore/lite, so nothing here is ever dialled.
+    // It only has to be non-empty, which is what a shipped build always has.
+    // The unconfigured case is not hidden by this -- firebaseConfigGuard.test.tsx
+    // stubs these back to empty and asserts the degraded path directly.
+    env: {
+      VITE_FIREBASE_API_KEY: 'test-api-key',
+      VITE_FIREBASE_AUTH_DOMAIN: 'test.firebaseapp.com',
+      VITE_FIREBASE_PROJECT_ID: 'test-project',
+      VITE_FIREBASE_STORAGE_BUCKET: 'test.appspot.com',
+      VITE_FIREBASE_MESSAGING_SENDER_ID: '0',
+      VITE_FIREBASE_APP_ID: '1:0:web:0',
+      VITE_FIREBASE_MEASUREMENT_ID: 'G-0',
+    },
+
     projects: [
       {
         extends: true,


### PR DESCRIPTION
## What

`getAuth()` validates the key and throws `auth/invalid-api-key` **during module init**, so a build made without `.env` took React down with it: the popup was a blank white rectangle with no message.

Found because that is exactly what CI was producing before #240 — diagnosed from a Playwright trace: one `pageError`, and a screenshot of nothing.

Cloud sync is optional here. A signed-out user has a fully working local extension, so an absent config now disables sync and leaves the rest alone — which is what going offline already does.

## Nullable handles are the design, not a side effect

```ts
export const isCloudConfigured = Boolean(config.apiKey && config.projectId);
const auth = isCloudConfigured ? getAuth(app) : null;
const db   = isCloudConfigured ? getFirestore(app) : null;
```

Making them `null` puts the fact in the type, so the **compiler** made every call site say what it does without a cloud rather than leaving it to my memory. It caught `saveToFirestore`, which I hadn't thought about.

Reads and writes `throw cloudUnavailable()` rather than returning quietly: every caller already sits inside a `try/catch` that turns a failed sync into the `sync_problem` state, so this reuses the path a network failure takes. Returning silently would claim a write that never happened — the exact failure those catches exist to prevent.

Two fields checked, not seven: the key is what `getAuth` rejects, the project id is what Firestore addresses. A build missing only a measurement id is misconfigured but not broken, and refusing to start over it would be this bug in a smaller costume.

## CI drops its fake Firebase values

That's the change that proves the fix. `build_before_merge` needed them **only** because an absent config was fatal (see #240). The build step is now also the regression test: if the crash returns, the E2E suite goes red there rather than in a user's popup.

**Verified by deleting `.env` and running the whole E2E suite against that build: 64 passed.** Before this, that same build rendered nothing at all.

## Tests

5 new, **1206 pass**. They re-import the module under a stubbed env, because the config is read once at module load and only a fresh import exercises the path that breaks — the same reasoning `sessionDateBasis.test.tsx` uses for `initialState`.

The first test reproduces the production error exactly:

```
FirebaseError: Firebase: Error (auth/invalid-api-key)
```

```
unguarded getAuth (the original bug)   → 4 failed  ✓
isCloudConfigured always true          → 4 failed  ✓
observeAuthState drops its guard       → 1 failed  ✓
fetchDataFromFirestore drops its guard → 1 failed  ✓
```

One test-isolation detail worth noting: Firebase keeps its app registry in a **global that `vi.resetModules` does not touch**, so a second `initializeApp` with different options throws `app/duplicate-app` and the configured control could never run after the unconfigured cases. The suite deletes the app between tests.