### PR TITLE
Size a substantial save against the user's own library (KAN-150)

### DIFF
--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -510,11 +510,46 @@ export interface saveToTabContainerParams {
 
 // save to tab container and display a toast message
 //
-// What counts as a save big enough to be worth being asked about (KAN-149).
-// Ten is a judgement, not a measurement: it is comfortably more than the
-// two-or-three-tab save that is routine, and comfortably less than the
-// session-full-of-research the feature exists for.
-export const VALUE_MOMENT_MIN_TABS = 10;
+/**
+ * Whether a save is big enough to be worth being asked about (KAN-149), sized
+ * against THIS user rather than against a number (KAN-150).
+ *
+ * It shipped as `tabCount >= 10`, which was a guess, and measuring it showed
+ * why that is not good enough: across a real library the median save was 8, so
+ * the constant sat above the middle and counted only the top quarter. Nor can
+ * the number be tuned honestly -- the extension carries no analytics by design,
+ * so nobody will ever have the data to justify one.
+ *
+ * "Substantial" only ever meant substantial FOR YOU. Someone whose sessions run
+ * to three tabs feels a nine-tab save; someone who banks forty at a time does
+ * not. Comparing against their own median says exactly that and needs no
+ * constant at all.
+ *
+ * The first save has no history to be larger than, and returns false. That is
+ * right rather than merely convenient: nothing has been demonstrated yet on an
+ * install with one session in it.
+ *
+ * That guard is redundant TODAY and is kept anyway: with no sessions the median
+ * works out to NaN, and every comparison against NaN is false, so the answer
+ * happens to come out the same (verified -- removing it fails nothing). Leaving
+ * it to NaN would make the empty case an accident of IEEE semantics that the
+ * next reader has to derive, rather than a decision this function states.
+ */
+export function isSubstantialSave(
+  tabCount: number,
+  existing: readonly tabContainerData[]
+): boolean {
+  if (existing.length === 0) return false;
+
+  const counts = existing.map((group) => group.tabCount).sort((a, b) => a - b);
+  const middle = Math.floor(counts.length / 2);
+  const median =
+    counts.length % 2 === 0
+      ? (counts[middle - 1] + counts[middle]) / 2
+      : counts[middle];
+
+  return tabCount > median;
+}
 
 // The scope is carried here only to name the action in the toast. It is not
 // re-derived from the captured data: a one-window 'all-windows' save is a real
@@ -523,16 +558,23 @@ export const VALUE_MOMENT_MIN_TABS = 10;
 export const saveToTabContainer = createAsyncThunk(
   'global/saveToTabContainer',
   async (params: saveToTabContainerParams, thunkAPI) => {
+    const existing = (thunkAPI.getState() as RootState).tabContainerDataState
+      .tabGroups;
+
     thunkAPI.dispatch(saveToTabContainerInternal(params.container));
 
-    // KAN-149. A SUBSTANTIAL save only. Every save is a save, but banking one
-    // stray tab is not the moment the extension has visibly earned anything,
-    // and counting it would make the prompt fire on ordinary housekeeping --
-    // which is the nagging this ticket exists to avoid.
+    // KAN-149. A SUBSTANTIAL save only -- banking one stray tab is not a moment
+    // the extension has visibly earned anything, and counting it would put the
+    // prompt on ordinary housekeeping.
+    //
+    // Measured against the sessions ALREADY saved, so read the state before
+    // this save was added: comparing the new session against a list that
+    // includes itself drags the median toward it, and a save can never be
+    // larger than a set it is a member of by the amount it should be.
     //
     // Counted on tabs rather than windows: one window of thirty tabs is the
-    // case the product is for, and it would score 1 on any window count.
-    if (params.container.tabCount >= VALUE_MOMENT_MIN_TABS) {
+    // case the product is for, and would score 1 on any window count.
+    if (isSubstantialSave(params.container.tabCount, existing)) {
       thunkAPI.dispatch(recordValueMoment());
     }
 

--- a/src/tests/redux/valueMoment.test.ts
+++ b/src/tests/redux/valueMoment.test.ts
@@ -17,7 +17,7 @@ import {
   openAllTabContainer,
   openTabsInAWindow,
   saveToTabContainer,
-  VALUE_MOMENT_MIN_TABS,
+  isSubstantialSave,
 } from '../../redux/slices/tabContainerDataStateSlice';
 
 // KAN-149. What counts as the extension having visibly paid off.
@@ -119,34 +119,117 @@ describe('restoring a session is a value moment', () => {
   });
 });
 
-describe('a save is a value moment only when it is substantial', () => {
-  test(`a save of ${VALUE_MOMENT_MIN_TABS} tabs records one`, async () => {
+// KAN-150. Sized against the user's own library rather than a constant.
+const seedSizes = (
+  store: ReturnType<typeof makeTestStore>['store'],
+  sizes: number[]
+) =>
+  sizes.forEach((n, i) =>
+    store.dispatch({
+      type: 'tabContainerDataState/saveToTabContainerInternal',
+      payload: session(`seed${i}`, n),
+    })
+  );
+
+describe('a save is a value moment only when it is substantial for this user', () => {
+  test('a save larger than their median records one', async () => {
     const { store } = makeTestStore();
+    seedSizes(store, [2, 3, 4]); // median 3
+    localStorage.clear();
 
     await store.dispatch(
-      saveToTabContainer({
-        container: session('big', VALUE_MOMENT_MIN_TABS),
-        scope: 'all-windows',
-      })
+      saveToTabContainer({ container: session('big', 5), scope: 'all-windows' })
     );
 
     expect(typeof momentOf(store)).toBe('number');
   });
 
-  // THE CONTROL, and the reason the threshold exists at all. Banking a couple
-  // of tabs is housekeeping; if it counted, the prompt would ride on ordinary
-  // use and become the nagging this ticket set out to avoid.
-  test('a small save records nothing', async () => {
+  // THE CONTROL. The same five-tab save, for someone who saves far more --
+  // proof this is relative rather than a constant wearing a new name. A fixed
+  // threshold could not tell these two cases apart.
+  test('CONTROL: the same save records nothing for a heavier user', async () => {
     const { store } = makeTestStore();
+    seedSizes(store, [30, 40, 50]); // median 40
+
+    await store.dispatch(
+      saveToTabContainer({ container: session('big', 5), scope: 'all-windows' })
+    );
+
+    expect(momentOf(store)).toBe('');
+  });
+
+  test('a save at exactly the median records nothing', async () => {
+    const { store } = makeTestStore();
+    seedSizes(store, [4, 6, 8]); // median 6
 
     await store.dispatch(
       saveToTabContainer({
-        container: session('small', VALUE_MOMENT_MIN_TABS - 1),
-        scope: 'current-window',
+        container: session('same', 6),
+        scope: 'all-windows',
       })
     );
 
     expect(momentOf(store)).toBe('');
+  });
+
+  // The library is read BEFORE the new session joins it, and this is the case
+  // that can tell. Against [1, 10] the median is 5.5 and a six-tab save wins;
+  // once the six is a member, [1, 6, 10] has median 6 and it ties, which loses.
+  // Every other size pairing gives the same answer either way.
+  test('measures against the library as it was before this save', async () => {
+    const { store } = makeTestStore();
+    seedSizes(store, [1, 10]);
+
+    await store.dispatch(
+      saveToTabContainer({ container: session('six', 6), scope: 'all-windows' })
+    );
+
+    expect(typeof momentOf(store)).toBe('number');
+  });
+
+  // Nothing has been demonstrated yet on an install holding one session.
+  test('the very first save records nothing', async () => {
+    const { store } = makeTestStore();
+
+    await store.dispatch(
+      saveToTabContainer({
+        container: session('first', 99),
+        scope: 'all-windows',
+      })
+    );
+
+    expect(momentOf(store)).toBe('');
+  });
+});
+
+describe('isSubstantialSave', () => {
+  const lib = (...sizes: number[]) =>
+    sizes.map((n, i) => session(`s${i}`, n)) as never;
+
+  test('an empty library is never a payoff', () => {
+    expect(isSubstantialSave(100, [])).toBe(false);
+  });
+
+  test('takes the middle of an odd-sized library', () => {
+    expect(isSubstantialSave(6, lib(1, 5, 9))).toBe(true);
+    expect(isSubstantialSave(5, lib(1, 5, 9))).toBe(false);
+  });
+
+  // Averaged, not "the one to the left". With [2,4,6,8] the median is 5, so a
+  // five-tab save is NOT larger -- picking counts[1] would have called it one.
+  test('averages the middle two of an even-sized library', () => {
+    expect(isSubstantialSave(5, lib(2, 4, 6, 8))).toBe(false);
+    expect(isSubstantialSave(6, lib(2, 4, 6, 8))).toBe(true);
+  });
+
+  // The counts are SORTED before the middle is taken. [1, 9, 5] is chosen
+  // deliberately: unsorted, its middle element is 9 and a six-tab save loses;
+  // sorted, the median is 5 and it wins. Comparing [9, 1, 5] against [1, 5, 9]
+  // -- the obvious pair -- cannot see this, because 6 beats the middle of both.
+  test('sorts before taking the middle, whatever order they arrive in', () => {
+    expect(isSubstantialSave(6, lib(1, 9, 5))).toBe(true);
+    expect(isSubstantialSave(6, lib(1, 5, 9))).toBe(true);
+    expect(isSubstantialSave(6, lib(9, 5, 1))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What

`VALUE_MOMENT_MIN_TABS = 10` shipped in #242 as an admitted guess. Justine: *"why guess not verify"*. Fair — and measuring made it worse rather than better.

Across a real library of 8 sessions: **3, 4, 5, 7, 8, 9, 13, 16** tabs, median **8**. The constant sits *above* the median and would count only **2 of 8** saves — exactly the failure mode I flagged when shipping it.

**But that measurement can't fix it either.** Six of those eight sessions were test artifacts from the same day's work. Tuning a constant against n=8 of my own debris is false precision, not verification. And no better data is coming: the extension carries **no analytics by design**, so nobody will ever hold the distribution needed to justify a number here.

## So the number goes

"Substantial" only ever meant substantial **for this user**. Someone whose sessions run to three tabs feels a nine-tab save; someone who banks forty at a time does not.

```
count it when the save is larger than the median of the sessions they already have
```

Self-calibrating, no constant. Measured against the library **before** the new session joins it — including itself drags the median toward the value being judged.

## Mutation testing found three hollow tests

My first pass looked fine and wasn't. Recording these because each is a way a test can be green and worthless:

- **"unaffected by the order they arrive in"** compared `[9,1,5]` with `[1,5,9]`. A six-tab save beats the middle of both, sorted or not — so **removing the sort passed**. `[1,9,5]` discriminates: unsorted its middle is 9 and the save loses; sorted the median is 5 and it wins.
- **The before/after distinction was untested.** Most size pairings answer the same either way. `[1,10]` with a six-tab save is one that doesn't: median 5.5 before, 6 after — wins before, ties after.
- **The empty-library guard survives removal**, and is kept anyway. With no sessions the median works out to `NaN`, and every comparison against `NaN` is false, so the answer coincides. Documented in the code as redundant-but-deliberate rather than left as an accident of IEEE semantics for the next reader to derive.

## Result

14 tests in `valueMoment.test.ts`. 5 mutations run, 4 caught, the fifth documented above. **1208 pass**, tsc clean, lint 0 errors.