### PR TITLE
Say when a sort discards a hand-dragged order (KAN-151)

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "Tab-Anzahl",
   "Date modified": "Änderungsdatum",
   "Edited": "Bearbeitet",
-  "Created": "Erstellt"
+  "Created": "Erstellt",
+  "Sessions reordered. Undo to restore the previous order.": "Sitzungen neu sortiert. Mit \"Rückgängig\" die vorherige Reihenfolge wiederherstellen."
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "Tab count",
   "Date modified": "Date modified",
   "Edited": "Edited",
-  "Created": "Created"
+  "Created": "Created",
+  "Sessions reordered. Undo to restore the previous order.": "Sessions reordered. Undo to restore the previous order."
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "Número de pestañas",
   "Date modified": "Fecha de modificación",
   "Edited": "Editado",
-  "Created": "Creado"
+  "Created": "Creado",
+  "Sessions reordered. Undo to restore the previous order.": "Sesiones reordenadas. Usa \"Deshacer\" para restaurar el orden anterior."
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "Nombre d'onglets",
   "Date modified": "Date de modification",
   "Edited": "Modifié",
-  "Created": "Créé"
+  "Created": "Créé",
+  "Sessions reordered. Undo to restore the previous order.": "Sessions réorganisées. Utilisez « Annuler » pour rétablir l’ordre précédent."
 }

--- a/public/locales/hi/translation.json
+++ b/public/locales/hi/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "टैब संख्या",
   "Date modified": "बदलाव की तारीख",
   "Edited": "संपादित",
-  "Created": "बनाया"
+  "Created": "बनाया",
+  "Sessions reordered. Undo to restore the previous order.": "सत्र पुनः क्रमबद्ध किए गए। पिछला क्रम वापस पाने के लिए \"पूर्ववत\" का उपयोग करें।"
 }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "Numero di schede",
   "Date modified": "Data di modifica",
   "Edited": "Modificato",
-  "Created": "Creato"
+  "Created": "Creato",
+  "Sessions reordered. Undo to restore the previous order.": "Sessioni riordinate. Usa \"Annulla\" per ripristinare l’ordine precedente."
 }

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "タブ数",
   "Date modified": "更新日",
   "Edited": "編集",
-  "Created": "作成"
+  "Created": "作成",
+  "Sessions reordered. Undo to restore the previous order.": "セッションを並べ替えました。「元に戻す」で以前の順序に戻せます。"
 }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "Número de abas",
   "Date modified": "Data de modificação",
   "Edited": "Editado",
-  "Created": "Criado"
+  "Created": "Criado",
+  "Sessions reordered. Undo to restore the previous order.": "Sessões reordenadas. Use \"Desfazer\" para restaurar a ordem anterior."
 }

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "Количество вкладок",
   "Date modified": "Дата изменения",
   "Edited": "Изменено",
-  "Created": "Создано"
+  "Created": "Создано",
+  "Sessions reordered. Undo to restore the previous order.": "Сессии переупорядочены. Нажмите «Отменить», чтобы вернуть прежний порядок."
 }

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "标签页数",
   "Date modified": "修改日期",
   "Edited": "已编辑",
-  "Created": "已创建"
+  "Created": "已创建",
+  "Sessions reordered. Undo to restore the previous order.": "会话已重新排序。使用“撤销”可恢复之前的顺序。"
 }

--- a/src/components/home/leftpane/MenuContainer.tsx
+++ b/src/components/home/leftpane/MenuContainer.tsx
@@ -6,8 +6,8 @@ import Icon from '../../common/Icon';
 import OverflowMenu from '../../common/OverflowMenu';
 import type { OverflowMenuItem } from '../../common/OverflowMenu';
 import {
-  clearSessionOrder,
-  sortSessionsInternal,
+  resetSessionOrder,
+  sortSessions,
 } from '../../../redux/slices/tabContainerDataStateSlice';
 import { AppDispatch, RootState } from '../../../redux/store';
 import {
@@ -147,7 +147,7 @@ export default function MenuContainer() {
       icon: 'history',
       checked: isDefaultOrder,
       onSelect: () => {
-        dispatch(clearSessionOrder());
+        dispatch(resetSessionOrder());
         dispatch(setSessionDateBasis('edited'));
       },
     },
@@ -157,9 +157,7 @@ export default function MenuContainer() {
       icon: 'schedule',
       checked: false,
       onSelect: () => {
-        dispatch(
-          sortSessionsInternal({ by: 'createdAt', locale: i18n.language })
-        );
+        dispatch(sortSessions({ by: 'createdAt', locale: i18n.language }));
         dispatch(setSessionDateBasis('created'));
       },
     },
@@ -169,7 +167,7 @@ export default function MenuContainer() {
       icon: 'sort_by_alpha',
       checked: false,
       onSelect: () => {
-        dispatch(sortSessionsInternal({ by: 'name', locale: i18n.language }));
+        dispatch(sortSessions({ by: 'name', locale: i18n.language }));
         dispatch(setSessionDateBasis('edited'));
       },
     },
@@ -179,9 +177,7 @@ export default function MenuContainer() {
       icon: 'tab',
       checked: false,
       onSelect: () => {
-        dispatch(
-          sortSessionsInternal({ by: 'tabCount', locale: i18n.language })
-        );
+        dispatch(sortSessions({ by: 'tabCount', locale: i18n.language }));
         dispatch(setSessionDateBasis('edited'));
       },
     },

--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -508,6 +508,53 @@ export interface saveToTabContainerParams {
   scope: CaptureScope;
 }
 
+// KAN-151. The two ways the session list gets rearranged, each wrapping its
+// reducer to announce what happened -- the same Internal-reducer-plus-toasting-
+// thunk shape saveToTabContainer uses.
+//
+// The toast fires ONLY when the visible order actually moved. Both reducers
+// return early when there is nothing to do (an already-sorted and already-
+// pinned list; an order with no ranks to clear), and announcing a change that
+// did not happen -- while telling the user to undo it -- is worse than silence.
+//
+// Compared on the rendered id sequence rather than on ranks: a sort can pin an
+// order that already looked right, which writes ranks but moves nothing on
+// screen. Nothing was lost in that case, so there is nothing to offer back.
+const sessionOrder = (state: RootState): string =>
+  state.tabContainerDataState.tabGroups.map((g) => g.tabGroupId).join('\u0000');
+
+function announceIfReordered(
+  thunkAPI: { getState: () => unknown; dispatch: (action: unknown) => unknown },
+  before: string
+): void {
+  if (sessionOrder(thunkAPI.getState() as RootState) === before) return;
+
+  thunkAPI.dispatch(
+    showToast({
+      toastText: TOAST_MESSAGES.SESSION_ORDER_CHANGED,
+      duration: 3000,
+    })
+  );
+}
+
+export const sortSessions = createAsyncThunk(
+  'global/sortSessions',
+  async (params: sortSessionsParams, thunkAPI) => {
+    const before = sessionOrder(thunkAPI.getState() as RootState);
+    thunkAPI.dispatch(sortSessionsInternal(params));
+    announceIfReordered(thunkAPI, before);
+  }
+);
+
+export const resetSessionOrder = createAsyncThunk(
+  'global/resetSessionOrder',
+  async (_: void, thunkAPI) => {
+    const before = sessionOrder(thunkAPI.getState() as RootState);
+    thunkAPI.dispatch(clearSessionOrder());
+    announceIfReordered(thunkAPI, before);
+  }
+);
+
 // save to tab container and display a toast message
 //
 /**

--- a/src/tests/redux/sortToast.test.ts
+++ b/src/tests/redux/sortToast.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+import { makeTestStore } from '../setup/makeStore';
+import {
+  moveSessionInternal,
+  resetSessionOrder,
+  saveToTabContainerInternal,
+  sortSessions,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import { TOAST_MESSAGES } from '../../utils/constants/common';
+
+// KAN-151. Reordering the list says so, and says how to get back.
+//
+// Applying a sort overwrites every rank, so a user who has spent time dragging
+// their sessions into an arrangement loses it in one click. Undo DOES restore
+// it -- verified, sorting goes on the undo stack like any other data change --
+// but nothing on screen says so, and "my arrangement is gone" is not a thought
+// that leads anyone to press undo.
+//
+// So the recovery is announced at the moment it becomes relevant. No new state,
+// no new menu item, and nothing to keep in step with the sort machinery.
+
+const session = (id: string, title: string, tabCount = 1) => ({
+  tabGroupId: id,
+  title,
+  createdTime: '2026-09-10 12:00:00',
+  createdAt: 1,
+  windowCount: 1,
+  tabCount,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: `${id}-w`,
+      windowHeight: 1,
+      windowWidth: 1,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount,
+      title: 'Window',
+      tabs: [
+        { tabId: `${id}-t`, favicon: '', title: 'T', url: 'https://a.co' },
+      ],
+    },
+  ],
+});
+
+type Store = ReturnType<typeof makeTestStore>['store'];
+
+const HOUR = 3600_000;
+const T0 = Date.UTC(2026, 8, 10, 12, 0, 0);
+
+// THE CLOCK IS PINNED, one hour apart per save. Saving stamps contentModified
+// with Date.now(), and that is what orders the list before any rank exists --
+// so unpinned, three saves may land in one millisecond or straddle a boundary
+// depending on how loaded the machine is, and the seeded order changes with it.
+//
+// Found the hard way: this file passed alone and failed in the full suite,
+// which is KAN-145 exactly, in a fixture written the same day that one was
+// fixed. Seeded oldest first, so the list reads newest first.
+const seed = (store: Store, titles: string[]) => {
+  vi.useFakeTimers();
+  try {
+    titles.forEach((t, i) => {
+      vi.setSystemTime(T0 - (titles.length - 1 - i) * HOUR);
+      store.dispatch(saveToTabContainerInternal(session(`g${i}`, t)));
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+};
+
+// showToast is a THUNK, so what the recorder sees is its lifecycle actions,
+// not a bare 'showToast'. Counting the pending one counts each call exactly
+// once -- fulfilled would too, but pending is the one that always fires.
+const toasts = (seen: string[]) =>
+  seen.filter((type) => type === 'global/showToast/pending');
+
+const order = (store: Store) =>
+  store.getState().tabContainerDataState.tabGroups.map((g) => g.title);
+
+beforeEach(() => localStorage.clear());
+
+describe('a sort that rearranges the list announces itself', () => {
+  test('sorting by name toasts', async () => {
+    const { store, seen } = makeTestStore();
+    seed(store, ['Banana', 'Cherry', 'Apple']);
+
+    await store.dispatch(sortSessions({ by: 'name', locale: 'en' }));
+
+    expect(order(store)).toEqual(['Apple', 'Banana', 'Cherry']);
+    expect(toasts(seen)).toHaveLength(1);
+    expect(store.getState().globalState.toastText).toBe(
+      TOAST_MESSAGES.SESSION_ORDER_CHANGED
+    );
+  });
+
+  test('clearing the order back to default toasts', async () => {
+    const { store, seen } = makeTestStore();
+    seed(store, ['Banana', 'Cherry', 'Apple']);
+    await store.dispatch(sortSessions({ by: 'name', locale: 'en' }));
+    const before = seen.length;
+
+    await store.dispatch(resetSessionOrder());
+
+    // Back to recency order, which is NOT name order -- so the list really
+    // moved and the toast really had something to announce.
+    expect(order(store)).toEqual(['Apple', 'Cherry', 'Banana']);
+    expect(toasts(seen.slice(before))).toHaveLength(1);
+  });
+});
+
+// THE HALF THAT KEEPS IT HONEST. A toast that always fires would satisfy every
+// test above and would lie twice a day: both reducers return early when there
+// is nothing to do, and announcing a change that did not happen -- while
+// telling the user to undo it -- is worse than staying quiet.
+describe('a sort that changes nothing stays quiet', () => {
+  test('re-sorting an already-sorted list does not toast', async () => {
+    const { store, seen } = makeTestStore();
+    seed(store, ['Banana', 'Cherry', 'Apple']);
+    await store.dispatch(sortSessions({ by: 'name', locale: 'en' }));
+
+    // The control for the assertion below: the FIRST sort did announce itself,
+    // so a zero count afterwards means this sort stayed quiet rather than that
+    // the toast never worked.
+    expect(toasts(seen)).toHaveLength(1);
+    const before = seen.length;
+
+    // Second identical sort: already in this order AND already pinned, which
+    // is the early return in sortSessionsInternal.
+    await store.dispatch(sortSessions({ by: 'name', locale: 'en' }));
+
+    expect(toasts(seen.slice(before))).toHaveLength(0);
+    expect(order(store)).toEqual(['Apple', 'Banana', 'Cherry']);
+  });
+
+  test('clearing an order that is already default does not toast', async () => {
+    const { store, seen } = makeTestStore();
+    seed(store, ['Banana', 'Cherry', 'Apple']);
+    const before = seen.length;
+
+    // Never sorted, never dragged -- no ranks exist, so there is nothing to
+    // clear and nothing to announce.
+    await store.dispatch(resetSessionOrder());
+
+    expect(toasts(seen.slice(before))).toHaveLength(0);
+  });
+
+  test('an empty list does not toast', async () => {
+    const { store, seen } = makeTestStore();
+
+    await store.dispatch(sortSessions({ by: 'name', locale: 'en' }));
+
+    expect(toasts(seen)).toHaveLength(0);
+  });
+});
+
+describe('the arrangement the toast promises back', () => {
+  // The claim in the message, asserted rather than trusted: the previous order
+  // really is one undo away. If this ever stops being true the toast becomes a
+  // false instruction, which is worse than no toast at all.
+  test('a dragged order survives a sort and one undo', async () => {
+    const { store } = makeTestStore();
+    seed(store, ['Banana', 'Cherry', 'Apple']);
+    store.dispatch(moveSessionInternal({ tabGroupId: 'g0', toIndex: 0 }));
+    const dragged = order(store);
+
+    await store.dispatch(sortSessions({ by: 'name', locale: 'en' }));
+    expect(order(store)).not.toEqual(dragged);
+
+    store.dispatch({ type: 'undoRedo/undo' });
+
+    expect(order(store)).toEqual(dragged);
+  });
+});

--- a/src/utils/constants/common.ts
+++ b/src/utils/constants/common.ts
@@ -81,6 +81,16 @@ export const TOAST_MESSAGES = {
   // saying "saved" would contradict the control the user just pressed.
   ADD_CURR_WINDOW_TO_TABGROUP_SUCCESS: 'Current window added to this session.',
   ADD_CURR_TAB_TO_WINDOW_SUCCESS: 'Current tab added to this window.',
+  // KAN-151. Applying a sort overwrites every rank, so a hand-arranged list is
+  // gone in one click. Undo restores it -- sorting goes on the undo stack like
+  // any other data change -- but nothing said so, and "my arrangement is gone"
+  // is not a thought that leads anyone to press undo.
+  //
+  // The instruction is only worth printing because it is TRUE: a test asserts
+  // the dragged order really does come back with one undo, so this cannot decay
+  // into a false promise without something going red.
+  SESSION_ORDER_CHANGED:
+    'Sessions reordered. Undo to restore the previous order.',
   DELETE_TAB_CONTAINER_SUCCESS: 'Session deleted.',
   DELETE_WINDOW_SUCCESS: 'Session window deleted.',
   DELETE_TAB_SUCCESS: 'Session tab deleted.',


### PR DESCRIPTION
## What

Justine: *"if some user drags and arranges left session rows and later press some sort option, they would lose the custom order they made and cant go back."*

The loss is real — a sort calls `renormalise`, overwriting **every** rank, so a dragged arrangement is gone in one click.

**But "can't go back" turned out to be wrong**, and that changed the fix. Sorting changes session data, so it goes on the undo stack like any other edit (`viewStateOnlyActions` contains only `selectTabContainer`). Verified at store level:

```
CUSTOM : Banana, Cherry, Apple     ← after dragging
SORTED : Apple, Banana, Cherry     ← clicked "Name"
UNDONE : Banana, Cherry, Apple     ← one undo
RECOVERED: true
```

So the gap is **discoverability, not capability**. Nothing said the arrangement could come back, and "my arrangement is gone" isn't a thought that leads anyone to press undo.

## Why not a "Custom order" menu item

That was the first proposal, and it was weighed rather than waved off:

- **It duplicates undo, worse.** Undo restores the exact prior arrangement. A menu item would snapshot ranks at each sort and mean "the order before the last sort" — undo, with a fuzzier promise and new state to sync.
- **It breaks the menu's grammar.** Four items that *arrange the list*, one that *restores a snapshot* — a different verb in the same list, with awkward states (greyed out until you've dragged? present but inert?).
- **"Custom order" isn't a thing the data can report.** A rank from a drag and a rank from a sort are identical — the same constraint that means only "Date modified" can be ticked today. The menu couldn't honestly show whether you're *in* a custom order, which is exactly what users would expect that item to indicate.

## What this does instead

> **Sessions reordered. Undo to restore the previous order.**

`sortSessions` and `resetSessionOrder` wrap the two reducers — the same Internal-reducer-plus-toasting-thunk shape `saveToTabContainer` already uses.

**It fires only when the visible order actually moved.** Both reducers return early when there's nothing to do, and announcing a change that didn't happen — while telling the user to undo it — is worse than silence. Compared on the rendered id sequence rather than on ranks, because a sort can pin an order that already looked right: that writes ranks but moves nothing on screen, so nothing was lost and there's nothing to offer back.

One test asserts **the message's own claim** — that a dragged order really does survive a sort and one undo — so this can't decay into a false instruction without going red.

## Evidence

6 tests. **1219 pass**, 64 e2e pass, tsc clean, lint 0 errors.

```
toast always fires (drop the changed check)  → 3 failed  ✓
toast never fires                            → 3 failed  ✓
sortSessions skips its reducer               → 4 failed  ✓
resetSessionOrder skips its reducer          → 1 failed  ✓
```

Verified live with a MutationObserver recorder — a 3s toast can't be caught by polling after the fact:

```
sort by Name          → "Sessions reordered. Undo to restore the previous order."
sort by Name again    → nothing          ← already sorted and pinned
```

## One thing worth flagging

This test file **passed alone and failed in the full suite** — KAN-145 exactly, in a fixture I wrote the same day I fixed KAN-145. Saving stamps `contentModified` with `Date.now()`, so unpinned, three saves may share a millisecond or straddle a boundary depending on machine load, and the seeded order moves with it. Clock now pinned per save.