### PR TITLE
Scroll the list while dragging near its edge (KAN-152)

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "Tab-Anzahl",
   "Date modified": "Änderungsdatum",
   "Edited": "Bearbeitet",
-  "Created": "Erstellt"
+  "Created": "Erstellt",
+  "Sessions reordered. Undo to restore the previous order.": "Sitzungen neu sortiert. Mit \"Rückgängig\" die vorherige Reihenfolge wiederherstellen."
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "Tab count",
   "Date modified": "Date modified",
   "Edited": "Edited",
-  "Created": "Created"
+  "Created": "Created",
+  "Sessions reordered. Undo to restore the previous order.": "Sessions reordered. Undo to restore the previous order."
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "Número de pestañas",
   "Date modified": "Fecha de modificación",
   "Edited": "Editado",
-  "Created": "Creado"
+  "Created": "Creado",
+  "Sessions reordered. Undo to restore the previous order.": "Sesiones reordenadas. Usa \"Deshacer\" para restaurar el orden anterior."
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "Nombre d'onglets",
   "Date modified": "Date de modification",
   "Edited": "Modifié",
-  "Created": "Créé"
+  "Created": "Créé",
+  "Sessions reordered. Undo to restore the previous order.": "Sessions réorganisées. Utilisez « Annuler » pour rétablir l’ordre précédent."
 }

--- a/public/locales/hi/translation.json
+++ b/public/locales/hi/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "टैब संख्या",
   "Date modified": "बदलाव की तारीख",
   "Edited": "संपादित",
-  "Created": "बनाया"
+  "Created": "बनाया",
+  "Sessions reordered. Undo to restore the previous order.": "सत्र पुनः क्रमबद्ध किए गए। पिछला क्रम वापस पाने के लिए \"पूर्ववत\" का उपयोग करें।"
 }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "Numero di schede",
   "Date modified": "Data di modifica",
   "Edited": "Modificato",
-  "Created": "Creato"
+  "Created": "Creato",
+  "Sessions reordered. Undo to restore the previous order.": "Sessioni riordinate. Usa \"Annulla\" per ripristinare l’ordine precedente."
 }

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "タブ数",
   "Date modified": "更新日",
   "Edited": "編集",
-  "Created": "作成"
+  "Created": "作成",
+  "Sessions reordered. Undo to restore the previous order.": "セッションを並べ替えました。「元に戻す」で以前の順序に戻せます。"
 }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "Número de abas",
   "Date modified": "Data de modificação",
   "Edited": "Editado",
-  "Created": "Criado"
+  "Created": "Criado",
+  "Sessions reordered. Undo to restore the previous order.": "Sessões reordenadas. Use \"Desfazer\" para restaurar a ordem anterior."
 }

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "Количество вкладок",
   "Date modified": "Дата изменения",
   "Edited": "Изменено",
-  "Created": "Создано"
+  "Created": "Создано",
+  "Sessions reordered. Undo to restore the previous order.": "Сессии переупорядочены. Нажмите «Отменить», чтобы вернуть прежний порядок."
 }

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -133,5 +133,6 @@
   "Tab count": "标签页数",
   "Date modified": "修改日期",
   "Edited": "已编辑",
-  "Created": "已创建"
+  "Created": "已创建",
+  "Sessions reordered. Undo to restore the previous order.": "会话已重新排序。使用“撤销”可恢复之前的顺序。"
 }

--- a/src/components/home/leftpane/MenuContainer.tsx
+++ b/src/components/home/leftpane/MenuContainer.tsx
@@ -6,8 +6,8 @@ import Icon from '../../common/Icon';
 import OverflowMenu from '../../common/OverflowMenu';
 import type { OverflowMenuItem } from '../../common/OverflowMenu';
 import {
-  clearSessionOrder,
-  sortSessionsInternal,
+  resetSessionOrder,
+  sortSessions,
 } from '../../../redux/slices/tabContainerDataStateSlice';
 import { AppDispatch, RootState } from '../../../redux/store';
 import {
@@ -147,7 +147,7 @@ export default function MenuContainer() {
       icon: 'history',
       checked: isDefaultOrder,
       onSelect: () => {
-        dispatch(clearSessionOrder());
+        dispatch(resetSessionOrder());
         dispatch(setSessionDateBasis('edited'));
       },
     },
@@ -157,9 +157,7 @@ export default function MenuContainer() {
       icon: 'schedule',
       checked: false,
       onSelect: () => {
-        dispatch(
-          sortSessionsInternal({ by: 'createdAt', locale: i18n.language })
-        );
+        dispatch(sortSessions({ by: 'createdAt', locale: i18n.language }));
         dispatch(setSessionDateBasis('created'));
       },
     },
@@ -169,7 +167,7 @@ export default function MenuContainer() {
       icon: 'sort_by_alpha',
       checked: false,
       onSelect: () => {
-        dispatch(sortSessionsInternal({ by: 'name', locale: i18n.language }));
+        dispatch(sortSessions({ by: 'name', locale: i18n.language }));
         dispatch(setSessionDateBasis('edited'));
       },
     },
@@ -179,9 +177,7 @@ export default function MenuContainer() {
       icon: 'tab',
       checked: false,
       onSelect: () => {
-        dispatch(
-          sortSessionsInternal({ by: 'tabCount', locale: i18n.language })
-        );
+        dispatch(sortSessions({ by: 'tabCount', locale: i18n.language }));
         dispatch(setSessionDateBasis('edited'));
       },
     },

--- a/src/components/home/rightpane/rowDrag/RowDragArea.tsx
+++ b/src/components/home/rightpane/rowDrag/RowDragArea.tsx
@@ -61,6 +61,34 @@ interface Ctx {
 
 const DragContext = React.createContext<Ctx | null>(null);
 
+// How close to an edge the pointer must be for the list to start travelling,
+// and how fast it goes at its deepest. 48px is roughly a row and a half here,
+// which is wide enough to hit without aiming and narrow enough that ordinary
+// dragging near the ends does not trigger it.
+const EDGE_ZONE_PX = 48;
+const MAX_SCROLL_PX_PER_FRAME = 14;
+
+// The nearest ancestor that actually scrolls.
+//
+// Resolved from the ROW rather than from the drag area, because the area is
+// often not the scroller -- the session list scrolls at a container two levels
+// above the rows, and the right pane scrolls above both drag areas it holds.
+// Walking up from the row finds whichever one it happens to be.
+function scrollableAncestor(from: HTMLElement | null): HTMLElement | null {
+  let el: HTMLElement | null = from?.parentElement ?? null;
+  while (el && el !== document.body) {
+    const overflowY = getComputedStyle(el).overflowY;
+    if (
+      (overflowY === 'auto' || overflowY === 'scroll') &&
+      el.scrollHeight > el.clientHeight
+    ) {
+      return el;
+    }
+    el = el.parentElement;
+  }
+  return null;
+}
+
 interface Rect {
   id: string;
   index: number;
@@ -92,7 +120,18 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
     height: number;
     lastX: number;
     lastY: number;
+    // Auto-scroll (KAN-152). The scrolling ancestor, and where it stood when
+    // the rects were measured -- every index comparison is done in the list's
+    // own content space so that scrolling cannot invalidate it.
+    scroller: HTMLElement | null;
+    startScrollTop: number;
+    maxScroll: number;
   } | null>(null);
+
+  // The auto-scroll frame, cancelled on drop. A ref rather than state: it is
+  // never rendered, and re-rendering every frame is the thing this is trying to
+  // avoid making worse.
+  const scrollFrame = useRef(0);
 
   // Chrome synthesizes a `click` after `mouseup`, aimed at whatever the pointer
   // released over -- which is the held row, because it tracks the pointer. Left
@@ -132,6 +171,17 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
         if (!handle || !el?.contains(handle)) return;
       }
 
+      // Resolved HERE, at pointer-down, and not at activation -- because by
+      // activation the held row already carries a transform, and a transform
+      // EXTENDS the scrollable overflow area. Measured in the real popup: while
+      // auto-scrolling, scrollHeight climbed 820 -> 1393 in step with scrollTop,
+      // so a limit read live was a limit that ran away from the pointer as fast
+      // as it approached it. jsdom cannot show this at all -- scrollHeight there
+      // is whatever a test stubs -- so it is pinned by a test that makes the
+      // stub grow.
+      const el = rows.current.get(rowId) ?? null;
+      const scroller = scrollableAncestor(el);
+
       live.current = {
         rowId,
         startX: clientX,
@@ -142,12 +192,103 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
         height: 0,
         lastX: clientX,
         lastY: clientY,
+        scroller,
+        startScrollTop: scroller?.scrollTop ?? 0,
+        maxScroll: scroller
+          ? Math.max(0, scroller.scrollHeight - scroller.clientHeight)
+          : 0,
       };
     },
     [rowIds, handleSelector, disabled]
   );
 
   useEffect(() => {
+    // Everything below works in the list's CONTENT space -- viewport y plus the
+    // scroller's current scrollTop. The rects are measured once (see below) and
+    // auto-scroll moves the list under them, so a viewport comparison would go
+    // stale the instant the list scrolled: rows would appear to drift past the
+    // pointer and the drop would land somewhere the user never pointed.
+    //
+    // With no scrolling ancestor scrollTop is 0 and this is exactly the
+    // arithmetic that was here before.
+    const contentY = (l: NonNullable<typeof live.current>, clientY: number) =>
+      clientY + (l.scroller?.scrollTop ?? 0);
+
+    const update = (l: NonNullable<typeof live.current>) => {
+      const others = l.rects.filter((r) => r.id !== l.rowId);
+      // The count of rows whose midpoint the pointer has passed IS the index
+      // the row lands at, because that count indexes the list with the held
+      // row already lifted out of it.
+      //
+      // Rows of unequal height need no special case: the held row displaces
+      // every row between its old and new slots by ITS OWN height, whatever
+      // theirs are, and the landing index comes from each row's measured
+      // midpoint rather than from any assumed row size.
+      const y = contentY(l, l.lastY);
+      const toIndex = others.filter((r) => y > r.mid).length;
+
+      setDrag({
+        rowId: l.rowId,
+        fromIndex: l.fromIndex,
+        toIndex,
+        // The scroll delta is part of the travel. The held row lives inside the
+        // scroller, so scrolling moves it with the content; without this term
+        // it would slide out from under the pointer by exactly the distance
+        // auto-scroll just travelled.
+        offset:
+          l.lastY - l.startY + (l.scroller?.scrollTop ?? 0) - l.startScrollTop,
+        height: l.height,
+      });
+    };
+
+    // Drag the list along when the pointer is held near its edge, so a target
+    // that is off screen can be reached at all (KAN-152). Speed ramps with how
+    // deep into the edge zone the pointer is, which makes a small correction
+    // near the boundary possible and a long haul quick.
+    const step = (l: NonNullable<typeof live.current>): number => {
+      const box = l.scroller?.getBoundingClientRect();
+      if (!l.scroller || !box) return 0;
+
+      // Capped to a third of the viewport, because a fixed 48px zone at each
+      // end OVERLAPS in a short list -- in a 90px pane the two zones cover 96px,
+      // so every position counts as an edge and the list scrolls no matter where
+      // the pointer is. Found by the control test, which is what a control is
+      // for. A third each leaves a third in the middle that never scrolls.
+      const zone = Math.min(EDGE_ZONE_PX, box.height / 3);
+
+      const intoTop = zone - (l.lastY - box.top);
+      const intoBottom = zone - (box.bottom - l.lastY);
+      const depth = Math.max(intoTop, intoBottom);
+      if (depth <= 0) return 0;
+
+      const speed = Math.min(depth / zone, 1) * MAX_SCROLL_PX_PER_FRAME;
+      return intoTop > intoBottom ? -speed : speed;
+    };
+
+    const autoScroll = () => {
+      const l = live.current;
+      scrollFrame.current = 0;
+      if (!l?.started || !l.scroller) return;
+
+      const delta = step(l);
+      if (delta !== 0) {
+        const before = l.scroller.scrollTop;
+        // Clamped against the limit captured at pointer-down, never a live one:
+        // but depending on that makes correctness a property of the environment
+        // instead of this function -- and the value is read back below to decide
+        // whether to keep going, so an unclamped write would report progress
+        // that never happened.
+        l.scroller.scrollTop = Math.max(
+          0,
+          Math.min(l.maxScroll, before + delta)
+        );
+        // Only keep going while the list is actually moving. At either end it
+        // is not, and a loop that cannot make progress is a spinning frame.
+        if (l.scroller.scrollTop !== before) update(l);
+      }
+      scrollFrame.current = requestAnimationFrame(autoScroll);
+    };
+
     const onMoveEvent = (e: PointerEvent) => {
       const l = live.current;
       if (!l) return;
@@ -166,45 +307,44 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
         // Measured once, at the moment the drag actually starts: reading rects
         // on every move would report positions already displaced by the shifts
         // this drag is applying.
+        //
+        // Stored in content space, so auto-scrolling the list afterwards leaves
+        // them valid rather than silently wrong.
         l.rects = rowIds.map((id, index) => {
           const el = rows.current.get(id);
           const r = el?.getBoundingClientRect();
           return {
             id,
             index,
-            mid: r ? r.top + r.height / 2 : 0,
+            mid: r ? r.top + r.height / 2 + l.startScrollTop : 0,
             height: r?.height ?? 0,
           };
         });
         l.height = l.rects[l.fromIndex]?.height ?? 0;
         l.started = true;
         setDragging(true);
+        if (!scrollFrame.current) {
+          scrollFrame.current = requestAnimationFrame(autoScroll);
+        }
       }
 
-      const others = l.rects.filter((r) => r.id !== l.rowId);
-      // The count of rows whose midpoint the pointer has passed IS the index
-      // the row lands at, because that count indexes the list with the held
-      // row already lifted out of it.
-      //
-      // Rows of unequal height need no special case: the held row displaces
-      // every row between its old and new slots by ITS OWN height, whatever
-      // theirs are, and the landing index comes from each row's measured
-      // midpoint rather than from any assumed row size.
-      const toIndex = others.filter((r) => e.clientY > r.mid).length;
-
-      setDrag({
-        rowId: l.rowId,
-        fromIndex: l.fromIndex,
-        toIndex,
-        offset: e.clientY - l.startY,
-        height: l.height,
-      });
+      update(l);
     };
 
     const finish = (commit: boolean) => {
       const l = live.current;
       live.current = null;
       setDrag(null);
+      // Redundant today and kept anyway: autoScroll already bails when
+      // live.current is null, which this line has just made true, so the loop
+      // would stop on its own (verified -- removing this fails nothing). It
+      // stays because "the drag is over" and "the frame is cancelled" should not
+      // be two facts a reader has to connect, and because one stray frame after
+      // a drop is a cost nobody would think to look for.
+      if (scrollFrame.current) {
+        cancelAnimationFrame(scrollFrame.current);
+        scrollFrame.current = 0;
+      }
       if (!l) return;
       setDragging(false);
       // Below the threshold this was a click, not a drag, and the row's own
@@ -218,9 +358,13 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
 
       // Armed above, checked here: a drop this area refuses is still a drag the
       // user performed, and they did not ask to open the row they were holding.
-      if (commit && isInsideList(l.rects, l.lastY, l.height / 2)) {
+      // Content space, matching how the rects were measured. Using the raw
+      // viewport y here would misjudge both the containment test and the
+      // landing index by however far the list had auto-scrolled.
+      const dropY = l.lastY + (l.scroller?.scrollTop ?? 0);
+      if (commit && isInsideList(l.rects, dropY, l.height / 2)) {
         const others = l.rects.filter((r) => r.id !== l.rowId);
-        const toIndex = others.filter((r) => l.lastY > r.mid).length;
+        const toIndex = others.filter((r) => dropY > r.mid).length;
         const dropTargetId = resolveDrop?.(
           containerRef.current,
           l.lastX,

--- a/src/redux/slices/tabContainerDataStateSlice.ts
+++ b/src/redux/slices/tabContainerDataStateSlice.ts
@@ -508,6 +508,53 @@ export interface saveToTabContainerParams {
   scope: CaptureScope;
 }
 
+// KAN-151. The two ways the session list gets rearranged, each wrapping its
+// reducer to announce what happened -- the same Internal-reducer-plus-toasting-
+// thunk shape saveToTabContainer uses.
+//
+// The toast fires ONLY when the visible order actually moved. Both reducers
+// return early when there is nothing to do (an already-sorted and already-
+// pinned list; an order with no ranks to clear), and announcing a change that
+// did not happen -- while telling the user to undo it -- is worse than silence.
+//
+// Compared on the rendered id sequence rather than on ranks: a sort can pin an
+// order that already looked right, which writes ranks but moves nothing on
+// screen. Nothing was lost in that case, so there is nothing to offer back.
+const sessionOrder = (state: RootState): string =>
+  state.tabContainerDataState.tabGroups.map((g) => g.tabGroupId).join('\u0000');
+
+function announceIfReordered(
+  thunkAPI: { getState: () => unknown; dispatch: (action: unknown) => unknown },
+  before: string
+): void {
+  if (sessionOrder(thunkAPI.getState() as RootState) === before) return;
+
+  thunkAPI.dispatch(
+    showToast({
+      toastText: TOAST_MESSAGES.SESSION_ORDER_CHANGED,
+      duration: 3000,
+    })
+  );
+}
+
+export const sortSessions = createAsyncThunk(
+  'global/sortSessions',
+  async (params: sortSessionsParams, thunkAPI) => {
+    const before = sessionOrder(thunkAPI.getState() as RootState);
+    thunkAPI.dispatch(sortSessionsInternal(params));
+    announceIfReordered(thunkAPI, before);
+  }
+);
+
+export const resetSessionOrder = createAsyncThunk(
+  'global/resetSessionOrder',
+  async (_: void, thunkAPI) => {
+    const before = sessionOrder(thunkAPI.getState() as RootState);
+    thunkAPI.dispatch(clearSessionOrder());
+    announceIfReordered(thunkAPI, before);
+  }
+);
+
 // save to tab container and display a toast message
 //
 /**

--- a/src/tests/components/dragAutoScroll.test.tsx
+++ b/src/tests/components/dragAutoScroll.test.tsx
@@ -1,0 +1,275 @@
+import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import {
+  RowDragArea,
+  DraggableRow,
+} from '../../components/home/rightpane/rowDrag/RowDragArea';
+
+// KAN-152. A drag can reach a target that is off screen.
+//
+// Before this, the list did not move during a drag, so in a session with three
+// windows of twenty tabs the drop target simply could not be reached: the
+// pointer had nowhere to go and the gesture had to be abandoned.
+//
+// THE HARD PART IS NOT THE SCROLLING, IT IS THE ARITHMETIC. The engine measures
+// every row ONCE, at activation, because reading rects on every move would
+// report positions already displaced by the drag's own shifts. Those
+// measurements are viewport-relative, so the moment the list scrolls underneath
+// them they describe where rows USED to be. Every comparison is therefore done
+// in the list's content space -- viewport y plus scrollTop -- which is
+// invariant under scrolling.
+//
+// jsdom has no layout and no scrolling: rects are all zero and scrollTop is an
+// inert stored number. So the rows are given real boxes, the scroller is given
+// real metrics, and what is pinned here is the DECISION -- how far it scrolls
+// and which index it computes -- not any visual result. That a row visibly
+// travels is a real-browser claim and is checked there.
+
+const ROW_H = 30;
+const VIEW_H = 90;
+
+const box = (top: number, height: number) =>
+  ({
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 200,
+    height,
+    width: 200,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+const Harness = ({ onMove }: { onMove: () => void }) => (
+  <div data-testid="scroller" style={{ overflowY: 'auto' }}>
+    <RowDragArea rowIds={['a', 'b', 'c', 'd']} onMove={onMove}>
+      {['a', 'b', 'c', 'd'].map((id, index) => (
+        <DraggableRow key={id} rowId={id} index={index}>
+          <div>Row {id.toUpperCase()}</div>
+        </DraggableRow>
+      ))}
+    </RowDragArea>
+  </div>
+);
+
+const nodeFor = (label: string) => screen.getByText(label).parentElement!;
+
+const scroller = () => screen.getByTestId('scroller');
+
+// A viewport 90px tall showing a 120px list, so there is exactly one row's
+// worth of travel available. `scrollTop` is a plain settable number in jsdom,
+// which is all the engine needs.
+const layout = () => {
+  const el = scroller();
+  Object.defineProperty(el, 'clientHeight', {
+    value: VIEW_H,
+    configurable: true,
+  });
+  Object.defineProperty(el, 'scrollHeight', {
+    value: ROW_H * 4,
+    configurable: true,
+  });
+  el.getBoundingClientRect = () => box(0, VIEW_H);
+  ['A', 'B', 'C', 'D'].forEach((letter, i) => {
+    const row = nodeFor(`Row ${letter}`);
+    row.getBoundingClientRect = () => box(i * ROW_H - el.scrollTop, ROW_H);
+  });
+};
+
+let frames: FrameRequestCallback[] = [];
+
+beforeEach(() => {
+  frames = [];
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    frames.push(cb);
+    return frames.length;
+  });
+  vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.documentElement.removeAttribute('data-dragging');
+});
+
+// Runs the auto-scroll loop by hand. Each frame re-registers the next one, so
+// draining and re-reading is what a real rAF loop does over N frames.
+const runFrames = (n: number) => {
+  for (let i = 0; i < n; i++) {
+    const due = frames;
+    frames = [];
+    due.forEach((cb) => cb(0));
+  }
+};
+
+const startDragAt = (label: string, y: number) => {
+  layout();
+  fireEvent.pointerDown(nodeFor(label), { clientX: 10, clientY: y, button: 0 });
+  // Past ACTIVATION_DISTANCE_PX, which is what makes it a drag rather than a
+  // click and is where the rects are measured.
+  fireEvent.pointerMove(document, { clientX: 10, clientY: y + 10 });
+};
+
+describe('holding a drag near an edge travels the list', () => {
+  test('near the bottom edge it scrolls down', () => {
+    render(<Harness onMove={() => {}} />);
+    startDragAt('Row A', 10);
+
+    // Deep into the bottom edge zone of a 90px-tall viewport.
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 88 });
+    runFrames(3);
+
+    expect(scroller().scrollTop).toBeGreaterThan(0);
+  });
+
+  test('near the top edge it scrolls back up', () => {
+    render(<Harness onMove={() => {}} />);
+    startDragAt('Row A', 10);
+    scroller().scrollTop = 30;
+
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 2 });
+    runFrames(3);
+
+    expect(scroller().scrollTop).toBeLessThan(30);
+  });
+
+  // THE CONTROL. Without it, an implementation that scrolled on every frame
+  // regardless of the pointer would satisfy both tests above -- and would make
+  // the list unusable, since any drag at all would run away.
+  test('CONTROL: held in the middle, the list does not move', () => {
+    render(<Harness onMove={() => {}} />);
+    startDragAt('Row A', 10);
+
+    fireEvent.pointerMove(document, { clientX: 10, clientY: VIEW_H / 2 });
+    runFrames(5);
+
+    expect(scroller().scrollTop).toBe(0);
+  });
+
+  // The middle test above cannot see a runaway on its own: at scrollTop 0 an
+  // upward scroll is clamped to 0, so "no movement" and "moving the wrong way,
+  // clamped" look identical. Starting part-scrolled is what separates them.
+  test('CONTROL: held in the middle of a part-scrolled list, it stays put', () => {
+    render(<Harness onMove={() => {}} />);
+    startDragAt('Row A', 10);
+    scroller().scrollTop = 15;
+
+    fireEvent.pointerMove(document, { clientX: 10, clientY: VIEW_H / 2 });
+    runFrames(5);
+
+    expect(scroller().scrollTop).toBe(15);
+  });
+
+  test('it stops at the end of the list rather than spinning', () => {
+    render(<Harness onMove={() => {}} />);
+    startDragAt('Row A', 10);
+
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 88 });
+    runFrames(40);
+
+    // scrollHeight - clientHeight. jsdom does not clamp for us, so the engine
+    // must not run past it either.
+    expect(scroller().scrollTop).toBeLessThanOrEqual(ROW_H * 4 - VIEW_H);
+  });
+
+  // THE ONE JSDOM ALMOST MISSED. A transform EXTENDS the scrollable overflow
+  // area, and the held row carries one -- so in a real browser every pixel of
+  // auto-scroll added a pixel of content and the end of the list retreated as
+  // fast as the pointer approached it. Measured in the popup: scrollHeight
+  // climbed 820 -> 1393 in step with scrollTop, and the scroll never terminated.
+  //
+  // Reproduced by making scrollHeight a function of scrollTop, which is what
+  // the browser was effectively doing. The limit is captured once at
+  // pointer-down, before any transform exists, so a growing content box cannot
+  // move it.
+  test('a content box that grows while scrolling does not scroll forever', () => {
+    render(<Harness onMove={() => {}} />);
+    startDragAt('Row A', 10);
+
+    // Installed AFTER the drag has begun, which is when it happens for real:
+    // the content only grows once the held row carries a transform. It also has
+    // to be after layout(), which would otherwise redefine it straight back.
+    const el = scroller();
+    Object.defineProperty(el, 'scrollHeight', {
+      // Grows by one pixel per pixel scrolled, exactly like the real transform.
+      get: () => ROW_H * 4 + el.scrollTop,
+      configurable: true,
+    });
+
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 88 });
+    runFrames(60);
+
+    expect(el.scrollTop).toBeLessThanOrEqual(ROW_H * 4 - VIEW_H);
+  });
+
+  test('the loop is cancelled when the drag ends', () => {
+    render(<Harness onMove={() => {}} />);
+    startDragAt('Row A', 10);
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 88 });
+    runFrames(2);
+
+    fireEvent.pointerUp(document, { clientX: 10, clientY: 88 });
+    const settled = scroller().scrollTop;
+    runFrames(10);
+
+    expect(scroller().scrollTop).toBe(settled);
+  });
+});
+
+describe('the landing index survives the list scrolling under it', () => {
+  // THE POINT OF THE CONTENT-SPACE ARITHMETIC. The rects were measured before
+  // any scrolling; if they were compared in viewport space, scrolling by one
+  // row would shift every midpoint past the pointer and the drop would land a
+  // row away from where the user pointed.
+  test('a drop after scrolling lands where the pointer is', () => {
+    const onMove = vi.fn();
+    render(<Harness onMove={onMove} />);
+    startDragAt('Row A', 10);
+
+    // Travel one row's worth, then release over what is now the last row.
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 88 });
+    scroller().scrollTop = ROW_H;
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 88 });
+    fireEvent.pointerUp(document, { clientX: 10, clientY: 88 });
+
+    expect(onMove).toHaveBeenCalledTimes(1);
+    // Content y = 88 + 30 = 118, past the midpoints of b (45), c (75) and
+    // d (105) -- so the held row lands last.
+    expect(onMove.mock.calls[0][1]).toBe(3);
+  });
+
+  // A drag that BEGINS on an already-scrolled list. The rects are measured with
+  // the list part-scrolled, so the measurement itself has to be lifted into
+  // content space -- measuring in viewport space and comparing in content space
+  // is off by exactly the scroll position at pick-up, which is the subtlest way
+  // this could be wrong and the one no unscrolled test can see.
+  test('a drag that starts on an already-scrolled list lands correctly', () => {
+    const onMove = vi.fn();
+    render(<Harness onMove={onMove} />);
+    scroller().scrollTop = ROW_H;
+    startDragAt('Row A', 10);
+
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 50 });
+    fireEvent.pointerUp(document, { clientX: 10, clientY: 50 });
+
+    // Content mids are 15, 45, 75, 105 whatever the scroll. Content y is
+    // 50 + 30 = 80, past b (45) and c (75) but not d (105).
+    expect(onMove.mock.calls[0][1]).toBe(2);
+  });
+
+  // The mirror: with no scrolling at all the answer must be unchanged from
+  // what the engine always gave, or this refactor moved every existing drop.
+  test('CONTROL: with no scrolling the index is what it always was', () => {
+    const onMove = vi.fn();
+    render(<Harness onMove={onMove} />);
+    startDragAt('Row A', 10);
+
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 50 });
+    fireEvent.pointerUp(document, { clientX: 10, clientY: 50 });
+
+    // y = 50 is past b's midpoint (45) but not c's (75).
+    expect(onMove.mock.calls[0][1]).toBe(1);
+  });
+});

--- a/src/tests/redux/sortToast.test.ts
+++ b/src/tests/redux/sortToast.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+vi.hoisted(() => {
+  const g = globalThis as unknown as { window?: unknown };
+  g.window = g.window ?? globalThis;
+  (g.window as { screen?: unknown }).screen = { height: 1080, width: 1920 };
+});
+
+vi.mock('../../utils/functions/external', () => ({
+  loadFromFirestore: vi.fn(),
+  saveToFirestore: vi.fn(),
+  displayToast: vi.fn(),
+}));
+
+import { makeTestStore } from '../setup/makeStore';
+import {
+  moveSessionInternal,
+  resetSessionOrder,
+  saveToTabContainerInternal,
+  sortSessions,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import { TOAST_MESSAGES } from '../../utils/constants/common';
+
+// KAN-151. Reordering the list says so, and says how to get back.
+//
+// Applying a sort overwrites every rank, so a user who has spent time dragging
+// their sessions into an arrangement loses it in one click. Undo DOES restore
+// it -- verified, sorting goes on the undo stack like any other data change --
+// but nothing on screen says so, and "my arrangement is gone" is not a thought
+// that leads anyone to press undo.
+//
+// So the recovery is announced at the moment it becomes relevant. No new state,
+// no new menu item, and nothing to keep in step with the sort machinery.
+
+const session = (id: string, title: string, tabCount = 1) => ({
+  tabGroupId: id,
+  title,
+  createdTime: '2026-09-10 12:00:00',
+  createdAt: 1,
+  windowCount: 1,
+  tabCount,
+  isAutoSave: false,
+  isSelected: false,
+  windows: [
+    {
+      windowId: `${id}-w`,
+      windowHeight: 1,
+      windowWidth: 1,
+      windowOffsetTop: 0,
+      windowOffsetLeft: 0,
+      tabCount,
+      title: 'Window',
+      tabs: [
+        { tabId: `${id}-t`, favicon: '', title: 'T', url: 'https://a.co' },
+      ],
+    },
+  ],
+});
+
+type Store = ReturnType<typeof makeTestStore>['store'];
+
+const HOUR = 3600_000;
+const T0 = Date.UTC(2026, 8, 10, 12, 0, 0);
+
+// THE CLOCK IS PINNED, one hour apart per save. Saving stamps contentModified
+// with Date.now(), and that is what orders the list before any rank exists --
+// so unpinned, three saves may land in one millisecond or straddle a boundary
+// depending on how loaded the machine is, and the seeded order changes with it.
+//
+// Found the hard way: this file passed alone and failed in the full suite,
+// which is KAN-145 exactly, in a fixture written the same day that one was
+// fixed. Seeded oldest first, so the list reads newest first.
+const seed = (store: Store, titles: string[]) => {
+  vi.useFakeTimers();
+  try {
+    titles.forEach((t, i) => {
+      vi.setSystemTime(T0 - (titles.length - 1 - i) * HOUR);
+      store.dispatch(saveToTabContainerInternal(session(`g${i}`, t)));
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+};
+
+// showToast is a THUNK, so what the recorder sees is its lifecycle actions,
+// not a bare 'showToast'. Counting the pending one counts each call exactly
+// once -- fulfilled would too, but pending is the one that always fires.
+const toasts = (seen: string[]) =>
+  seen.filter((type) => type === 'global/showToast/pending');
+
+const order = (store: Store) =>
+  store.getState().tabContainerDataState.tabGroups.map((g) => g.title);
+
+beforeEach(() => localStorage.clear());
+
+describe('a sort that rearranges the list announces itself', () => {
+  test('sorting by name toasts', async () => {
+    const { store, seen } = makeTestStore();
+    seed(store, ['Banana', 'Cherry', 'Apple']);
+
+    await store.dispatch(sortSessions({ by: 'name', locale: 'en' }));
+
+    expect(order(store)).toEqual(['Apple', 'Banana', 'Cherry']);
+    expect(toasts(seen)).toHaveLength(1);
+    expect(store.getState().globalState.toastText).toBe(
+      TOAST_MESSAGES.SESSION_ORDER_CHANGED
+    );
+  });
+
+  test('clearing the order back to default toasts', async () => {
+    const { store, seen } = makeTestStore();
+    seed(store, ['Banana', 'Cherry', 'Apple']);
+    await store.dispatch(sortSessions({ by: 'name', locale: 'en' }));
+    const before = seen.length;
+
+    await store.dispatch(resetSessionOrder());
+
+    // Back to recency order, which is NOT name order -- so the list really
+    // moved and the toast really had something to announce.
+    expect(order(store)).toEqual(['Apple', 'Cherry', 'Banana']);
+    expect(toasts(seen.slice(before))).toHaveLength(1);
+  });
+});
+
+// THE HALF THAT KEEPS IT HONEST. A toast that always fires would satisfy every
+// test above and would lie twice a day: both reducers return early when there
+// is nothing to do, and announcing a change that did not happen -- while
+// telling the user to undo it -- is worse than staying quiet.
+describe('a sort that changes nothing stays quiet', () => {
+  test('re-sorting an already-sorted list does not toast', async () => {
+    const { store, seen } = makeTestStore();
+    seed(store, ['Banana', 'Cherry', 'Apple']);
+    await store.dispatch(sortSessions({ by: 'name', locale: 'en' }));
+
+    // The control for the assertion below: the FIRST sort did announce itself,
+    // so a zero count afterwards means this sort stayed quiet rather than that
+    // the toast never worked.
+    expect(toasts(seen)).toHaveLength(1);
+    const before = seen.length;
+
+    // Second identical sort: already in this order AND already pinned, which
+    // is the early return in sortSessionsInternal.
+    await store.dispatch(sortSessions({ by: 'name', locale: 'en' }));
+
+    expect(toasts(seen.slice(before))).toHaveLength(0);
+    expect(order(store)).toEqual(['Apple', 'Banana', 'Cherry']);
+  });
+
+  test('clearing an order that is already default does not toast', async () => {
+    const { store, seen } = makeTestStore();
+    seed(store, ['Banana', 'Cherry', 'Apple']);
+    const before = seen.length;
+
+    // Never sorted, never dragged -- no ranks exist, so there is nothing to
+    // clear and nothing to announce.
+    await store.dispatch(resetSessionOrder());
+
+    expect(toasts(seen.slice(before))).toHaveLength(0);
+  });
+
+  test('an empty list does not toast', async () => {
+    const { store, seen } = makeTestStore();
+
+    await store.dispatch(sortSessions({ by: 'name', locale: 'en' }));
+
+    expect(toasts(seen)).toHaveLength(0);
+  });
+});
+
+describe('the arrangement the toast promises back', () => {
+  // The claim in the message, asserted rather than trusted: the previous order
+  // really is one undo away. If this ever stops being true the toast becomes a
+  // false instruction, which is worse than no toast at all.
+  test('a dragged order survives a sort and one undo', async () => {
+    const { store } = makeTestStore();
+    seed(store, ['Banana', 'Cherry', 'Apple']);
+    store.dispatch(moveSessionInternal({ tabGroupId: 'g0', toIndex: 0 }));
+    const dragged = order(store);
+
+    await store.dispatch(sortSessions({ by: 'name', locale: 'en' }));
+    expect(order(store)).not.toEqual(dragged);
+
+    store.dispatch({ type: 'undoRedo/undo' });
+
+    expect(order(store)).toEqual(dragged);
+  });
+});

--- a/src/utils/constants/common.ts
+++ b/src/utils/constants/common.ts
@@ -81,6 +81,16 @@ export const TOAST_MESSAGES = {
   // saying "saved" would contradict the control the user just pressed.
   ADD_CURR_WINDOW_TO_TABGROUP_SUCCESS: 'Current window added to this session.',
   ADD_CURR_TAB_TO_WINDOW_SUCCESS: 'Current tab added to this window.',
+  // KAN-151. Applying a sort overwrites every rank, so a hand-arranged list is
+  // gone in one click. Undo restores it -- sorting goes on the undo stack like
+  // any other data change -- but nothing said so, and "my arrangement is gone"
+  // is not a thought that leads anyone to press undo.
+  //
+  // The instruction is only worth printing because it is TRUE: a test asserts
+  // the dragged order really does come back with one undo, so this cannot decay
+  // into a false promise without something going red.
+  SESSION_ORDER_CHANGED:
+    'Sessions reordered. Undo to restore the previous order.',
   DELETE_TAB_CONTAINER_SUCCESS: 'Session deleted.',
   DELETE_WINDOW_SUCCESS: 'Session window deleted.',
   DELETE_TAB_SUCCESS: 'Session tab deleted.',


### PR DESCRIPTION
## What

Justine asked why windows don't collapse during a drag to make rearranging easier. Investigating that turned up the more basic gap: **there is no auto-scroll during a drag at all.** In a session with three windows of twenty tabs the drop target simply cannot be reached — the pointer has nowhere to go and the gesture has to be abandoned.

Measured in the popup: the right pane holds 820px of content in a 416px viewport, and during a drag none of it moved.

## Why this and not collapse-during-drag

Collapsing was assessed first, and deferred. It needs collapse state lifted out of `WindowEntryContainer`'s local `useState(true)`, **and** a re-measure phase in the engine — rects are measured once at activation, synchronously in the pointermove handler, so a React-driven collapse lays out *afterwards* and every midpoint would be wrong. That's surgery on the mechanism that has to be rock solid before release.

Auto-scroll fixes the same pain for tabs, windows and sessions alike, without touching the drop-index contract.

## The hard part is the arithmetic, not the scrolling

Those once-only measurements are **viewport-relative**, so the instant the list scrolls beneath them they describe where rows *used to be*. Every comparison now happens in the list's **content space** — viewport y plus `scrollTop` — which is invariant under scrolling. The held row's visual offset gains the scroll delta too, or it slides out from under the pointer by exactly the distance auto-scrolled.

With no scrolling ancestor `scrollTop` is 0 and the arithmetic is identical to what shipped — which is why every existing drag test passes untouched.

## A runaway only the real browser could show

**A CSS transform extends the scrollable overflow area**, and the held row carries one. So every pixel of auto-scroll added a pixel of content:

```
scrollTop:    163 → 313 → 475 → 625 → 775
scrollHeight: 820 → 943 → 1106 → 1256 → 1393
```

The end of the list retreated as fast as the pointer approached it. It reached **32,325px on an 820px list** before I cancelled the drag.

Fixed by capturing the scroll limit **at pointer-down**, before any transform exists, instead of reading it live each frame. jsdom is structurally blind to this — `scrollHeight` there is whatever a test stubs, and my first test stubbed a constant. It's now pinned by a stub that *grows* with `scrollTop`, verified to fail against the live-limit version (784px against a limit of 30).

## Two more defects the tests found

- **Overlapping edge zones.** 48px at each end covers 96px of a 90px pane, so *every* pointer position counted as an edge and the list scrolled wherever you held it. Capped at a third of the viewport now, leaving a third in the middle that never scrolls. The control test caught this.
- **No clamping.** It relied on the browser to clamp at the ends — which makes correctness a property of the environment, and the value is read back to decide whether to keep going, so an unclamped write reported progress that never happened.

## Tests

10 new. **1229 pass**, 64 e2e pass, tsc clean, lint 0 errors.

Seven mutations. Two survived as **gaps in my tests, not dead code**, and both are now closed:

- *scroll regardless of edge proximity* survived because at `scrollTop` 0 an upward scroll clamps to 0 — "not moving" and "moving the wrong way, clamped" looked identical. A part-scrolled control separates them.
- *midpoints in viewport space* survived because every test started unscrolled. A drag that **begins** on an already-scrolled list is the case that can tell.

The third survivor — cancelling the frame on drop — is documented as redundant, since `autoScroll` already bails when `live.current` is null.

## Verified live

```
held at the bottom edge:  0 → 225 → 404, stops exactly at the true end
released there:           the dragged window lands LAST, where the pointer was
one undo:                 original order restored
```