### PR TITLE
Fold windows shut while a window is dragged (KAN-153)

### DIFF
--- a/e2e/window-drag.spec.ts
+++ b/e2e/window-drag.spec.ts
@@ -1,0 +1,207 @@
+import type { BrowserContext, Page } from '@playwright/test';
+
+import { test, expect } from './fixtures/extension';
+import { buildContainer, buildSession, seedSessions } from './fixtures/seed';
+
+// KAN-153/154/155/156. Dragging a window folds every window shut, and a folded
+// list is a different LAYOUT from the one the user picked the row up in. Every
+// defect in this area was a coordinate read from the wrong one of those two
+// layouts, and every one was invisible to jsdom, which has neither layout nor
+// scrolling. So these run in the real popup, and every drag in a session long
+// enough to scroll starts SCROLLED: scrollTop 0 is the one starting position
+// where the stale-origin bugs cannot appear.
+//
+// "Where the user pointed" is read off the drag PREVIEW at the instant of
+// release -- the rows shifted aside are the index the UI was showing -- rather
+// than predicted from rects. Predicting from rects misread two KAN-129 probes;
+// the preview is what the user actually saw.
+
+const win = (i: number, tabs: number) => ({
+  windowId: `w${i}`,
+  windowHeight: 1080,
+  windowWidth: 1920,
+  windowOffsetTop: 0,
+  windowOffsetLeft: 0,
+  tabCount: tabs,
+  title: `Window ${i}`,
+  tabs: Array.from({ length: tabs }, (_, t) => ({
+    tabId: `w${i}-t${t}`,
+    favicon: '',
+    title: `W${i} tab ${t}`,
+    url: `https://w${i}-${t}.test/`,
+  })),
+});
+
+async function openSession(
+  context: BrowserContext,
+  extensionId: string,
+  windows: number,
+  tabsEach: number
+): Promise<Page> {
+  const session = buildSession({
+    tabGroupId: 's1',
+    title: 'Drag session',
+    isSelected: true,
+    windowCount: windows,
+    tabCount: windows * tabsEach,
+    windows: Array.from({ length: windows }, (_, i) => win(i, tabsEach)),
+  });
+  await seedSessions(context, {
+    ...buildContainer([session]),
+    selectedTabGroupId: 's1',
+  });
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/index.html`);
+  // goto resolves before React mounts (KAN-105); wait on the LAST window, which
+  // is the one the pane has to be tall enough to hold.
+  await expect(
+    page.locator(`[data-drag-row-id="w${windows - 1}"]`)
+  ).toBeAttached();
+  return page;
+}
+
+// The pane: the bordered `overflow: auto` box holding the window list. Scrolls
+// it, and records at the instant of release -- in capture, so before the
+// engine's own pointerup runs -- what the preview was showing.
+async function scrollPaneAndRecord(page: Page, scrollTop: number) {
+  return page.evaluate((top) => {
+    let el = document.querySelector('[data-drag-row-id="w0"]')!.parentElement;
+    while (el && !['auto', 'scroll'].includes(getComputedStyle(el).overflowY))
+      el = el.parentElement;
+    const pane = el!;
+    pane.scrollTop = top;
+    (window as unknown as { __preview: number | null }).__preview = null;
+
+    const windowRows = () =>
+      [...document.querySelectorAll<HTMLElement>('[data-drag-row-id]')].filter(
+        (r) => r.querySelector('[data-window-drag-handle]') !== null
+      );
+    window.addEventListener(
+      'pointerup',
+      () => {
+        const rows = windowRows();
+        const from = rows.findIndex((r) => r.style.boxShadow !== '');
+        const shift = (r: HTMLElement) =>
+          Number(
+            /translateY\((-?[\d.]+)px\)/.exec(r.style.transform)?.[1] ?? 0
+          );
+        const up = rows.filter((r, i) => i !== from && shift(r) < 0).length;
+        const down = rows.filter((r, i) => i !== from && shift(r) > 0).length;
+        (window as unknown as { __preview: number }).__preview =
+          from + up - down;
+      },
+      { capture: true, once: true }
+    );
+
+    const b = pane.getBoundingClientRect();
+    return {
+      scrollTop: pane.scrollTop,
+      top: b.top,
+      bottom: b.bottom,
+    };
+  }, scrollTop);
+}
+
+// The topmost window header wholly inside the pane -- the one a user scrolled
+// to this position would actually grab.
+async function topVisibleHeader(
+  page: Page,
+  pane: { top: number; bottom: number }
+) {
+  return page.evaluate(({ top, bottom }) => {
+    for (const h of document.querySelectorAll('[data-window-drag-handle]')) {
+      const r = h.getBoundingClientRect();
+      if (r.top >= top && r.bottom <= bottom) {
+        return {
+          id: (h.closest('[data-drag-row-id]') as HTMLElement).dataset
+            .dragRowId!,
+          x: r.left + 60,
+          y: r.top + r.height / 2,
+        };
+      }
+    }
+    throw new Error('no window header is visible in the pane');
+  }, pane);
+}
+
+async function dragTo(page: Page, from: { x: number; y: number }, toY: number) {
+  await page.mouse.move(from.x, from.y);
+  await page.mouse.down();
+  // Past the activation distance, which is where the list folds.
+  await page.mouse.move(from.x, from.y + 10, { steps: 3 });
+  await page.mouse.move(from.x, toY, { steps: 12 });
+  await page.mouse.up();
+}
+
+const storedOrder = (page: Page) =>
+  page.evaluate(() =>
+    (
+      JSON.parse(localStorage.getItem('tabContainerData')!) as {
+        tabGroups: { windows: { windowId: string }[] }[];
+      }
+    ).tabGroups[0].windows.map((w) => w.windowId)
+  );
+
+test.describe('dragging a window from a scrolled position', () => {
+  // KAN-156. Twenty windows fold to a list that STILL overflows, so the scroll
+  // never reaches 0 and the browser re-anchors it when the windows unfold. The
+  // drop was judged after unfolding and landed last whatever the preview said.
+  test('in a long session, it lands where the preview showed', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openSession(context, extensionId, 20, 3);
+    const pane = await scrollPaneAndRecord(page, 1200);
+    expect(pane.scrollTop).toBe(1200);
+    const grab = await topVisibleHeader(page, pane);
+
+    // Mid-pane: clear of both auto-scroll edge zones, and inside the rows.
+    await dragTo(page, grab, (pane.top + pane.bottom) / 2);
+
+    const preview = await page.evaluate(
+      () => (window as unknown as { __preview: number | null }).__preview
+    );
+    // The control that the premise held: a real mid-list slot, not an end.
+    // Both ends are where a mis-judged drop saturates.
+    expect(preview).toBeGreaterThan(0);
+    expect(preview).toBeLessThan(19);
+
+    await expect
+      .poll(async () => (await storedOrder(page)).indexOf(grab.id))
+      .toBe(preview);
+  });
+
+  // KAN-155. Two windows never overflow the pane, so there is no scrolling
+  // ancestor -- and the first cut of the clamp looked for one, and refused.
+  test('in a short session, a release under the folded rows lands last', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openSession(context, extensionId, 2, 3);
+    const pane = await scrollPaneAndRecord(page, 0);
+    const grab = await topVisibleHeader(page, pane);
+    expect(grab.id).toBe('w0');
+
+    // The bottom of the view: far below two folded headers.
+    await dragTo(page, grab, pane.bottom - 8);
+
+    await expect.poll(() => storedOrder(page)).toEqual(['w1', 'w0']);
+  });
+
+  // THE CONTROL for the one above: the pane is the bound, not the screen. Above
+  // it are the session header and the save row.
+  test('CONTROL: released above the pane, nothing moves', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openSession(context, extensionId, 5, 6);
+    const pane = await scrollPaneAndRecord(page, 300);
+    const grab = await topVisibleHeader(page, pane);
+
+    await dragTo(page, grab, pane.top - 30);
+    // Long enough for a commit to have been written, were there one.
+    await page.waitForTimeout(300);
+
+    expect(await storedOrder(page)).toEqual(['w0', 'w1', 'w2', 'w3', 'w4']);
+  });
+});

--- a/e2e/window-drag.spec.ts
+++ b/e2e/window-drag.spec.ts
@@ -190,7 +190,11 @@ test.describe('dragging a window from a scrolled position', () => {
 
   // THE CONTROL for the one above: the pane is the bound, not the screen. Above
   // it are the session header and the save row.
-  test('CONTROL: released above the pane, nothing moves', async ({
+  //
+  // And KAN-157: nothing moved, so the view is back where it was. Folding five
+  // windows clamps the scroll 300 -> 0, and before the fix it stayed there,
+  // with the held window off screen below the pane.
+  test('CONTROL: released above the pane, nothing moves and the view comes back', async ({
     context,
     extensionId,
   }) => {
@@ -203,5 +207,51 @@ test.describe('dragging a window from a scrolled position', () => {
     await page.waitForTimeout(300);
 
     expect(await storedOrder(page)).toEqual(['w0', 'w1', 'w2', 'w3', 'w4']);
+    expect(await paneState(page, grab.id)).toEqual({
+      scrollTop: 300,
+      headerVisible: true,
+    });
+  });
+
+  // KAN-157. Escape means nothing happened, and that includes what you were
+  // looking at.
+  test('after Escape, the view is where the drag began', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openSession(context, extensionId, 5, 6);
+    const pane = await scrollPaneAndRecord(page, 300);
+    const grab = await topVisibleHeader(page, pane);
+
+    await page.mouse.move(grab.x, grab.y);
+    await page.mouse.down();
+    await page.mouse.move(grab.x, grab.y + 40, { steps: 6 });
+    // The premise: the fold really did take the scroll away. Without it, a
+    // restore that never ran would pass.
+    expect((await paneState(page, grab.id)).scrollTop).toBe(0);
+    await page.keyboard.press('Escape');
+    await page.mouse.up();
+
+    await expect
+      .poll(() => paneState(page, grab.id))
+      .toEqual({ scrollTop: 300, headerVisible: true });
+    expect(await storedOrder(page)).toEqual(['w0', 'w1', 'w2', 'w3', 'w4']);
   });
 });
+
+// The pane's scroll, and whether the given window's header is wholly on screen.
+const paneState = (page: Page, windowId: string) =>
+  page.evaluate((id) => {
+    const header = document.querySelector(
+      `[data-drag-row-id="${id}"] [data-window-drag-handle]`
+    )!;
+    let el = header.parentElement;
+    while (el && !['auto', 'scroll'].includes(getComputedStyle(el).overflowY))
+      el = el.parentElement;
+    const p = el!.getBoundingClientRect();
+    const h = header.getBoundingClientRect();
+    return {
+      scrollTop: el!.scrollTop,
+      headerVisible: h.top >= p.top && h.bottom <= p.bottom,
+    };
+  }, windowId);

--- a/src/App.css
+++ b/src/App.css
@@ -53,6 +53,20 @@ body {
   background-color: transparent !important;
 }
 
+/* KAN-153. While a WINDOW is being dragged, every window folds shut so the
+   whole session fits on screen and the drop target can actually be seen.
+
+   Scoped to the window kind on purpose: `[data-dragging]` alone would match a
+   TAB drag too, and hiding the tab list mid-tab-drag would remove the very
+   rows being reordered out from under the pointer.
+
+   Visual only. No component's open/closed state is touched, which is what
+   makes "and it comes back exactly how it was" need no bookkeeping -- the rule
+   simply stops applying when the attribute goes. */
+[data-dragging='window'] [data-window-tabs] {
+  display: none !important;
+}
+
 ::-webkit-scrollbar {
   width: 10px;
 }

--- a/src/components/home/leftpane/TabGroupEntryContainer.tsx
+++ b/src/components/home/leftpane/TabGroupEntryContainer.tsx
@@ -209,6 +209,7 @@ export default function TabGroupEntryContainer() {
             rowIds={sessionIds}
             onMove={handleMoveSession}
             dragKind="session"
+            clampDropToEnds
             disabled={isSearchPanel}
           >
             {filteredTabGroups.map((tabGroupData, index) => {

--- a/src/components/home/leftpane/TabGroupEntryContainer.tsx
+++ b/src/components/home/leftpane/TabGroupEntryContainer.tsx
@@ -208,6 +208,7 @@ export default function TabGroupEntryContainer() {
           <RowDragArea
             rowIds={sessionIds}
             onMove={handleMoveSession}
+            dragKind="session"
             disabled={isSearchPanel}
           >
             {filteredTabGroups.map((tabGroupData, index) => {

--- a/src/components/home/rightpane/TabGroupDetailsContainer.tsx
+++ b/src/components/home/rightpane/TabGroupDetailsContainer.tsx
@@ -160,6 +160,7 @@ export default function TabGroupDetailsContainer() {
             rowIds={windowIds}
             onMove={handleMoveWindow}
             handleSelector="[data-window-drag-handle]"
+            dragKind="window"
             // The mode, not the box's contents -- see KAN-140 on
             // TabGroupEntryContainer for why this is not isFilteredView.
             disabled={isSearchPanel}

--- a/src/components/home/rightpane/TabGroupDetailsContainer.tsx
+++ b/src/components/home/rightpane/TabGroupDetailsContainer.tsx
@@ -162,6 +162,7 @@ export default function TabGroupDetailsContainer() {
             handleSelector="[data-window-drag-handle]"
             dragKind="window"
             clampDropToEnds
+            restoreScrollIfNoDrop
             // The mode, not the box's contents -- see KAN-140 on
             // TabGroupEntryContainer for why this is not isFilteredView.
             disabled={isSearchPanel}

--- a/src/components/home/rightpane/TabGroupDetailsContainer.tsx
+++ b/src/components/home/rightpane/TabGroupDetailsContainer.tsx
@@ -161,6 +161,7 @@ export default function TabGroupDetailsContainer() {
             onMove={handleMoveWindow}
             handleSelector="[data-window-drag-handle]"
             dragKind="window"
+            clampDropToEnds
             // The mode, not the box's contents -- see KAN-140 on
             // TabGroupEntryContainer for why this is not isFilteredView.
             disabled={isSearchPanel}

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -686,10 +686,15 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
         </div>
       </div>
       {windowOpenState && (
-        <div css={childrenContainerStyle}>
+        // data-window-tabs is the hook App.css uses to fold every window shut
+        // while a WINDOW is being dragged (KAN-153). Visual only -- this
+        // component's own open/closed state is never touched, which is what
+        // makes "and it comes back how it was" require no bookkeeping at all.
+        <div css={childrenContainerStyle} data-window-tabs>
           <RowDragArea
             rowIds={tabIds}
             onMove={handleMove}
+            dragKind="tab"
             resolveDrop={bandAt}
             // The mode, not the box's contents -- see KAN-140 on
             // TabGroupEntryContainer for why this is not isFilteredView.

--- a/src/components/home/rightpane/rowDrag/RowDragArea.tsx
+++ b/src/components/home/rightpane/rowDrag/RowDragArea.tsx
@@ -119,6 +119,7 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
   handleSelector,
   dragKind = 'tab',
   clampDropToEnds = false,
+  restoreScrollIfNoDrop = false,
   resolveDrop,
   disabled = false,
   children,
@@ -144,6 +145,11 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
     // own content space so that scrolling cannot invalidate it.
     scroller: HTMLElement | null;
     startScrollTop: number;
+    // The scroll at pointer-down, before any collapse -- what a drag that
+    // commits nothing puts back (KAN-157). Not startScrollTop, which is
+    // deliberately re-read AFTER the collapse (KAN-154) and so describes the
+    // folded list, not the one the user was looking at.
+    scrollTopAtPress: number;
     maxScroll: number;
     // Where a release still counts as a drop on this list, when the list has
     // opted in (KAN-155). Null otherwise, and then only the rows count.
@@ -216,6 +222,7 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
         lastY: clientY,
         scroller,
         startScrollTop: scroller?.scrollTop ?? 0,
+        scrollTopAtPress: scroller?.scrollTop ?? 0,
         maxScroll: scroller
           ? Math.max(0, scroller.scrollHeight - scroller.clientHeight)
           : 0,
@@ -483,13 +490,21 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
         // so a row already on screen is left exactly where it is.
         //
         // Only on a COMMITTED drop, which is the only case with a new place to
-        // show. What a drag that commits nothing should restore is KAN-157:
-        // for a window drag the collapse has already moved the list, so doing
-        // nothing here is not the same as leaving the view alone.
+        // show. A drag that commits nothing is the branch below.
         const dropped = l.rowId;
         requestAnimationFrame(() => {
           rows.current.get(dropped)?.scrollIntoView({ block: 'nearest' });
         });
+      } else if (restoreScrollIfNoDrop && l.scroller) {
+        // Put the view back (KAN-157). For a window drag "nothing happened" is
+        // not the same as "leave the scroll alone": the collapse already
+        // clamped it, and unfolding does not give it back -- measured, five
+        // windows scrolled to 300 ended at 0 with the held window off screen.
+        //
+        // Synchronous, and after setDragging(false) above: the kind is
+        // unpublished, so this write lays out against the UNFOLDED list and
+        // its full scroll range, which is the only one 300 fits in.
+        l.scroller.scrollTop = l.scrollTopAtPress;
       }
     };
 
@@ -522,7 +537,7 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
       // `grabbing`.
       setDragging(false);
     };
-  }, [rowIds, onMove, resolveDrop, dragKind]);
+  }, [rowIds, onMove, resolveDrop, dragKind, restoreScrollIfNoDrop]);
 
   const ctx = useMemo<Ctx>(
     () => ({ register, begin, drag }),

--- a/src/components/home/rightpane/rowDrag/RowDragArea.tsx
+++ b/src/components/home/rightpane/rowDrag/RowDragArea.tsx
@@ -89,6 +89,23 @@ function scrollableAncestor(from: HTMLElement | null): HTMLElement | null {
   return null;
 }
 
+// The box the list lives in: the nearest ancestor that scrolls OR COULD.
+//
+// Not scrollableAncestor, which skips a container whose content happens to fit
+// -- the right thing for auto-scroll, where there is nothing to scroll, and the
+// wrong thing here. A two-window session never overflows its pane, and the dead
+// space under its folded rows is still that pane; measured in the popup, the
+// scrolling-ancestor version refused exactly that release (KAN-155).
+function paneOf(from: HTMLElement | null): HTMLElement | null {
+  let el: HTMLElement | null = from?.parentElement ?? null;
+  while (el && el !== document.body) {
+    const overflowY = getComputedStyle(el).overflowY;
+    if (overflowY === 'auto' || overflowY === 'scroll') return el;
+    el = el.parentElement;
+  }
+  return null;
+}
+
 interface Rect {
   id: string;
   index: number;
@@ -101,6 +118,7 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
   onMove,
   handleSelector,
   dragKind = 'tab',
+  clampDropToEnds = false,
   resolveDrop,
   disabled = false,
   children,
@@ -127,6 +145,9 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
     scroller: HTMLElement | null;
     startScrollTop: number;
     maxScroll: number;
+    // Where a release still counts as a drop on this list, when the list has
+    // opted in (KAN-155). Null otherwise, and then only the rows count.
+    pane: HTMLElement | null;
   } | null>(null);
 
   // The auto-scroll frame, cancelled on drop. A ref rather than state: it is
@@ -198,9 +219,10 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
         maxScroll: scroller
           ? Math.max(0, scroller.scrollHeight - scroller.clientHeight)
           : 0,
+        pane: clampDropToEnds ? paneOf(el) : null,
       };
     },
-    [rowIds, handleSelector, disabled]
+    [rowIds, handleSelector, disabled, clampDropToEnds]
   );
 
   useEffect(() => {
@@ -373,6 +395,51 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
       update(l);
     };
 
+    // Where a release lands, or undefined for a release this list refuses.
+    //
+    // MUST RUN BEFORE THE DRAG KIND IS UNPUBLISHED (KAN-156). The rows were
+    // measured in the drag's own layout -- folded, for a window drag -- and the
+    // drop has to be judged in that same layout. Unpublishing unfolds every
+    // window, and the first layout read after it (scrollTop, below) forces the
+    // unfolded layout: measured on a twenty-window session, scrollTop read 385
+    // folded and 1200 straight after unpublishing, and a window released
+    // mid-pane landed last. The mirror of the rule at activation, where the
+    // kind is published BEFORE measuring.
+    const judgeDrop = (
+      l: NonNullable<typeof live.current>
+    ): { toIndex: number; dropTargetId: string | undefined } | undefined => {
+      // Content space, matching how the rects were measured. Using the raw
+      // viewport y here would misjudge both the containment test and the
+      // landing index by however far the list had auto-scrolled.
+      const dropY = contentY(l, l.lastY);
+
+      // A release in the empty space below (or above) the rows, but still
+      // inside the pane being dragged in. toIndex needs no special case: it
+      // counts the midpoints the pointer has passed, so a release under every
+      // row already comes out as the last index, and one above them as 0.
+      //
+      // l.pane is only set when the list OPTED IN, never on the geometry alone
+      // -- for a nested tab list this same release means "dragged out of this
+      // window", and committing it is the KAN-132 defect isInsideList was
+      // written to stop.
+      const paneBox = l.pane?.getBoundingClientRect();
+      const releasedInPane =
+        paneBox !== undefined &&
+        l.lastY >= paneBox.top &&
+        l.lastY <= paneBox.bottom &&
+        l.lastX >= paneBox.left &&
+        l.lastX <= paneBox.right;
+
+      if (!isInsideList(l.rects, dropY, l.height / 2) && !releasedInPane) {
+        return undefined;
+      }
+      const others = l.rects.filter((r) => r.id !== l.rowId);
+      return {
+        toIndex: others.filter((r) => dropY > r.mid).length,
+        dropTargetId: resolveDrop?.(containerRef.current, l.lastX, l.lastY),
+      };
+    };
+
     const finish = (commit: boolean) => {
       const l = live.current;
       live.current = null;
@@ -388,31 +455,41 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
         scrollFrame.current = 0;
       }
       if (!l) return;
+      // Judged first, while the drag's layout still stands -- see judgeDrop.
+      const drop = commit && l.started ? judgeDrop(l) : undefined;
       setDragging(false);
       // Below the threshold this was a click, not a drag, and the row's own
       // handler must run untouched.
       if (!l.started) return;
 
-      // Armed for a real drag whether it committed or was cancelled with Esc:
-      // in both cases the user was dragging, and in neither did they ask for
-      // the row to open.
+      // Armed for a real drag whether it committed, was refused, or was
+      // cancelled with Esc: in every case the user was dragging, and in none
+      // did they ask for the row they were holding to open.
       suppressClickUntil.current = performance.now() + 400;
 
-      // Armed above, checked here: a drop this area refuses is still a drag the
-      // user performed, and they did not ask to open the row they were holding.
-      // Content space, matching how the rects were measured. Using the raw
-      // viewport y here would misjudge both the containment test and the
-      // landing index by however far the list had auto-scrolled.
-      const dropY = l.lastY + (l.scroller?.scrollTop ?? 0);
-      if (commit && isInsideList(l.rects, dropY, l.height / 2)) {
-        const others = l.rects.filter((r) => r.id !== l.rowId);
-        const toIndex = others.filter((r) => dropY > r.mid).length;
-        const dropTargetId = resolveDrop?.(
-          containerRef.current,
-          l.lastX,
-          l.lastY
-        );
-        onMove(l.rowId, toIndex, dropTargetId);
+      if (drop) {
+        onMove(l.rowId, drop.toIndex, drop.dropTargetId);
+
+        // Follow the row you just dropped (KAN-155).
+        //
+        // Releasing ENDS the collapse, so the list springs back from a third of
+        // its height to all of it -- and a row dropped at the bottom of the
+        // folded list is then far below the fold. The user placed it
+        // deliberately and cannot see where it went, which is KAN-143's
+        // complaint arriving by a different route.
+        //
+        // On the next frame, because the reorder has to be committed and laid
+        // out before there is anything to scroll to; and `block: 'nearest'`
+        // so a row already on screen is left exactly where it is.
+        //
+        // Only on a COMMITTED drop, which is the only case with a new place to
+        // show. What a drag that commits nothing should restore is KAN-157:
+        // for a window drag the collapse has already moved the list, so doing
+        // nothing here is not the same as leaving the view alone.
+        const dropped = l.rowId;
+        requestAnimationFrame(() => {
+          rows.current.get(dropped)?.scrollIntoView({ block: 'nearest' });
+        });
       }
     };
 
@@ -445,7 +522,7 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
       // `grabbing`.
       setDragging(false);
     };
-  }, [rowIds, onMove, resolveDrop]);
+  }, [rowIds, onMove, resolveDrop, dragKind]);
 
   const ctx = useMemo<Ctx>(
     () => ({ register, begin, drag }),

--- a/src/components/home/rightpane/rowDrag/RowDragArea.tsx
+++ b/src/components/home/rightpane/rowDrag/RowDragArea.tsx
@@ -100,6 +100,7 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
   rowIds,
   onMove,
   handleSelector,
+  dragKind = 'tab',
   resolveDrop,
   disabled = false,
   children,
@@ -304,6 +305,15 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
         // onClick must be allowed to fire untouched.
         if (travelled < ACTIVATION_DISTANCE_PX) return;
 
+        // BEFORE the measurement, not after (KAN-153). A window drag collapses
+        // every tab list via CSS, which changes every row's height -- and this
+        // writes the attribute straight to the DOM, so the
+        // getBoundingClientRect calls below flush style and layout and read the
+        // COLLAPSED boxes. Measure first and every midpoint would describe a
+        // layout that no longer exists.
+        l.started = true;
+        setDragging(true, dragKind);
+
         // Measured once, at the moment the drag actually starts: reading rects
         // on every move would report positions already displaced by the shifts
         // this drag is applying.
@@ -321,8 +331,26 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
           };
         });
         l.height = l.rects[l.fromIndex]?.height ?? 0;
-        l.started = true;
-        setDragging(true);
+
+        // Re-read now that the list may have collapsed: the limit captured at
+        // pointer-down described the expanded content, and auto-scrolling to
+        // THAT would run far past the end of a list a third the size.
+        if (l.scroller) {
+          l.maxScroll = Math.max(
+            0,
+            l.scroller.scrollHeight - l.scroller.clientHeight
+          );
+        }
+
+        // Re-anchor the grab. Collapsing moves every row, so the row being held
+        // is no longer under the pointer where it was picked up -- without this
+        // it jumps away by however much the rows above it shrank. Pinning the
+        // pointer to the row's CENTRE rather than preserving the original grab
+        // offset is deliberate: that offset was measured against a row that no
+        // longer exists at that height, and a centred row is what the drop
+        // arithmetic assumes anyway.
+        const held = l.rects[l.fromIndex];
+        if (held) l.startY = held.mid - l.startScrollTop;
         if (!scrollFrame.current) {
           scrollFrame.current = requestAnimationFrame(autoScroll);
         }

--- a/src/components/home/rightpane/rowDrag/RowDragArea.tsx
+++ b/src/components/home/rightpane/rowDrag/RowDragArea.tsx
@@ -314,6 +314,20 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
         l.started = true;
         setDragging(true, dragKind);
 
+        // RE-READ AFTER THE COLLAPSE, and this is load-bearing (KAN-154).
+        // Folding the windows shut can make the list shorter than its viewport,
+        // and the browser then clamps scrollTop to fit -- measured, 404 -> 0 on
+        // a five-window session scrolled to the bottom. The value captured at
+        // pointer-down describes a scroll position that no longer exists, and
+        // using it puts every midpoint AND the held row's offset out by exactly
+        // that much: the row lands 316px above the pane, off screen, and the
+        // drop index is computed against a list nobody is pointing at.
+        //
+        // Reading it here, after the attribute is set and the rects below have
+        // forced layout, is what keeps the measurement and the pointer in one
+        // consistent frame.
+        l.startScrollTop = l.scroller?.scrollTop ?? 0;
+
         // Measured once, at the moment the drag actually starts: reading rects
         // on every move would report positions already displaced by the shifts
         // this drag is applying.

--- a/src/components/home/rightpane/rowDrag/dropRules.ts
+++ b/src/components/home/rightpane/rowDrag/dropRules.ts
@@ -38,6 +38,23 @@ export interface RowDragAreaProps {
   // `begin` runs owns the gesture.
   handleSelector?: string;
   dragKind?: DragKind;
+  /**
+   * Treat a release anywhere inside the list's pane -- the nearest
+   * `overflow: auto` box, whether or not it currently overflows -- as a drop
+   * on this list, landing at whichever end the pointer is past (KAN-155).
+   *
+   * OFF BY DEFAULT, and that is the important half. `isInsideList` exists to
+   * stop a tab dragged OUT of its window saturating at the bottom of the window
+   * it came from -- see the comment on that function, and KAN-132. Turning this
+   * on for the tab lists would hand that defect straight back.
+   *
+   * It is on for the two lists that are the only list in their pane, where a
+   * release in empty space below the rows can mean nothing else. It matters
+   * because collapsing during a window drag leaves the folded list occupying a
+   * fraction of the pane -- measured, 190px of rows in a 417px pane -- so the
+   * dead zone underneath is large and easy to release into.
+   */
+  clampDropToEnds?: boolean;
   resolveDrop?: ResolveDrop;
   // Dragging is off while the list on screen is a FILTERED view of the stored
   // one (KAN-131). toIndex counts rendered rows, and the reducers apply it to

--- a/src/components/home/rightpane/rowDrag/dropRules.ts
+++ b/src/components/home/rightpane/rowDrag/dropRules.ts
@@ -55,6 +55,21 @@ export interface RowDragAreaProps {
    * dead zone underneath is large and easy to release into.
    */
   clampDropToEnds?: boolean;
+  /**
+   * After a drag that commits nothing -- Escape, or a release the list
+   * refuses -- put the scroll back where it was when the row was picked up
+   * (KAN-157).
+   *
+   * For a list whose drag CHANGES ITS OWN LAYOUT. A window drag folds every
+   * window shut, the browser clamps the scroll to fit, and unfolding does not
+   * give the position back: measured, five windows scrolled to 300 ended at 0
+   * with the held window off screen. A committed drop recovers by following
+   * the dropped row; a drag that moved nothing had nothing to follow.
+   *
+   * Off for the tab lists, which fold nothing: there the only scrolling a drag
+   * does is the auto-scroll the user asked for by holding near an edge.
+   */
+  restoreScrollIfNoDrop?: boolean;
   resolveDrop?: ResolveDrop;
   // Dragging is off while the list on screen is a FILTERED view of the stored
   // one (KAN-131). toIndex counts rendered rows, and the reducers apply it to

--- a/src/components/home/rightpane/rowDrag/dropRules.ts
+++ b/src/components/home/rightpane/rowDrag/dropRules.ts
@@ -20,6 +20,11 @@ export type ResolveDrop = (
   y: number
 ) => string | undefined;
 
+// Which list is being dragged. Only the CSS cares, but it has to come from the
+// caller: the area itself has no idea what its rows represent, and that is
+// deliberate -- see the file header on RowDragArea.
+export type DragKind = 'tab' | 'window' | 'session';
+
 export interface RowDragAreaProps {
   // Flat, in render order. Index into this is what onMove's toIndex means.
   rowIds: string[];
@@ -32,6 +37,7 @@ export interface RowDragAreaProps {
   // underneath it. The two areas need no other coordination: only the one whose
   // `begin` runs owns the gesture.
   handleSelector?: string;
+  dragKind?: DragKind;
   resolveDrop?: ResolveDrop;
   // Dragging is off while the list on screen is a FILTERED view of the stored
   // one (KAN-131). toIndex counts rendered rows, and the reducers apply it to
@@ -128,7 +134,12 @@ export function isInsideList(
 // (`[data-dragging] *`) rather than a property set on one node. The styles live
 // in App.css; this only says when they apply. It also carries `user-select`,
 // which had the same shape and is now in the same rule.
-export function setDragging(on: boolean): void {
-  if (on) document.documentElement.setAttribute('data-dragging', '');
+export function setDragging(on: boolean, kind: DragKind = 'tab'): void {
+  // The KIND is published, not just the fact (KAN-153). A window drag collapses
+  // every window's tab list so the whole session fits on screen, and that rule
+  // must not fire during a TAB drag -- it would hide the very list being
+  // reordered. Existing `[data-dragging]` rules are unaffected: an attribute
+  // selector matches whatever the value is.
+  if (on) document.documentElement.setAttribute('data-dragging', kind);
   else document.documentElement.removeAttribute('data-dragging');
 }

--- a/src/tests/components/dragAutoScroll.test.tsx
+++ b/src/tests/components/dragAutoScroll.test.tsx
@@ -273,3 +273,78 @@ describe('the landing index survives the list scrolling under it', () => {
     expect(onMove.mock.calls[0][1]).toBe(1);
   });
 });
+
+// KAN-155. Releasing ends the collapse, so the list springs back from a third
+// of its height to all of it -- and a row dropped at the bottom of the folded
+// list is then far below the fold. The user placed it deliberately and cannot
+// see where it went.
+//
+// Asserted on WHICH element was asked to scroll, not on any visual result:
+// jsdom implements no scrolling at all (see the stub in componentSetup.ts).
+describe('after a drop, the row you placed is brought into view', () => {
+  // Both the element AND the argument: `nearest` is what leaves a row that is
+  // already on screen exactly where it is, so a drop the user can already see
+  // does not jump the list. Recording only the element cannot see that.
+  const scrolled: {
+    rowId: string | undefined;
+    options: ScrollIntoViewOptions | boolean | undefined;
+  }[] = [];
+
+  beforeEach(() => {
+    scrolled.length = 0;
+    vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(function (
+      this: Element,
+      options?: ScrollIntoViewOptions | boolean
+    ) {
+      scrolled.push({
+        rowId: (this as HTMLElement).dataset?.dragRowId,
+        options,
+      });
+    });
+  });
+
+  const drag = (from: string, toY: number, commit: boolean) => {
+    startDragAt(from, 10);
+    fireEvent.pointerMove(document, { clientX: 10, clientY: toY });
+    if (commit) fireEvent.pointerUp(document, { clientX: 10, clientY: toY });
+    else fireEvent.keyDown(document, { key: 'Escape' });
+    // The scroll is deferred a frame, because the reorder has to commit and lay
+    // out before there is anything to scroll to.
+    runFrames(1);
+  };
+
+  test('a committed drop scrolls the dropped row into view', () => {
+    render(<Harness onMove={() => {}} />);
+
+    drag('Row A', 88, true);
+
+    expect(scrolled).toEqual([{ rowId: 'a', options: { block: 'nearest' } }]);
+  });
+
+  // THE CONTROL. A cancelled drag moved nothing, and yanking the list after an
+  // Escape would be the app arguing with the user.
+  test('CONTROL: a cancelled drag scrolls nothing', () => {
+    render(<Harness onMove={() => {}} />);
+
+    drag('Row A', 88, false);
+
+    expect(scrolled).toEqual([]);
+  });
+
+  // The other control: a press that never became a drag is a click, and the
+  // row's own handler owns it.
+  test('CONTROL: a plain click scrolls nothing', () => {
+    render(<Harness onMove={() => {}} />);
+    layout();
+
+    fireEvent.pointerDown(nodeFor('Row A'), {
+      clientX: 10,
+      clientY: 10,
+      button: 0,
+    });
+    fireEvent.pointerUp(document, { clientX: 10, clientY: 10 });
+    runFrames(1);
+
+    expect(scrolled).toEqual([]);
+  });
+});

--- a/src/tests/components/dragCollapse.test.tsx
+++ b/src/tests/components/dragCollapse.test.tsx
@@ -109,3 +109,94 @@ describe('the collapse happens before the rows are measured', () => {
     expect(seenAtMeasure.every((v) => v === 'window')).toBe(true);
   });
 });
+
+// KAN-154. The collapse can make the list SHORTER THAN ITS VIEWPORT, and the
+// browser then clamps scrollTop to fit. Measured in the popup on a five-window
+// session scrolled to the bottom: content 820 -> 416 (exactly the viewport) and
+// scrollTop 404 -> 0.
+//
+// The scroll origin captured at pointer-down then describes a position that no
+// longer exists, and everything derived from it is out by that much: the held
+// row was translated 316px up, landing at y=-31 against a pane starting at 124
+// -- off screen -- and the drop was computed against a list nobody was pointing
+// at, so it committed nothing. Only windows reachable at scrollTop 0 could be
+// dragged, which is exactly how it was reported.
+//
+// jsdom neither collapses nor clamps, so both are simulated here: scrollHeight
+// shrinks once the window-drag flag is set, and scrollTop clamps the way a real
+// scroller does.
+describe('a drag that starts scrolled, on a list that collapses', () => {
+  const VIEW = 90;
+  const OPEN_H = 30;
+  const SHUT_H = 15;
+
+  const mountClampingScroller = (el: HTMLElement) => {
+    const collapsed = () =>
+      document.documentElement.getAttribute('data-dragging') === 'window';
+    const rowH = () => (collapsed() ? SHUT_H : OPEN_H);
+    let top = 0;
+    Object.defineProperty(el, 'clientHeight', {
+      value: VIEW,
+      configurable: true,
+    });
+    Object.defineProperty(el, 'scrollHeight', {
+      get: () => rowH() * 4,
+      configurable: true,
+    });
+    const max = () => Math.max(0, rowH() * 4 - VIEW);
+    Object.defineProperty(el, 'scrollTop', {
+      // Clamped on READ as well as on write, which is what a real scroller
+      // does: when the content shrinks below the viewport the browser re-clamps
+      // at layout rather than waiting to be written to. Clamping only on write
+      // made this test disagree with the popup, and the popup was right.
+      get: () => (top = Math.min(top, max())),
+      set: (v: number) => (top = Math.max(0, Math.min(v, max()))),
+      configurable: true,
+    });
+    el.getBoundingClientRect = () => box(0, VIEW);
+    return { rowH };
+  };
+
+  test('the held row stays put and the drop lands where the pointer is', () => {
+    const onMove = vi.fn();
+    const { container } = render(
+      <div style={{ overflowY: 'auto' }}>
+        <RowDragArea
+          rowIds={['a', 'b', 'c', 'd']}
+          onMove={onMove}
+          dragKind="window"
+        >
+          {['a', 'b', 'c', 'd'].map((id, i) => (
+            <DraggableRow key={id} rowId={id} index={i}>
+              <div>Row {id}</div>
+            </DraggableRow>
+          ))}
+        </RowDragArea>
+      </div>
+    );
+
+    const scroller = container.firstElementChild as HTMLElement;
+    const { rowH } = mountClampingScroller(scroller);
+    ['a', 'b', 'c', 'd'].forEach((id, i) => {
+      const row = screen.getByText(`Row ${id}`).parentElement!;
+      row.getBoundingClientRect = () =>
+        box(i * rowH() - scroller.scrollTop, rowH());
+    });
+
+    // Scrolled to the bottom of the EXPANDED list, which is the only way to
+    // reach the last row -- and the state the report came from.
+    scroller.scrollTop = 999;
+    expect(scroller.scrollTop).toBe(OPEN_H * 4 - VIEW);
+
+    const held = screen.getByText('Row d').parentElement!;
+    fireEvent.pointerDown(held, { clientX: 10, clientY: 65, button: 0 });
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 20 });
+    fireEvent.pointerUp(document, { clientX: 10, clientY: 20 });
+
+    // Collapsed, the four rows span 0..60 inside a 90px viewport, so the
+    // browser has clamped the scroll to 0 and the content mids are 7.5, 22.5,
+    // 37.5, 52.5. Releasing at 20 is past only the first of the others.
+    expect(onMove).toHaveBeenCalledTimes(1);
+    expect(onMove.mock.calls[0][1]).toBe(1);
+  });
+});

--- a/src/tests/components/dragCollapse.test.tsx
+++ b/src/tests/components/dragCollapse.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, test, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import {
+  RowDragArea,
+  DraggableRow,
+} from '../../components/home/rightpane/rowDrag/RowDragArea';
+import { setDragging } from '../../components/home/rightpane/rowDrag/dropRules';
+
+// KAN-153. Dragging a window folds every window shut, so a session of three
+// windows and sixty tabs fits on screen while it is being rearranged, and
+// unfolds them exactly as they were on release.
+//
+// NO STATE IS LIFTED AND NOTHING IS RESTORED. The collapse is a CSS rule keyed
+// on the drag kind, so each window's own open/closed state is never touched --
+// which is what makes "and it comes back how it was" require no bookkeeping at
+// all, and what makes it impossible to leave a window collapsed if a drag ends
+// in some way nobody anticipated.
+//
+// jsdom applies no stylesheet from App.css and resolves no cascade, so the
+// collapse itself cannot be observed here. What IS pinned is the two halves
+// that make it work: the rule exists and is scoped to a window drag, and the
+// attribute is published BEFORE the rows are measured. The visual result is a
+// browser claim and is checked there.
+
+const box = (top: number, height: number) =>
+  ({
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 200,
+    height,
+    width: 200,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+afterEach(() => {
+  document.documentElement.removeAttribute('data-dragging');
+  vi.restoreAllMocks();
+});
+
+describe('the published drag kind', () => {
+  test.each(['tab', 'window', 'session'] as const)('says %s', (kind) => {
+    setDragging(true, kind);
+    expect(document.documentElement.getAttribute('data-dragging')).toBe(kind);
+  });
+
+  test('and clears on release', () => {
+    setDragging(true, 'window');
+    setDragging(false);
+    expect(document.documentElement.hasAttribute('data-dragging')).toBe(false);
+  });
+
+  // Every existing rule is written `[data-dragging]` with no value, and an
+  // attribute selector matches whatever the value is -- so publishing a kind
+  // must not have quietly stopped the grabbing cursor or the hidden row actions
+  // matching. The rules themselves are asserted in dragStyles.test.ts, which
+  // runs in the project that can read CSS text.
+  test('CONTROL: a kinded attribute still matches the valueless selector', () => {
+    setDragging(true, 'window');
+    expect(document.documentElement.matches('[data-dragging]')).toBe(true);
+  });
+});
+
+describe('the collapse happens before the rows are measured', () => {
+  // THE ORDERING BUG THIS EXISTS TO PREVENT. Collapsing changes every row's
+  // height. The attribute is written straight to the DOM, so the
+  // getBoundingClientRect calls that follow flush style and layout and read the
+  // COLLAPSED boxes -- but only if the attribute is set FIRST. Measure first and
+  // every midpoint describes a layout that no longer exists, and every drop
+  // lands somewhere the user never pointed.
+  //
+  // Asserted by recording what the document looked like at the moment each row
+  // was measured, which is the only way to see an ordering from outside.
+  test('the drag kind is already published when each row is measured', () => {
+    const seenAtMeasure: (string | null)[] = [];
+
+    render(
+      <RowDragArea rowIds={['a', 'b']} onMove={() => {}} dragKind="window">
+        <DraggableRow rowId="a" index={0}>
+          <div>Row A</div>
+        </DraggableRow>
+        <DraggableRow rowId="b" index={1}>
+          <div>Row B</div>
+        </DraggableRow>
+      </RowDragArea>
+    );
+
+    ['Row A', 'Row B'].forEach((label, i) => {
+      const el = screen.getByText(label).parentElement!;
+      el.getBoundingClientRect = () => {
+        seenAtMeasure.push(
+          document.documentElement.getAttribute('data-dragging')
+        );
+        return box(i * 30, 30);
+      };
+    });
+
+    fireEvent.pointerDown(screen.getByText('Row A').parentElement!, {
+      clientX: 10,
+      clientY: 5,
+      button: 0,
+    });
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 20 });
+
+    expect(seenAtMeasure.length).toBeGreaterThan(0);
+    expect(seenAtMeasure.every((v) => v === 'window')).toBe(true);
+  });
+});

--- a/src/tests/components/dragCollapse.test.tsx
+++ b/src/tests/components/dragCollapse.test.tsx
@@ -200,3 +200,86 @@ describe('a drag that starts scrolled, on a list that collapses', () => {
     expect(onMove.mock.calls[0][1]).toBe(1);
   });
 });
+
+// KAN-156. THE SAME ORDERING RULE AT THE OTHER END OF THE DRAG. The rows were
+// measured in the collapsed layout, so the drop must be judged in it too --
+// before the drag kind is unpublished, not after.
+//
+// Unpublishing expands every window again, and reading scrollTop then forces
+// that layout. Measured in the popup on a twenty-window session, where the
+// FOLDED list still overflows so the scroll never reaches 0: scrollTop 1200
+// before the drag, 385 while folded, and read straight after unpublishing,
+// 1200 again -- the browser re-anchored the expanded list. Judged against that,
+// a window released mid-pane (around index 14) landed LAST.
+//
+// Every five-window probe missed it, because each one folded to scrollTop 0,
+// where there is nothing to re-anchor: "the folded list fits" is the new
+// "started from scrollTop 0". This fake reproduces the measured sequence,
+// nothing more: folded it reads the clamped offset, expanded it reads its
+// expanded one.
+describe('a drop on a list that is still scrolled while folded', () => {
+  const VIEW = 90;
+  const OPEN_H = 30;
+  const SHUT_H = 20;
+  const IDS = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+  test('is judged in the folded layout the rows were measured in', () => {
+    const onMove = vi.fn();
+    const { container } = render(
+      <div style={{ overflowY: 'auto' }}>
+        <RowDragArea rowIds={IDS} onMove={onMove} dragKind="window">
+          {IDS.map((id, i) => (
+            <DraggableRow key={id} rowId={id} index={i}>
+              <div>Row {id}</div>
+            </DraggableRow>
+          ))}
+        </RowDragArea>
+      </div>
+    );
+
+    const scroller = container.firstElementChild as HTMLElement;
+    const folded = () =>
+      document.documentElement.getAttribute('data-dragging') === 'window';
+    const rowH = () => (folded() ? SHUT_H : OPEN_H);
+    const max = () => Math.max(0, rowH() * IDS.length - VIEW);
+    let top = 0;
+    Object.defineProperty(scroller, 'clientHeight', {
+      value: VIEW,
+      configurable: true,
+    });
+    Object.defineProperty(scroller, 'scrollHeight', {
+      get: () => rowH() * IDS.length,
+      configurable: true,
+    });
+    Object.defineProperty(scroller, 'scrollTop', {
+      get: () => (folded() ? Math.min(top, max()) : top),
+      set: (v: number) => (top = Math.max(0, Math.min(v, max()))),
+      configurable: true,
+    });
+    scroller.getBoundingClientRect = () => box(0, VIEW);
+    IDS.forEach((id, i) => {
+      screen.getByText(`Row ${id}`).parentElement!.getBoundingClientRect = () =>
+        box(i * rowH() - scroller.scrollTop, rowH());
+    });
+
+    // Expanded: 180 of content in a 90 view, scrolled to the bottom.
+    scroller.scrollTop = 90;
+    // Row d's expanded box is content 90..120, so viewport 0..30.
+    const held = screen.getByText('Row d').parentElement!;
+    fireEvent.pointerDown(held, { clientX: 10, clientY: 15, button: 0 });
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 25 });
+
+    // Folded: 120 of content, so the scroll clamps to 30 -- NOT to 0, which is
+    // the whole point of this test.
+    expect(scroller.scrollTop).toBe(30);
+
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 5 });
+    fireEvent.pointerUp(document, { clientX: 10, clientY: 5 });
+
+    // Folded content mids are 10, 30, 50, 70, 90, 110. Released at viewport 5
+    // with the folded scroll of 30 is content 35: past a and b, so index 2.
+    // Judged after unfolding it reads 5 + 90 = 95, past a, b, c and e -- 4.
+    expect(onMove).toHaveBeenCalledTimes(1);
+    expect(onMove.mock.calls[0].slice(0, 2)).toEqual(['d', 2]);
+  });
+});

--- a/src/tests/components/dragDeadSpace.test.tsx
+++ b/src/tests/components/dragDeadSpace.test.tsx
@@ -1,0 +1,368 @@
+import { describe, expect, test, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import {
+  RowDragArea,
+  DraggableRow,
+} from '../../components/home/rightpane/rowDrag/RowDragArea';
+import TabGroupDetailsContainer from '../../components/home/rightpane/TabGroupDetailsContainer';
+import TabGroupEntryContainer from '../../components/home/leftpane/TabGroupEntryContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import type { RenderWithProvidersResult } from '../setup/renderWithProviders';
+import {
+  saveToTabContainerInternal,
+  selectTabContainer,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import {
+  setHasTabGroupsPermission,
+  setIsNotDirty,
+} from '../../redux/slices/globalStateSlice';
+
+// KAN-155. A release in the pane's empty space is a drop at the end it is past.
+//
+// Collapsing during a window drag (KAN-153) leaves the folded list occupying a
+// fraction of its pane -- measured, 190px of rows in a 417px pane -- so a
+// release at the bottom of the VIEW lands in dead space under the rows, and
+// isInsideList refused it. To the user the drag simply did nothing.
+//
+// The pane is the box the list lives in -- the nearest `overflow: auto` --
+// whether or not its content currently overflows. The first cut used the
+// scrolling ancestor, which only exists while the list overflows, and measured
+// in the popup that left a two-window session refusing exactly this release.
+//
+// jsdom applies no emotion stylesheet (every ancestor computes `overflow-y:
+// visible`) and has no layout, so the integration tests below set the pane's
+// overflow inline and give the rows and the pane real boxes. What is pinned is
+// the DECISION -- does this release commit, and at which index.
+
+const box = (top: number, height: number, left = 0, width = 200) =>
+  ({
+    top,
+    bottom: top + height,
+    left,
+    right: left + width,
+    height,
+    width,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+afterEach(() => {
+  document.documentElement.removeAttribute('data-dragging');
+  vi.restoreAllMocks();
+});
+
+const PANE_H = 200;
+const ROW_H = 30;
+
+// A pane 200px tall holding four 30px rows, so 80px of dead space sits under
+// them. The pane does NOT overflow: this is the short session, the case the
+// scrolling-ancestor version could not see.
+const Harness = ({
+  onMove,
+  clamp,
+  rowsTop = 0,
+}: {
+  onMove: (id: string, to: number) => void;
+  clamp: boolean;
+  rowsTop?: number;
+}) => {
+  const ids = ['a', 'b', 'c', 'd'];
+  return (
+    <div
+      data-testid="pane"
+      style={{ overflowY: 'auto' }}
+      ref={(el) => {
+        if (el) el.getBoundingClientRect = () => box(0, PANE_H);
+      }}
+    >
+      <RowDragArea
+        rowIds={ids}
+        onMove={onMove}
+        dragKind="window"
+        clampDropToEnds={clamp}
+      >
+        {ids.map((id, i) => (
+          <DraggableRow key={id} rowId={id} index={i}>
+            <div
+              ref={(el) => {
+                // The DraggableRow node is what the engine measures.
+                if (el?.parentElement)
+                  el.parentElement.getBoundingClientRect = () =>
+                    box(rowsTop + i * ROW_H, ROW_H);
+              }}
+            >
+              Row {id}
+            </div>
+          </DraggableRow>
+        ))}
+      </RowDragArea>
+    </div>
+  );
+};
+
+const drag = (label: string, fromY: number, to: { x?: number; y: number }) => {
+  const node = screen.getByText(label).parentElement!;
+  fireEvent.pointerDown(node, { clientX: 10, clientY: fromY, button: 0 });
+  fireEvent.pointerMove(document, { clientX: 10, clientY: fromY + 10 });
+  fireEvent.pointerMove(document, { clientX: to.x ?? 10, clientY: to.y });
+  fireEvent.pointerUp(document, { clientX: to.x ?? 10, clientY: to.y });
+};
+
+describe('a release in the dead space of its own pane', () => {
+  test('below the rows, it lands last', () => {
+    const onMove = vi.fn();
+    render(<Harness onMove={onMove} clamp />);
+
+    // Rows end at 120; 190 is deep in the dead space, still inside the pane.
+    drag('Row a', 15, { y: 190 });
+
+    expect(onMove).toHaveBeenCalledTimes(1);
+    expect(onMove.mock.calls[0].slice(0, 2)).toEqual(['a', 3]);
+  });
+
+  test('above the rows, it lands first', () => {
+    const onMove = vi.fn();
+    // Rows pushed down to start at 80, leaving dead space above them.
+    render(<Harness onMove={onMove} clamp rowsTop={80} />);
+
+    drag('Row d', 80 + 3 * ROW_H + 15, { y: 5 });
+
+    expect(onMove).toHaveBeenCalledTimes(1);
+    expect(onMove.mock.calls[0].slice(0, 2)).toEqual(['d', 0]);
+  });
+
+  // THE CONTROL that the clamp is what commits it. Without it the tests above
+  // could be passing on isInsideList's own slack -- and 190 is 70px past the
+  // last row, far beyond the half-row it allows.
+  test('CONTROL: without the opt-in, the same release is refused', () => {
+    const onMove = vi.fn();
+    render(<Harness onMove={onMove} clamp={false} />);
+
+    drag('Row a', 15, { y: 190 });
+
+    expect(onMove).not.toHaveBeenCalled();
+  });
+
+  // The pane is the bound, not the whole screen. A release below the pane or
+  // beside it is somewhere else -- another list, the header, the save row --
+  // and the drag must still come back as nothing.
+  test('CONTROL: released below the pane, it is refused', () => {
+    const onMove = vi.fn();
+    render(<Harness onMove={onMove} clamp />);
+
+    drag('Row a', 15, { y: PANE_H + 40 });
+
+    expect(onMove).not.toHaveBeenCalled();
+  });
+
+  // Above the pane is the session header and the save row in the real popup,
+  // and a release there must not land the row first.
+  test('CONTROL: released above the pane, it is refused', () => {
+    const onMove = vi.fn();
+    // Pane spans 0..200, so y=-40 is above it -- and past isInsideList's
+    // half-row of slack above the first row at 0.
+    render(<Harness onMove={onMove} clamp />);
+
+    drag('Row d', 3 * ROW_H + 15, { y: -40 });
+
+    expect(onMove).not.toHaveBeenCalled();
+  });
+
+  test('CONTROL: released beside the pane, it is refused', () => {
+    const onMove = vi.fn();
+    render(<Harness onMove={onMove} clamp />);
+
+    drag('Row a', 15, { x: 260, y: 190 });
+
+    expect(onMove).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The wiring. Each engine test above would pass with the opt-in removed from
+// every real list, or turned on for the tab lists -- which is the half that
+// matters, because that hands back KAN-132.
+
+const win = (id: string, n: number) => ({
+  windowId: id,
+  windowHeight: 800,
+  windowWidth: 1200,
+  windowOffsetTop: 0,
+  windowOffsetLeft: 0,
+  tabCount: n,
+  title: `Window ${id}`,
+  tabs: Array.from({ length: n }, (_, i) => ({
+    tabId: `${id}-t${i}`,
+    favicon: '',
+    title: `${id} tab ${i}`,
+    url: `https://${id}-${i}.test`,
+  })),
+});
+
+const renderDetails = () =>
+  renderWithProviders(<TabGroupDetailsContainer />, {
+    seedStore: (store) => {
+      store.dispatch(setHasTabGroupsPermission(false));
+      store.dispatch(
+        saveToTabContainerInternal({
+          tabGroupId: 'g1',
+          title: 'Session',
+          createdTime: '2026-09-07 09:00:00',
+          windowCount: 2,
+          tabCount: 5,
+          isAutoSave: false,
+          isSelected: true,
+          windows: [win('wA', 3), win('wB', 2)],
+        })
+      );
+      store.dispatch(selectTabContainer('g1'));
+      store.dispatch(setIsNotDirty());
+    },
+  });
+
+// The pane is the component's own root: the bordered `overflow: auto` box.
+// Its overflow is set inline because jsdom will not compute the emotion class.
+const mountPane = (container: HTMLElement, height = 400) => {
+  const pane = container.firstElementChild as HTMLElement;
+  pane.style.overflowY = 'auto';
+  pane.getBoundingClientRect = () => box(0, height);
+  return pane;
+};
+
+const nodeIn = (container: HTMLElement, id: string) =>
+  container.querySelector<HTMLElement>(`[data-drag-row-id="${id}"]`)!;
+
+const dragFrom = (from: Element, startY: number, endY: number) => {
+  fireEvent.pointerDown(from, { clientX: 10, clientY: startY, button: 0 });
+  fireEvent.pointerMove(document, { clientX: 10, clientY: startY + 10 });
+  fireEvent.pointerMove(document, { clientX: 10, clientY: endY });
+  fireEvent.pointerUp(document, { clientX: 10, clientY: endY });
+};
+
+const windowOrder = (store: RenderWithProvidersResult['store']) =>
+  store
+    .getState()
+    .tabContainerDataState.tabGroups[0].windows.map((w) => w.windowId);
+
+const tabsOf = (store: RenderWithProvidersResult['store'], i: number) =>
+  store
+    .getState()
+    .tabContainerDataState.tabGroups[0].windows[i].tabs.map((t) => t.tabId);
+
+describe('the window list takes a release in its dead space', () => {
+  test('a window released under the folded rows moves to the end', async () => {
+    const { container, store } = await renderDetails();
+    mountPane(container);
+    // Folded, each window is just its header: 0..40 and 40..80.
+    nodeIn(container, 'wA').getBoundingClientRect = () => box(0, 40);
+    nodeIn(container, 'wB').getBoundingClientRect = () => box(40, 40);
+    const handle = nodeIn(container, 'wA').querySelector(
+      '[data-window-drag-handle]'
+    )!;
+
+    dragFrom(handle, 20, 380);
+
+    expect(windowOrder(store)).toEqual(['wB', 'wA']);
+  });
+});
+
+// THE CONTROL THIS WHOLE CHANGE HANGS ON. A tab list sits in the SAME pane as
+// the window list around it, so for a tab the pane test passes just as easily
+// -- and a tab released there has left its window. Committing that is the
+// KAN-132 saturation: the tab drops to the bottom of the window it came from,
+// and the session is dirtied for a cloud write. See dragOutsideItsListIsNoOp.
+//
+// That test cannot catch the clamp being turned on for tabs, because in it no
+// pane is ever found, so "released in the pane" is never true. This one gives
+// the release a real pane to be inside.
+describe('a tab list still refuses a release outside its own window', () => {
+  test.each([
+    ['over the next window', 235],
+    ['in the dead space under everything', 380],
+  ])('%s', async (_where, endY) => {
+    const { container, store } = await renderDetails();
+    mountPane(container);
+    // Window A's tabs tile [0,60); window B's tile [200,240).
+    ['wA-t0', 'wA-t1', 'wA-t2'].forEach((id, i) => {
+      nodeIn(container, id).getBoundingClientRect = () => box(i * 20, 20);
+    });
+    ['wB-t0', 'wB-t1'].forEach((id, i) => {
+      nodeIn(container, id).getBoundingClientRect = () => box(200 + i * 20, 20);
+    });
+
+    dragFrom(nodeIn(container, 'wA-t0'), 10, endY);
+
+    expect(tabsOf(store, 0)).toEqual(['wA-t0', 'wA-t1', 'wA-t2']);
+    expect(store.getState().globalState.isDirty).toBe(false);
+  });
+
+  // And the positive control, or a tab area that refused everything would
+  // pass both of the above.
+  test('CONTROL: the same tab still reorders inside its window', async () => {
+    const { container, store } = await renderDetails();
+    mountPane(container);
+    ['wA-t0', 'wA-t1', 'wA-t2'].forEach((id, i) => {
+      nodeIn(container, id).getBoundingClientRect = () => box(i * 20, 20);
+    });
+
+    dragFrom(nodeIn(container, 'wA-t0'), 10, 55);
+
+    expect(tabsOf(store, 0)).toEqual(['wA-t1', 'wA-t2', 'wA-t0']);
+  });
+});
+
+describe('the session list takes a release in its dead space', () => {
+  const session = (id: string, createdAt: number) => ({
+    tabGroupId: id,
+    title: id.toUpperCase(),
+    createdTime: '2026-09-09 12:00:00',
+    createdAt,
+    windowCount: 1,
+    tabCount: 1,
+    isAutoSave: false,
+    isSelected: false,
+    windows: [win(`${id}-w`, 1)],
+  });
+
+  test('a session released under the list moves to the end', async () => {
+    const T0 = Date.UTC(2026, 8, 9, 12, 0, 0);
+    const { container, store } = await renderWithProviders(
+      <TabGroupEntryContainer />,
+      {
+        seedStore: (s) => {
+          s.dispatch(setHasTabGroupsPermission(false));
+          // Pinned per save -- see sessionDragReorder.test.tsx (KAN-141).
+          vi.useFakeTimers();
+          try {
+            for (const [id, at] of [
+              ['a', T0 - 2],
+              ['b', T0 - 1],
+              ['c', T0],
+            ] as const) {
+              vi.setSystemTime(at);
+              s.dispatch(saveToTabContainerInternal(session(id, at)));
+            }
+          } finally {
+            vi.useRealTimers();
+          }
+          s.dispatch(setIsNotDirty());
+        },
+      }
+    );
+    const order = () =>
+      store.getState().tabContainerDataState.tabGroups.map((g) => g.tabGroupId);
+    // The pane renders newest first, so this is also the rendered order.
+    expect(order()).toEqual(['c', 'b', 'a']);
+
+    mountPane(container);
+    ['c', 'b', 'a'].forEach((id, i) => {
+      nodeIn(container, id).getBoundingClientRect = () => box(i * 40, 40);
+    });
+
+    dragFrom(nodeIn(container, 'c'), 20, 380);
+
+    expect(order()).toEqual(['b', 'a', 'c']);
+  });
+});

--- a/src/tests/components/dragRestoresScroll.test.tsx
+++ b/src/tests/components/dragRestoresScroll.test.tsx
@@ -1,0 +1,270 @@
+import { describe, expect, test, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import {
+  RowDragArea,
+  DraggableRow,
+} from '../../components/home/rightpane/rowDrag/RowDragArea';
+import TabGroupDetailsContainer from '../../components/home/rightpane/TabGroupDetailsContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  saveToTabContainerInternal,
+  selectTabContainer,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import {
+  setHasTabGroupsPermission,
+  setIsNotDirty,
+} from '../../redux/slices/globalStateSlice';
+
+// KAN-157. A window drag that commits nothing puts the view back.
+//
+// Folding the windows shut makes a short session fit its pane, and the browser
+// clamps scrollTop to fit (KAN-154). A committed drop then scrolls the dropped
+// row into view (KAN-155) -- but a drag that commits nothing had nothing to put
+// it back. Measured in the popup, five windows scrolled to 300: Escape, or a
+// release outside the pane, left scrollTop at 0 and the held window at y=589,
+// below a pane ending at 541. A drag that changed nothing changed what you were
+// looking at.
+//
+// Opt-in, and on only for the window list: the collapse is the only thing that
+// destroys the position, and a tab drag folds nothing. Restoring there would
+// only undo auto-scroll the user did on purpose.
+//
+// jsdom neither folds nor clamps, so the scroller below does both: it clamps
+// DESTRUCTIVELY on read while the window-drag flag is set, which is what the
+// popup measured for a short session (300 -> 0, and still 0 after unfolding).
+
+const box = (top: number, height: number) =>
+  ({
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 200,
+    height,
+    width: 200,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+afterEach(() => {
+  document.documentElement.removeAttribute('data-dragging');
+  vi.restoreAllMocks();
+});
+
+const VIEW = 90;
+const OPEN_H = 30;
+const SHUT_H = 15;
+const IDS = ['a', 'b', 'c', 'd'];
+
+// Returns the writes made to scrollTop, so a test can tell "restored" from
+// "happened to be left there".
+const mountFoldingScroller = (el: HTMLElement) => {
+  const folded = () =>
+    document.documentElement.getAttribute('data-dragging') === 'window';
+  const rowH = () => (folded() ? SHUT_H : OPEN_H);
+  const max = () => Math.max(0, rowH() * IDS.length - VIEW);
+  let top = 0;
+  const writes: number[] = [];
+  Object.defineProperty(el, 'clientHeight', {
+    value: VIEW,
+    configurable: true,
+  });
+  Object.defineProperty(el, 'scrollHeight', {
+    get: () => rowH() * IDS.length,
+    configurable: true,
+  });
+  Object.defineProperty(el, 'scrollTop', {
+    get: () => (top = Math.min(top, max())),
+    set: (v: number) => {
+      writes.push(v);
+      top = Math.max(0, Math.min(v, max()));
+    },
+    configurable: true,
+  });
+  el.getBoundingClientRect = () => box(0, VIEW);
+  return { rowH, writes };
+};
+
+const Harness = ({
+  restore,
+  onMove = () => {},
+}: {
+  restore: boolean;
+  onMove?: () => void;
+}) => (
+  <div data-testid="pane" style={{ overflowY: 'auto' }}>
+    <RowDragArea
+      rowIds={IDS}
+      onMove={onMove}
+      dragKind="window"
+      restoreScrollIfNoDrop={restore}
+    >
+      {IDS.map((id, i) => (
+        <DraggableRow key={id} rowId={id} index={i}>
+          <div>Row {id}</div>
+        </DraggableRow>
+      ))}
+    </RowDragArea>
+  </div>
+);
+
+// Mounted, scrolled to the bottom of the EXPANDED list (30), with row b's
+// header picked up -- visible there at viewport 0..30.
+const setUp = (restore: boolean, onMove?: () => void) => {
+  render(<Harness restore={restore} onMove={onMove} />);
+  const scroller = screen.getByTestId('pane');
+  const { rowH, writes } = mountFoldingScroller(scroller);
+  IDS.forEach((id, i) => {
+    screen.getByText(`Row ${id}`).parentElement!.getBoundingClientRect = () =>
+      box(i * rowH() - scroller.scrollTop, rowH());
+  });
+  scroller.scrollTop = 999;
+  expect(scroller.scrollTop).toBe(OPEN_H * IDS.length - VIEW);
+
+  fireEvent.pointerDown(screen.getByText('Row b').parentElement!, {
+    clientX: 10,
+    clientY: 15,
+    button: 0,
+  });
+  fireEvent.pointerMove(document, { clientX: 10, clientY: 30 });
+  // The premise: folding clamped the scroll away. Without this, a restore that
+  // never ran would pass every test below.
+  expect(scroller.scrollTop).toBe(0);
+  writes.length = 0;
+  return { scroller, writes };
+};
+
+describe('a window drag that commits nothing puts the view back', () => {
+  test('after Escape, the scroll is where it was when the row was picked up', () => {
+    const { scroller } = setUp(true);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(scroller.scrollTop).toBe(30);
+  });
+
+  test('after a release outside the pane, likewise', () => {
+    const { scroller } = setUp(true);
+
+    // Below the pane: refused.
+    fireEvent.pointerMove(document, { clientX: 10, clientY: VIEW + 40 });
+    fireEvent.pointerUp(document, { clientX: 10, clientY: VIEW + 40 });
+
+    expect(scroller.scrollTop).toBe(30);
+  });
+
+  // CONTROL. A committed drop has a new place to show, and KAN-155 shows it by
+  // scrolling the dropped row into view on the next frame. Restoring the old
+  // position as well would fight that. Asserted on WRITES, because in this
+  // fake a restore and "left at 0" are otherwise told apart only by value.
+  test('CONTROL: a committed drop does not restore', () => {
+    const onMove = vi.fn();
+    const { writes } = setUp(true, onMove);
+
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 50 });
+    fireEvent.pointerUp(document, { clientX: 10, clientY: 50 });
+
+    expect(onMove).toHaveBeenCalledTimes(1);
+    expect(writes).toEqual([]);
+  });
+
+  // CONTROL. Off by default: every other list keeps the scroll it has.
+  test('CONTROL: without the opt-in, Escape leaves the scroll alone', () => {
+    const { writes } = setUp(false);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(writes).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The wiring: on for the window list, off for the tab lists inside it.
+
+const win = (id: string, n: number) => ({
+  windowId: id,
+  windowHeight: 800,
+  windowWidth: 1200,
+  windowOffsetTop: 0,
+  windowOffsetLeft: 0,
+  tabCount: n,
+  title: `Window ${id}`,
+  tabs: Array.from({ length: n }, (_, i) => ({
+    tabId: `${id}-t${i}`,
+    favicon: '',
+    title: `${id} tab ${i}`,
+    url: `https://${id}-${i}.test`,
+  })),
+});
+
+const renderDetails = async () => {
+  const result = await renderWithProviders(<TabGroupDetailsContainer />, {
+    seedStore: (store) => {
+      store.dispatch(setHasTabGroupsPermission(false));
+      store.dispatch(
+        saveToTabContainerInternal({
+          tabGroupId: 'g1',
+          title: 'Session',
+          createdTime: '2026-09-07 09:00:00',
+          windowCount: 2,
+          tabCount: 4,
+          isAutoSave: false,
+          isSelected: true,
+          windows: [win('wA', 2), win('wB', 2)],
+        })
+      );
+      store.dispatch(selectTabContainer('g1'));
+      store.dispatch(setIsNotDirty());
+    },
+  });
+  // The component's root is the bordered `overflow: auto` pane. jsdom will not
+  // compute the emotion class, so its overflow and metrics are set here.
+  const pane = result.container.firstElementChild as HTMLElement;
+  pane.style.overflowY = 'auto';
+  const { writes } = mountFoldingScroller(pane);
+  const node = (id: string) =>
+    result.container.querySelector<HTMLElement>(`[data-drag-row-id="${id}"]`)!;
+  return { ...result, pane, writes, node };
+};
+
+describe('the real lists', () => {
+  test('the window list restores the scroll after Escape', async () => {
+    const { pane, node } = await renderDetails();
+    node('wA').getBoundingClientRect = () => box(0, 30);
+    node('wB').getBoundingClientRect = () => box(30, 30);
+    pane.scrollTop = 30;
+    const handle = node('wA').querySelector('[data-window-drag-handle]')!;
+
+    fireEvent.pointerDown(handle, { clientX: 10, clientY: 15, button: 0 });
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 30 });
+    expect(pane.scrollTop).toBe(0);
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(pane.scrollTop).toBe(30);
+  });
+
+  // A tab drag folds nothing, so there is no lost position to put back -- only
+  // auto-scroll the user did while holding the tab, which is theirs to keep.
+  // Simulated by moving the scroll mid-drag.
+  test('CONTROL: a tab list leaves the scroll alone after Escape', async () => {
+    const { pane, node, writes } = await renderDetails();
+    ['wA-t0', 'wA-t1'].forEach((id, i) => {
+      node(id).getBoundingClientRect = () => box(i * 20, 20);
+    });
+    pane.scrollTop = 30;
+
+    fireEvent.pointerDown(node('wA-t0'), {
+      clientX: 10,
+      clientY: 10,
+      button: 0,
+    });
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 25 });
+    pane.scrollTop = 10;
+    writes.length = 0;
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(writes).toEqual([]);
+    expect(pane.scrollTop).toBe(10);
+  });
+});

--- a/src/tests/config/dragStyles.test.ts
+++ b/src/tests/config/dragStyles.test.ts
@@ -59,3 +59,32 @@ describe('the drag stylesheet rules', () => {
     expect(flat).not.toMatch(/(^|})\s*\[data-row-actions\] \{[^}]*opacity: 0/);
   });
 });
+
+// KAN-153. Dragging a WINDOW folds every window shut so the whole session fits
+// on screen while it is being rearranged.
+//
+// A stylesheet rule rather than lifted React state, and that is the design: no
+// component's open/closed state is touched, so "it comes back exactly how it
+// was" needs no bookkeeping and cannot be left half-applied by a drag that ends
+// in an unanticipated way.
+describe('the window-drag collapse rule', () => {
+  test('folds window tab lists away while a window is dragged', () => {
+    expect(flat).toContain(
+      "[data-dragging='window'] [data-window-tabs] { display: none !important; }"
+    );
+  });
+
+  // THE SCOPE IS THE POINT. `[data-dragging]` matches whatever the value is, so
+  // an unscoped rule would fire during a TAB drag too and take the very rows
+  // being reordered out from under the pointer.
+  test('and is scoped, so a tab drag does not hide its own rows', () => {
+    expect(flat).not.toContain('[data-dragging] [data-window-tabs]');
+  });
+
+  // The control for that scoping: the rules that SHOULD apply to every kind are
+  // still written without a value, and an attribute selector matches any value.
+  test('CONTROL: the kind-agnostic rules stay kind-agnostic', () => {
+    expect(flat).toContain('[data-dragging] * {');
+    expect(flat).toContain('[data-dragging] [data-row-actions] {');
+  });
+});


### PR DESCRIPTION
## What

Justine: dragging a window should collapse the windows so rearranging is easier, and put them back how they were on release.

Stacked on **#246** (auto-scroll), which touches the same measurement path.

## No state is lifted, and nothing is restored

The obvious implementation pulls `windowOpenState` out of `WindowEntryContainer`'s local `useState(true)`, overrides every window during the drag, and puts them back. That's three new problems: a store for view state, a restore step, and a way for a drag that ends unexpectedly to leave a window collapsed forever.

This is a stylesheet rule keyed on the drag instead:

```css
[data-dragging='window'] [data-window-tabs] { display: none !important; }
```

No component's open/closed state is ever touched — so "it comes back exactly how it was" needs **no bookkeeping**, and a window the user collapsed by hand is still collapsed afterwards, because nothing changed it.

## The document flag now carries the kind

`setDragging` published a valueless `data-dragging` shared by all three areas — so an unscoped rule would fire during a **tab** drag and hide the very rows being reordered. It now publishes `tab`, `window` or `session`, supplied by the caller via a new `dragKind` prop; the area still has no idea what its rows represent, deliberately.

Existing `[data-dragging]` rules match any value. That's asserted as a control rather than assumed.

## Ordering is the subtle part

Rows are measured once, synchronously, at activation — and collapsing changes every row's height. So the attribute is written **before** the measurement: `setAttribute` goes straight to the DOM, so the `getBoundingClientRect` calls that follow flush style and layout and read the *collapsed* boxes. Measure first and every midpoint describes a layout that no longer exists.

Two consequences handled with it:

- **The auto-scroll limit is re-read** after the collapse. The one captured at pointer-down describes the expanded content; scrolling to that would run far past the end of a list a third the size.
- **The grab is re-anchored** to the held row's centre, since collapsing moves every row out from under the pointer. The original grab offset was measured against a row that no longer exists at that height.

## Tests (KAN-153 alone)

9 new. 1238 passed at the time, 64 e2e, tsc clean, lint 0 errors.

```
measure before publishing the kind  → 1 failed  ✓
kind not published                  → 4 failed  ✓
collapse rule unscoped              → 2 failed  ✓
collapse rule removed               → 1 failed  ✓
```

The stylesheet assertions had to move to the `unit` project: vitest stubs CSS imports in `components` and the stub swallows `?raw`, so `appCss` came back as `''` and my assertions passed against nothing. Same trap `dragStyles.test.ts` already documents — I walked into it anyway.

## Verified live

Five-window session, one window collapsed by hand first:

```
before:  788px content, scrollable
during:  416px, NOT scrollable — the whole session fits, 0 tab lists rendered
after:   788px restored, 4 expanded, hand-collapsed one STILL collapsed
```

Control — a **tab** drag: flag reads `tab`, all four tab lists stay visible.

## Found before merge: KAN-154 to KAN-157

Four defects, all introduced by this PR and caught before merge, so none shipped. Each one read a coordinate from the wrong one of two layouts, folded or unfolded, and each was invisible to jsdom, which has neither layout nor scrolling.

| | defect | measured | fix |
|---|---|---|---|
| **KAN-154** | only windows reachable at scrollTop 0 could be dragged | folding clamps scrollTop 404 → 0; the held row flew to y=-31 and the drop was refused | re-read the scroll origin after the collapse |
| **KAN-155** | releasing below the folded rows did nothing, and a dropped window ended up out of sight | 190px of rows in a 417px pane; the release landed in dead space | opt-in `clampDropToEnds`: a release anywhere in the list's pane lands at the end it is past. Then follow the dropped row |
| **KAN-156** | in a long session a dropped window landed in the wrong place | 20 windows: scrollTop 1200 → 385 folded → 1200 read after unfolding; preview said 14, landed 19 | judge the drop before unpublishing the drag kind |
| **KAN-157** | a drag that commits nothing left the view at the top | Escape from 300 ended at 0, held window at y=589 below a 124–541 pane | opt-in `restoreScrollIfNoDrop`: put back the pointer-down scroll |

**`clampDropToEnds` is on for the window and session lists and off for the tab lists, on purpose.** `isInsideList` is what stops a tab dragged out of its window from saturating at the bottom of the window it came from (KAN-132). A tab released in the same pane, outside its window, must still be refused, and a test pins that. The existing KAN-132 test can't: in it no pane is ever found, so it passes with the opt-in switched on for tabs.

**The pane is the nearest `overflow: auto` box whether or not it overflows.** The first cut used the scrolling ancestor, and a two-window session, which never scrolls, still refused exactly the release it was for.

**`restoreScrollIfNoDrop` is on for the window list only.** The collapse is the only thing that destroys the position. A tab drag folds nothing, and restoring there would undo auto-scroll the user did on purpose. It restores from its own `scrollTopAtPress`: `startScrollTop` is re-read after the collapse (KAN-154), and restoring to it restores to 0.

KAN-154 and KAN-156 were missed the same way: probes started at scrollTop 0, and then from sessions that folded to scrollTop 0, where the browser has nothing to re-anchor. "The folded list fits" hides the same bugs that "started from scrollTop 0" does.

## Tests

**1260 pass**, **68 e2e pass** (4 new in `e2e/window-drag.spec.ts`, the first drag spec in the real popup), tsc clean, lint 0 errors.

`e2e/window-drag.spec.ts` starts every drag scrolled where the session can scroll. It reads "where the user pointed" off the drag preview at the instant of release and requires the landed index to match.

```
vitest mutants (KAN-155/156)      10 of 10 killed, incl. clampDropToEnds switched on for the tab list
follow-the-dropped-row mutants     3 of 3
vitest mutants (KAN-157)           6 of 6, incl. restoring to the post-collapse origin
mutant BUILDS against the e2e      4 of 4, each failing only the test written for it
```

## Verified live (Playwright, built artifact)

```
5 windows @300, top visible window -> bottom of view   lands last = preview, header visible
2 windows (never scrolls), same release                lands last            (refused before)
20 windows @1200, released mid-pane                    preview 14, landed 14 (landed 19 before)
tab released in the pane outside its window            refused, tabs unchanged
released above / below / beside the pane               refused, scroll back to 300, header visible
Escape @300                                            scroll back to 300    (0 before)
Escape, 20 windows @1200                               1200 (the browser re-anchors this one itself)
```

Still open, not in this PR: on a refused release the preview still shows a landing slot before nothing happens. Noted on KAN-157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
