### PR TITLE
Preview only what the release will do, and keep a drag alive through a sync (KAN-158, KAN-159)

### DIFF
--- a/e2e/window-drag.spec.ts
+++ b/e2e/window-drag.spec.ts
@@ -201,12 +201,20 @@ test.describe('dragging a window from a scrolled position', () => {
     const page = await openSession(context, extensionId, 5, 6);
     const pane = await scrollPaneAndRecord(page, 300);
     const grab = await topVisibleHeader(page, pane);
+    const from = (await storedOrder(page)).indexOf(grab.id);
 
     await dragTo(page, grab, pane.top - 30);
     // Long enough for a commit to have been written, were there one.
     await page.waitForTimeout(300);
 
     expect(await storedOrder(page)).toEqual(['w0', 'w1', 'w2', 'w3', 'w4']);
+    // KAN-158: and the preview said so. Before the fix it opened a gap at the
+    // TOP here -- promising a move to index 0 that the release then refused.
+    expect(
+      await page.evaluate(
+        () => (window as unknown as { __preview: number | null }).__preview
+      )
+    ).toBe(from);
     expect(await paneState(page, grab.id)).toEqual({
       scrollTop: 300,
       headerVisible: true,

--- a/src/components/home/rightpane/TabGroupDetailsContainer.tsx
+++ b/src/components/home/rightpane/TabGroupDetailsContainer.tsx
@@ -59,11 +59,14 @@ export default function TabGroupDetailsContainer() {
   // Memoized, and ABOVE the early return with the other hooks -- a hook below
   // it would change the hook count between the nothing-selected and selected
   // renders and React would throw on the transition. Both of these feed
-  // RowDragArea's effect deps, and a fresh identity every render re-binds its
-  // window listeners; the cleanup that runs on each re-bind clears the
-  // `grabbing` cursor, so an unmemoized value drops the drag cursor whenever
-  // anything else re-renders this pane mid-drag. WindowEntryContainer
+  // RowDragArea's effect deps, and a fresh identity re-binds its window
+  // listeners -- cheap, but pointless on every render. WindowEntryContainer
   // memoizes its own tabIds and handleMove for the same reason.
+  //
+  // No longer load-bearing for correctness. The re-bind used to clear the drag
+  // flag mid-drag, and this memo was the mitigation -- which only held while
+  // the session object survived. A sync replaces it, and the flag went anyway
+  // (KAN-159). The flag is now cleared on unmount alone.
   const windowIds = useMemo(
     () => selectedTabGroup?.windows.map((w) => w.windowId) ?? [],
     [selectedTabGroup]

--- a/src/components/home/rightpane/rowDrag/RowDragArea.tsx
+++ b/src/components/home/rightpane/rowDrag/RowDragArea.tsx
@@ -244,8 +244,46 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
     const contentY = (l: NonNullable<typeof live.current>, clientY: number) =>
       clientY + (l.scroller?.scrollTop ?? 0);
 
-    const update = (l: NonNullable<typeof live.current>) => {
-      const others = l.rects.filter((r) => r.id !== l.rowId);
+    // Where a release at the pointer's current position lands, or undefined
+    // where it would be refused.
+    //
+    // THE ONE DECISION, used by both the preview and the release (KAN-158).
+    // The preview used to count midpoints on its own, so it always named some
+    // index -- and where the release was refused (above, below or beside the
+    // pane; a tab outside its window) it opened a gap and promised a move that
+    // never came. Two copies of this rule are two chances to disagree.
+    //
+    // Reads the pane's box, so like everything here it must run while the
+    // drag's own layout stands -- see judgeDrop.
+    const landingIndex = (
+      l: NonNullable<typeof live.current>
+    ): number | undefined => {
+      // Content space, matching how the rects were measured. Using the raw
+      // viewport y here would misjudge both the containment test and the
+      // landing index by however far the list had auto-scrolled.
+      const dropY = contentY(l, l.lastY);
+
+      // A release in the empty space below (or above) the rows, but still
+      // inside the pane being dragged in. The index needs no special case: it
+      // counts the midpoints the pointer has passed, so a release under every
+      // row already comes out as the last index, and one above them as 0.
+      //
+      // l.pane is only set when the list OPTED IN, never on the geometry alone
+      // -- for a nested tab list this same release means "dragged out of this
+      // window", and committing it is the KAN-132 defect isInsideList was
+      // written to stop.
+      const paneBox = l.pane?.getBoundingClientRect();
+      const releasedInPane =
+        paneBox !== undefined &&
+        l.lastY >= paneBox.top &&
+        l.lastY <= paneBox.bottom &&
+        l.lastX >= paneBox.left &&
+        l.lastX <= paneBox.right;
+
+      if (!isInsideList(l.rects, dropY, l.height / 2) && !releasedInPane) {
+        return undefined;
+      }
+
       // The count of rows whose midpoint the pointer has passed IS the index
       // the row lands at, because that count indexes the list with the held
       // row already lifted out of it.
@@ -254,8 +292,14 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
       // every row between its old and new slots by ITS OWN height, whatever
       // theirs are, and the landing index comes from each row's measured
       // midpoint rather than from any assumed row size.
-      const y = contentY(l, l.lastY);
-      const toIndex = others.filter((r) => y > r.mid).length;
+      const others = l.rects.filter((r) => r.id !== l.rowId);
+      return others.filter((r) => dropY > r.mid).length;
+    };
+
+    const update = (l: NonNullable<typeof live.current>) => {
+      // Where the release would be refused, preview the row going back where
+      // it came from: no row steps aside, and its own slot stays open.
+      const toIndex = landingIndex(l) ?? l.fromIndex;
 
       setDrag({
         rowId: l.rowId,
@@ -412,37 +456,16 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
     // folded and 1200 straight after unpublishing, and a window released
     // mid-pane landed last. The mirror of the rule at activation, where the
     // kind is published BEFORE measuring.
+    //
+    // The landing decision itself is landingIndex, shared with the preview, so
+    // what the user was shown and what happens cannot differ (KAN-158).
     const judgeDrop = (
       l: NonNullable<typeof live.current>
     ): { toIndex: number; dropTargetId: string | undefined } | undefined => {
-      // Content space, matching how the rects were measured. Using the raw
-      // viewport y here would misjudge both the containment test and the
-      // landing index by however far the list had auto-scrolled.
-      const dropY = contentY(l, l.lastY);
-
-      // A release in the empty space below (or above) the rows, but still
-      // inside the pane being dragged in. toIndex needs no special case: it
-      // counts the midpoints the pointer has passed, so a release under every
-      // row already comes out as the last index, and one above them as 0.
-      //
-      // l.pane is only set when the list OPTED IN, never on the geometry alone
-      // -- for a nested tab list this same release means "dragged out of this
-      // window", and committing it is the KAN-132 defect isInsideList was
-      // written to stop.
-      const paneBox = l.pane?.getBoundingClientRect();
-      const releasedInPane =
-        paneBox !== undefined &&
-        l.lastY >= paneBox.top &&
-        l.lastY <= paneBox.bottom &&
-        l.lastX >= paneBox.left &&
-        l.lastX <= paneBox.right;
-
-      if (!isInsideList(l.rects, dropY, l.height / 2) && !releasedInPane) {
-        return undefined;
-      }
-      const others = l.rects.filter((r) => r.id !== l.rowId);
+      const toIndex = landingIndex(l);
+      if (toIndex === undefined) return undefined;
       return {
-        toIndex: others.filter((r) => dropY > r.mid).length,
+        toIndex,
         dropTargetId: resolveDrop?.(containerRef.current, l.lastX, l.lastY),
       };
     };
@@ -533,11 +556,37 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
       window.removeEventListener('pointercancel', onCancel);
       window.removeEventListener('keydown', onKey);
       window.removeEventListener('click', onClickCapture, true);
-      // A drag interrupted by unmount must not leave the document stuck in
-      // `grabbing`.
-      setDragging(false);
+      // NOT setDragging(false) -- see the unmount effect below (KAN-159). This
+      // cleanup runs on every change to the deps as well as on unmount, and a
+      // drag in flight must survive the listeners being re-bound.
     };
   }, [rowIds, onMove, resolveDrop, dragKind, restoreScrollIfNoDrop]);
+
+  // A drag interrupted by UNMOUNT must not leave the document stuck in a drag.
+  //
+  // Its own effect with no deps, so it runs on unmount and nothing else
+  // (KAN-159). This used to live in the listener effect's cleanup above, which
+  // React also runs whenever rowIds, onMove or the rest change identity -- and
+  // a store update that rebuilds the session data (a sync landing) changes them
+  // for every list at once. Measured in the popup: the flag vanished mid-drag
+  // with the row still held, the windows unfolded under the pointer, and the
+  // drag carried on against rects measured in the folded layout.
+  //
+  // And only when THIS area owns a started drag. The flag is document-wide,
+  // so clearing it unconditionally let a tab list unmounting -- its window
+  // deleted, say -- end a window drag somewhere else.
+  useEffect(
+    () => () => {
+      const l = live.current;
+      live.current = null;
+      if (scrollFrame.current) {
+        cancelAnimationFrame(scrollFrame.current);
+        scrollFrame.current = 0;
+      }
+      if (l?.started) setDragging(false);
+    },
+    []
+  );
 
   const ctx = useMemo<Ctx>(
     () => ({ register, begin, drag }),

--- a/src/tests/components/dragPreviewAgreesWithDrop.test.tsx
+++ b/src/tests/components/dragPreviewAgreesWithDrop.test.tsx
@@ -1,0 +1,201 @@
+import { describe, expect, test, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+import {
+  RowDragArea,
+  DraggableRow,
+} from '../../components/home/rightpane/rowDrag/RowDragArea';
+
+// KAN-158. The preview must show what the release will do.
+//
+// While dragging, the other rows move aside to open a gap where the held row
+// will land. That gap was computed from the pointer against the row midpoints
+// alone, so it always named SOME index -- even where the release would be
+// refused. Measured in the popup, five windows: held above the pane the gap
+// opened at the top, held below or beside it at the bottom, and releasing did
+// nothing each time. The drop was right; the preview promised a move that never
+// came.
+//
+// So the preview asks the same question the release does. Where the release
+// would be refused, no row moves aside -- the held row's own slot stays open,
+// which is the honest picture of "this goes back where it came from".
+//
+// Read from the rows' transforms, which is what the user sees: a row shifted
+// up by the held row's height has been passed going down, and vice versa.
+
+const box = (top: number, height: number, left = 0, width = 200) =>
+  ({
+    top,
+    bottom: top + height,
+    left,
+    right: left + width,
+    height,
+    width,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+afterEach(() => {
+  document.documentElement.removeAttribute('data-dragging');
+  vi.restoreAllMocks();
+});
+
+const PANE_H = 200;
+const ROW_H = 30;
+const IDS = ['a', 'b', 'c', 'd'];
+const HELD = 1; // row b
+
+// Four 30px rows at 0..120 in a pane 0..200 wide 0..200: dead space under the
+// rows, and room outside the pane in every direction.
+const Harness = ({
+  clamp,
+  onMove,
+}: {
+  clamp: boolean;
+  onMove: (id: string, to: number) => void;
+}) => (
+  <div
+    style={{ overflowY: 'auto' }}
+    ref={(el) => {
+      if (el) el.getBoundingClientRect = () => box(0, PANE_H);
+    }}
+  >
+    <RowDragArea
+      rowIds={IDS}
+      onMove={onMove}
+      dragKind="window"
+      clampDropToEnds={clamp}
+    >
+      {IDS.map((id, i) => (
+        <DraggableRow key={id} rowId={id} index={i}>
+          <div
+            ref={(el) => {
+              if (el?.parentElement)
+                el.parentElement.getBoundingClientRect = () =>
+                  box(i * ROW_H, ROW_H);
+            }}
+          >
+            Row {id}
+          </div>
+        </DraggableRow>
+      ))}
+    </RowDragArea>
+  </div>
+);
+
+const rowNode = (id: string) => screen.getByText(`Row ${id}`).parentElement!;
+
+const shift = (id: string) =>
+  Number(
+    /translateY\((-?[\d.]+)px\)/.exec(rowNode(id).style.transform)?.[1] ?? 0
+  );
+
+// What the preview is showing, as an index: the held row's own slot, moved by
+// every row that has stepped aside for it.
+const previewIndex = () => {
+  const others = IDS.filter((_, i) => i !== HELD);
+  const up = others.filter((id) => shift(id) < 0).length;
+  const down = others.filter((id) => shift(id) > 0).length;
+  return HELD + up - down;
+};
+
+const othersShifted = () =>
+  IDS.filter((_, i) => i !== HELD).filter((id) => shift(id) !== 0);
+
+// Picks up row b, holds it at (x, y), and reports what the preview showed
+// there and what releasing there did.
+const holdAt = (clamp: boolean, x: number, y: number) => {
+  const onMove = vi.fn();
+  render(<Harness clamp={clamp} onMove={onMove} />);
+  fireEvent.pointerDown(rowNode('b'), { clientX: 10, clientY: 45, button: 0 });
+  fireEvent.pointerMove(document, { clientX: 10, clientY: 55 });
+  fireEvent.pointerMove(document, { clientX: x, clientY: y });
+  const shown = { index: previewIndex(), shifted: othersShifted() };
+  fireEvent.pointerUp(document, { clientX: x, clientY: y });
+  const landed: number | undefined = onMove.mock.calls[0]?.[1];
+  cleanup();
+  document.documentElement.removeAttribute('data-dragging');
+  return { shown, landed };
+};
+
+describe('where the release will be refused, no gap opens', () => {
+  test('held above the pane', () => {
+    const { shown, landed } = holdAt(true, 10, -40);
+    expect(landed).toBeUndefined();
+    expect(shown.shifted).toEqual([]);
+  });
+
+  test('held below the pane', () => {
+    const { shown, landed } = holdAt(true, 10, PANE_H + 40);
+    expect(landed).toBeUndefined();
+    expect(shown.shifted).toEqual([]);
+  });
+
+  // Beside the pane AND below the rows. Level with the rows a release lands
+  // whatever its x -- isInsideList is vertical only, deliberately, since nobody
+  // drags perfectly straight -- and there preview and drop already agree.
+  test('held beside the pane, below the rows', () => {
+    const { shown, landed } = holdAt(true, 260, 190);
+    expect(landed).toBeUndefined();
+    expect(shown.shifted).toEqual([]);
+  });
+
+  // A list that has NOT opted into the pane -- a tab list. Its dead space is
+  // "dragged out of this window", which is refused (KAN-132), so it must not
+  // preview a landing at the end of the window either.
+  test('a list without the opt-in, held in the dead space under its rows', () => {
+    const { shown, landed } = holdAt(false, 10, 190);
+    expect(landed).toBeUndefined();
+    expect(shown.shifted).toEqual([]);
+  });
+});
+
+describe('CONTROLS: where the release will land, the gap still opens', () => {
+  // Without these, a preview that never moved anything would pass every test
+  // above -- and would break the feature outright.
+  test('held among the rows, the gap is where it lands', () => {
+    // 100 is past a (15), c (75) but not d (105): index 2.
+    const { shown, landed } = holdAt(true, 10, 100);
+    expect(landed).toBe(2);
+    expect(shown.index).toBe(2);
+  });
+
+  test('held in the pane dead space with the opt-in, the gap opens at the end', () => {
+    const { shown, landed } = holdAt(true, 10, 190);
+    expect(landed).toBe(3);
+    expect(shown.index).toBe(3);
+  });
+});
+
+// THE CONTRACT, everywhere rather than at a few chosen points: at every place
+// the row can be held, the preview shows exactly what releasing there does.
+describe('the preview and the release agree at every position', () => {
+  const positions: [number, number][] = [];
+  for (let y = -60; y <= PANE_H + 60; y += 5) positions.push([10, y]);
+  for (let y = 0; y <= PANE_H; y += 40) positions.push([260, y]);
+
+  test.each([true, false])('clampDropToEnds=%s', (clamp) => {
+    const disagreements: string[] = [];
+    let landedSomewhere = 0;
+    let refusedSomewhere = 0;
+    for (const [x, y] of positions) {
+      const { shown, landed } = holdAt(clamp, x, y);
+      if (landed === undefined) {
+        refusedSomewhere++;
+        if (shown.shifted.length > 0)
+          disagreements.push(`(${x},${y}) refused, but rows moved aside`);
+      } else {
+        landedSomewhere++;
+        if (shown.index !== landed)
+          disagreements.push(
+            `(${x},${y}) previewed ${shown.index}, landed ${landed}`
+          );
+      }
+    }
+    // The sweep has to cover BOTH outcomes, or agreement is vacuous.
+    expect(landedSomewhere).toBeGreaterThan(0);
+    expect(refusedSomewhere).toBeGreaterThan(0);
+    expect(disagreements).toEqual([]);
+  });
+});

--- a/src/tests/components/dragSurvivesRerender.test.tsx
+++ b/src/tests/components/dragSurvivesRerender.test.tsx
@@ -1,0 +1,226 @@
+import { describe, expect, test, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+
+import {
+  RowDragArea,
+  DraggableRow,
+} from '../../components/home/rightpane/rowDrag/RowDragArea';
+import TabGroupDetailsContainer from '../../components/home/rightpane/TabGroupDetailsContainer';
+import { renderWithProviders } from '../setup/renderWithProviders';
+import {
+  restoreContainer,
+  saveToTabContainerInternal,
+  selectTabContainer,
+} from '../../redux/slices/tabContainerDataStateSlice';
+import {
+  setHasTabGroupsPermission,
+  setIsNotDirty,
+} from '../../redux/slices/globalStateSlice';
+
+// KAN-159. A drag must survive the list re-rendering underneath it.
+//
+// The area's listener effect cleared the document's drag flag in its cleanup.
+// That was written for UNMOUNT -- "a drag interrupted by unmount must not leave
+// the document stuck in grabbing" -- but React runs an effect's cleanup every
+// time its inputs change, too. So anything that handed the area a new rowIds
+// or onMove mid-drag cleared the flag while the row was still held.
+//
+// Measured in the popup: the app rewrote the session data ~450ms into a window
+// drag (the startup sync landing), all seven drag areas re-ran their effects in
+// the same commit, and data-dragging vanished with the row still in hand. The
+// windows unfolded under the pointer, the grabbing cursor went, the row actions
+// came back, and the drag carried on against rects measured in the folded
+// layout. Started after the app settled, the same drag kept its flag
+// throughout -- which is why it looked intermittent.
+//
+// The same cleanup also cleared the flag when a DIFFERENT area re-rendered or
+// unmounted, so a tab list unmounting could end a window drag's fold.
+
+const ROW_H = 30;
+const box = (top: number, height: number) =>
+  ({
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 200,
+    height,
+    width: 200,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+afterEach(() => {
+  document.documentElement.removeAttribute('data-dragging');
+  vi.restoreAllMocks();
+});
+
+const flag = () => document.documentElement.getAttribute('data-dragging');
+
+const Area = ({
+  ids,
+  onMove,
+  kind = 'window',
+}: {
+  ids: string[];
+  onMove: (id: string, to: number) => void;
+  kind?: 'window' | 'tab';
+}) => (
+  <RowDragArea rowIds={ids} onMove={onMove} dragKind={kind}>
+    {ids.map((id, i) => (
+      <DraggableRow key={id} rowId={id} index={i}>
+        <div
+          ref={(el) => {
+            if (el?.parentElement)
+              el.parentElement.getBoundingClientRect = () =>
+                box(i * ROW_H, ROW_H);
+          }}
+        >
+          Row {id}
+        </div>
+      </DraggableRow>
+    ))}
+  </RowDragArea>
+);
+
+const startDrag = (label: string) => {
+  const row = screen.getByText(label).parentElement!;
+  fireEvent.pointerDown(row, { clientX: 10, clientY: 15, button: 0 });
+  fireEvent.pointerMove(document, { clientX: 10, clientY: 30 });
+};
+
+describe('a re-render mid-drag keeps the drag alive', () => {
+  // Same ids, NEW ARRAY: exactly what a store update that rebuilds the
+  // container does to every memoised id list.
+  test('a new rowIds array: still flagged, and the drop still lands', () => {
+    const onMove = vi.fn();
+    const { rerender } = render(<Area ids={['a', 'b', 'c']} onMove={onMove} />);
+    startDrag('Row a');
+    expect(flag()).toBe('window');
+
+    rerender(<Area ids={['a', 'b', 'c']} onMove={onMove} />);
+    expect(flag()).toBe('window');
+
+    // 70 is past b (45) but not c (75): index 1.
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 70 });
+    fireEvent.pointerUp(document, { clientX: 10, clientY: 70 });
+    expect(onMove).toHaveBeenCalledWith('a', 1, undefined);
+    expect(flag()).toBeNull();
+  });
+
+  test('a new onMove: still flagged', () => {
+    const { rerender } = render(<Area ids={['a', 'b']} onMove={() => {}} />);
+    startDrag('Row a');
+
+    rerender(<Area ids={['a', 'b']} onMove={() => {}} />);
+
+    expect(flag()).toBe('window');
+  });
+});
+
+describe('another area cannot end this drag', () => {
+  // The tab list of one window unmounting -- deleting it, or the window
+  // collapsing by hand -- while a session drag is live elsewhere.
+  test('an area that is not dragging unmounts: the flag stays', () => {
+    const Page = ({ showOther }: { showOther: boolean }) => (
+      <>
+        <Area ids={['a', 'b']} onMove={() => {}} />
+        {showOther && <Area ids={['x', 'y']} onMove={() => {}} kind="tab" />}
+      </>
+    );
+    const { rerender } = render(<Page showOther />);
+    startDrag('Row a');
+    expect(flag()).toBe('window');
+
+    rerender(<Page showOther={false} />);
+
+    expect(flag()).toBe('window');
+  });
+});
+
+// CONTROL, and the half the old cleanup existed for: the area that OWNS the
+// drag going away mid-drag must not leave the document stuck in a drag. Also
+// pinned in dragSetsDocumentFlag.test.tsx; restated here beside the tests that
+// narrow when the flag may be cleared, because narrowing it too far is the
+// obvious way to break this.
+test('CONTROL: the dragging area unmounting clears the flag', () => {
+  const { unmount } = render(<Area ids={['a', 'b']} onMove={() => {}} />);
+  startDrag('Row a');
+  expect(flag()).toBe('window');
+
+  unmount();
+
+  expect(flag()).toBeNull();
+});
+
+// The real trigger, through the real component: a store update that rebuilds
+// the session data with UNCHANGED content, as a sync that finds nothing new
+// does. restoreContainer rebuilds the container and every id list below it.
+describe('a store update landing mid-drag', () => {
+  const win = (id: string) => ({
+    windowId: id,
+    windowHeight: 800,
+    windowWidth: 1200,
+    windowOffsetTop: 0,
+    windowOffsetLeft: 0,
+    tabCount: 1,
+    title: `Window ${id}`,
+    tabs: [
+      { tabId: `${id}-t0`, favicon: '', title: 't', url: `https://${id}.test` },
+    ],
+  });
+
+  test('does not unfold the windows under the held row', async () => {
+    const { container, store } = await renderWithProviders(
+      <TabGroupDetailsContainer />,
+      {
+        seedStore: (s) => {
+          s.dispatch(setHasTabGroupsPermission(false));
+          s.dispatch(
+            saveToTabContainerInternal({
+              tabGroupId: 'g1',
+              title: 'Session',
+              createdTime: '2026-09-07 09:00:00',
+              windowCount: 2,
+              tabCount: 2,
+              isAutoSave: false,
+              isSelected: true,
+              windows: [win('wA'), win('wB')],
+            })
+          );
+          s.dispatch(selectTabContainer('g1'));
+          s.dispatch(setIsNotDirty());
+        },
+      }
+    );
+    const node = (id: string) =>
+      container.querySelector<HTMLElement>(`[data-drag-row-id="${id}"]`)!;
+    node('wA').getBoundingClientRect = () => box(0, 30);
+    node('wB').getBoundingClientRect = () => box(30, 30);
+    const handle = node('wA').querySelector('[data-window-drag-handle]')!;
+
+    fireEvent.pointerDown(handle, { clientX: 10, clientY: 15, button: 0 });
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 30 });
+    expect(flag()).toBe('window');
+
+    // A DEEP COPY, because that is what a sync delivers: the cloud document
+    // parsed from JSON -- the same content, every object new. Passing the
+    // current state back instead keeps the session's identity, the memoised id
+    // list never changes, and this test passed against the broken code. The
+    // memo in TabGroupDetailsContainer was the earlier mitigation for this
+    // exact bug; it only holds while the session object survives.
+    const before = store.getState().tabContainerDataState;
+    act(() => {
+      store.dispatch(restoreContainer(JSON.parse(JSON.stringify(before))));
+    });
+    // The premise: the selected session really is a new object now. Without
+    // it, "still flagged" could just mean nothing re-rendered.
+    const selected = (s: typeof before) =>
+      s.tabGroups.find((g) => g.tabGroupId === 'g1');
+    expect(selected(store.getState().tabContainerDataState)).not.toBe(
+      selected(before)
+    );
+
+    expect(flag()).toBe('window');
+  });
+});


### PR DESCRIPTION
## What

Two drag bugs, one found while demonstrating the other. Both are on main and unreleased.

**KAN-158.** While dragging, the other rows move apart to preview where the held row will land. That preview counted midpoints on its own, so it named a landing spot even where letting go would be refused. Held above the list, a window previewed moving to the top; a tab held over another window previewed moving to the end of its own. Letting go did nothing, which is correct, but the preview had promised otherwise.

**KAN-159.** A sync landing mid-drag wiped the document's drag flag while the row was still held. The windows unfolded under the pointer, the grabbing cursor and row actions came back, and the drag carried on against positions measured in the folded layout, so **letting go did nothing: the move was silently lost.**

## One rule for the preview and the release

The landing decision is now a single function, `landingIndex`, called by both the preview (`update`) and the release (`judgeDrop`). Where the release would be refused, no row moves aside and the held row's own slot stays open. Two copies of the rule were two chances to disagree.

Level with the rows, a release still lands whatever its x. `isInsideList` is vertical only, deliberately, because nobody drags perfectly straight. Preview and release already agreed there.

## The flag is cleared on unmount only

`RowDragArea`'s listener effect called `setDragging(false)` in its cleanup. That was meant for unmount, but React also runs the cleanup whenever `rowIds` or `onMove` change identity. A sync rebuilds the session data from parsed JSON, so every list gets new ids. Measured in the popup: seven listener re-registrations in one commit, 5ms after the `tabContainerData` write.

The `windowIds` memo in `TabGroupDetailsContainer` was the earlier mitigation, and its comment described this bug. It only held while the session object survived, and a sync replaces it.

Now the listener cleanup only removes listeners, and an unmount-only effect clears the flag, only when this area owns a started drag. The old cleanup also let an unrelated area unmounting (a tab list whose window was deleted) end someone else's drag.

## Tests

**1273 pass** (13 new), **68 e2e pass**, tsc clean, lint 0 errors.

* `dragPreviewAgreesWithDrop.test.tsx` holds the row at every position in and around the pane, with and without `clampDropToEnds`, and requires the preview to match the release at each one. A guard makes sure the sweep covers both outcomes, so agreement can't be vacuous.
* `dragSurvivesRerender.test.tsx`: new `rowIds`, new `onMove`, another area unmounting, a real `restoreContainer` mid-drag, and the control that the dragging area unmounting still clears the flag. The store test passed against the broken code until it dispatched a **deep copy**. Re-dispatching the same objects kept the memo intact, and a deep copy is what a sync delivers.
* `e2e/window-drag.spec.ts`: the above-the-pane control now asserts the preview at release.

```
old preview (midpoints only)            6 failed  ✓
refused preview falls back to index 0   6 failed  ✓
shared rule accepts everything         15 failed  ✓
listener cleanup clears the flag        4 failed  ✓
unmount clears another area's drag      1 failed  ✓
unmount never clears                    2 failed  ✓
mutant BUILD with the old preview       e2e "above the pane" failed  ✓
```

With `RowDragArea.tsx` reverted to `c376326`, the two new files give 10 failed, 3 passed.

## Verified live (Playwright, built artifact, mouse held down)

```
                                        rows moved aside     release
window held above the pane              2 -> 0               refused
tab held over the next window           1 -> 0               refused
control: window held inside the list    3 -> 3               commits
drag started while the startup sync lands:
  before   flag lost in 3 of 3 runs, release did nothing
  after    flag kept in 3 of 3 runs, release commits
```

Control for KAN-159: the same drag started 5s after load, once the app has settled, keeps its flag on both builds. That's why it looked intermittent.

Not addressed, noted on KAN-159: if a sync actually adds or removes a row mid-drag, the drop index was computed against the old list. Not reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
