### PR TITLE
Shift rows aside by the held row's footprint, not its height (KAN-163)

### DIFF
--- a/e2e/group-drag.spec.ts
+++ b/e2e/group-drag.spec.ts
@@ -406,3 +406,157 @@ test.describe('dragging a group', () => {
     expect(await itemOrder(page)).toEqual(START);
   });
 });
+
+// KAN-163 in the group list: the same defect at a different margin, which is
+// why the fix reads the gap instead of naming it. Measured here, held group
+// compressed: 32px tall, 34px apart -- a 2px gap, from the band's `margin:
+// 2px 0`.
+//
+// Not the 4px the KAN-160 spec predicted. That figure came from an UNFOLDED
+// group, 96px against a 100px pitch, and the drag never measures that layout:
+// the rects are taken after the held group compresses. A prediction made in the
+// wrong one of the two layouts, which is the standing hazard in this engine.
+test.describe('the gap a group drag opens', () => {
+  test('the item stepping aside lands on the vacated slot, margin included', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await open(context, extensionId);
+    const pane = await scrollToGroupAndRecord(page, 'alpha');
+    const at = await grab(page, 'alpha');
+
+    // Down past the next item's midpoint in the compressed layout, so it steps.
+    await page.mouse.move(at.x + 8, at.y + 50, { steps: 8 });
+    // The step is animated (0.18s); measuring early reads it part-way.
+    await page.waitForTimeout(320);
+
+    const geom = await page.evaluate(() => {
+      const rows = [
+        ...document.querySelectorAll<HTMLElement>(
+          '[data-drag-row-id="w1"] [data-drag-row-id^="tab:"], [data-drag-row-id="w1"] [data-drag-row-id^="group:"]'
+        ),
+      ];
+      const shift = (r: HTMLElement) =>
+        Number(/translateY\((-?[\d.]+)px\)/.exec(r.style.transform)?.[1] ?? 0);
+      const layoutTop = (r: HTMLElement) =>
+        r.getBoundingClientRect().top - shift(r);
+
+      const from = rows.findIndex((r) => r.hasAttribute('data-drag-held'));
+      const held = rows[from];
+      const stepped = rows[from + 1];
+      return {
+        from,
+        heldHeight: held.getBoundingClientRect().height,
+        pitch: layoutTop(stepped) - layoutTop(held),
+        slotTop: layoutTop(held),
+        steppedTop: stepped.getBoundingClientRect().top,
+        steppedShift: shift(stepped),
+      };
+    });
+
+    await page.keyboard.press('Escape');
+    await page.mouse.up();
+
+    // PREMISES: the held row is the group, the pick-up scrolled nothing, there
+    // is a margin to forget at all, and the row below really stepped.
+    expect(geom.from).toBe(1);
+    expect(await paneScrollTop(page)).toBe(pane.scrollTop);
+    expect(geom.pitch).toBeGreaterThan(geom.heldHeight);
+    expect(geom.steppedShift).toBeLessThan(0);
+
+    // THE CLAIM.
+    expect(geom.steppedTop).toBeCloseTo(geom.slotTop, 0);
+
+    expect(await itemOrder(page)).toEqual(START);
+  });
+});
+
+// KAN-163, the case the window and item lists cannot show. The `tabs` scope is
+// a FLAT list of every tab in the window, so two consecutive rows in it are not
+// necessarily consecutive in the LAYOUT: between the last tab before a group
+// and that group's first member sits the group's band header, 32px belonging to
+// neither row. Measuring a footprint as "the distance to the next row's top"
+// swallows it, and the held tab reports 66px instead of its own 34.
+//
+// The oracle is built from rows the held one is not involved in: a tab's
+// footprint is its own height plus the gap the item list puts between items,
+// measured between the group above and the tab below it.
+test.describe('a tab dragged across a group boundary', () => {
+  test('steps the rows below it by its own footprint, not across the band', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await open(context, extensionId);
+
+    // Centre the tab in the pane: clear of both 48px auto-scroll zones, so the
+    // pick-up cannot measure a list that is moving under it.
+    const before = await page.evaluate(() => {
+      const w1 = document.querySelector<HTMLElement>(
+        '[data-drag-row-id="w1"]'
+      )!;
+      let pane = w1.parentElement;
+      while (
+        pane &&
+        !['auto', 'scroll'].includes(getComputedStyle(pane).overflowY)
+      )
+        pane = pane.parentElement;
+      const held = document.querySelector<HTMLElement>(
+        '[data-drag-row-id="a0"]'
+      )!;
+      const hb = held.getBoundingClientRect();
+      const pb = pane!.getBoundingClientRect();
+      pane!.scrollTop += hb.top + hb.height / 2 - (pb.top + pb.height / 2);
+
+      const box = (sel: string) =>
+        document.querySelector<HTMLElement>(sel)!.getBoundingClientRect();
+      const h = box('[data-drag-row-id="a0"]');
+      return {
+        heldHeight: h.height,
+        // The item list's own separation, measured away from the held row.
+        itemGap:
+          box('[data-drag-row-id="tab:a1"]').top -
+          box('[data-drag-row-id="group:alpha"]').bottom,
+        grabX: h.left + 80,
+        grabY: h.top + h.height / 2,
+      };
+    });
+
+    await page.mouse.move(before.grabX, before.grabY);
+    await page.mouse.down();
+    await page.mouse.move(before.grabX, before.grabY + 10, { steps: 3 });
+    // Past the first group member's midpoint, so it has to step up. That
+    // midpoint is a band header further down than the tab pitch suggests.
+    await page.mouse.move(before.grabX, before.grabY + 110, { steps: 10 });
+    // The step is animated (0.18s); measuring early reads it part-way.
+    await page.waitForTimeout(320);
+
+    const shifted = await page.evaluate(() => {
+      const shift = (el: HTMLElement) =>
+        Number(/translateY\((-?[\d.]+)px\)/.exec(el.style.transform)?.[1] ?? 0);
+      const first = document.querySelector<HTMLElement>(
+        '[data-drag-row-id="alpha0"]'
+      )!;
+      return {
+        heldIsTab: !!document.querySelector(
+          '[data-drag-row-id="a0"][data-drag-held]'
+        ),
+        steppedBy: Math.abs(shift(first)),
+      };
+    });
+
+    await page.keyboard.press('Escape');
+    await page.mouse.up();
+
+    // PREMISES: the tab really is the held row, and the row below really moved.
+    expect(shifted.heldIsTab).toBe(true);
+    expect(shifted.steppedBy).toBeGreaterThan(0);
+
+    // THE CLAIM. Its own footprint -- never the band header's 32px as well.
+    expect(shifted.steppedBy).toBeCloseTo(
+      before.heldHeight + before.itemGap,
+      1
+    );
+
+    expect(await itemOrder(page)).toEqual(START);
+  });
+});

--- a/e2e/window-drag.spec.ts
+++ b/e2e/window-drag.spec.ts
@@ -247,6 +247,164 @@ test.describe('dragging a window from a scrolled position', () => {
   });
 });
 
+// KAN-163. The rows that close up behind the held window must land ON the slot
+// it vacated, not one margin below it.
+//
+// Measured mid-drag, because the preview only exists while the pointer is down,
+// and the drag is then abandoned with Escape: this is a claim about what the
+// user is SHOWN, and nothing about it should commit. jsdom cannot see any of
+// it -- it has no layout, so every rect there is zero and the assertion below
+// passes against the broken code.
+test.describe('the gap a drag opens', () => {
+  test('a row stepping aside lands on the vacated slot, margin included', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openSession(context, extensionId, 5, 6);
+    const pane = await scrollPaneAndRecord(page, 0);
+    const grab = await topVisibleHeader(page, pane);
+    // w0 is the one window with nothing above it to fold, so the pick-up moves
+    // nothing and the slot it leaves is where it already was (KAN-161).
+    expect(grab.id).toBe('w0');
+
+    await page.mouse.move(grab.x, grab.y);
+    await page.mouse.down();
+    // Past the activation distance, which folds the list, then past the next
+    // window's folded midpoint so that it has to step up.
+    await page.mouse.move(grab.x, grab.y + 10, { steps: 3 });
+    await page.mouse.move(grab.x, grab.y + 50, { steps: 8 });
+    // The step is animated (0.18s). Measuring before it settles reads a row
+    // part-way through the shift and fails for the wrong reason.
+    await page.waitForTimeout(320);
+
+    const geom = await page.evaluate(() => {
+      const rows = [
+        ...document.querySelectorAll<HTMLElement>('[data-drag-row-id]'),
+      ].filter((r) => r.querySelector('[data-window-drag-handle]') !== null);
+      const shift = (r: HTMLElement) =>
+        Number(/translateY\((-?[\d.]+)px\)/.exec(r.style.transform)?.[1] ?? 0);
+      // Where a row sits in the LAYOUT, with the drag's own transform removed.
+      const layoutTop = (r: HTMLElement) =>
+        r.getBoundingClientRect().top - shift(r);
+
+      const from = rows.findIndex((r) => r.hasAttribute('data-drag-held'));
+      const held = rows[from];
+      const stepped = rows[from + 1];
+      let el = held.parentElement;
+      while (el && !['auto', 'scroll'].includes(getComputedStyle(el).overflowY))
+        el = el.parentElement;
+
+      return {
+        from,
+        scrollTop: el!.scrollTop,
+        heldHeight: held.getBoundingClientRect().height,
+        pitch: layoutTop(stepped) - layoutTop(held),
+        // The slot the held row left, and where the next row actually is now.
+        slotTop: layoutTop(held),
+        steppedTop: stepped.getBoundingClientRect().top,
+        steppedShift: shift(stepped),
+      };
+    });
+
+    await page.keyboard.press('Escape');
+    await page.mouse.up();
+
+    // PREMISES. Without these the assertion below can pass vacuously: on a list
+    // whose rows are exactly one height apart there is no margin to forget, and
+    // a row that never stepped is trivially in the right place.
+    expect(geom.from).toBe(0);
+    expect(geom.scrollTop).toBe(0);
+    expect(geom.pitch).toBeGreaterThan(geom.heldHeight);
+    expect(geom.steppedShift).toBeLessThan(0);
+
+    // THE CLAIM. Flush with the slot, not one collapsed margin below it.
+    expect(geom.steppedTop).toBeCloseTo(geom.slotTop, 0);
+
+    // Nothing was committed: this test only ever looked.
+    expect(await storedOrder(page)).toEqual(['w0', 'w1', 'w2', 'w3', 'w4']);
+  });
+
+  // The last row is the one case with no next row to measure the pitch against,
+  // so the footprint comes from the gap ABOVE it instead. Every other test in
+  // this file grabs a row that has a neighbour below, which leaves that branch
+  // reasoned but unexercised.
+  //
+  // Two windows, because they never overflow the pane: with no scrolling
+  // ancestor there is no auto-scroll to move the list under the measurement.
+  test('the LAST row carries a footprint too, measured from the gap above it', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await openSession(context, extensionId, 2, 3);
+    const pane = await scrollPaneAndRecord(page, 0);
+    expect(pane.scrollTop).toBe(0);
+
+    const grab = await page.evaluate(() => {
+      const h = document
+        .querySelector('[data-drag-row-id="w1"] [data-window-drag-handle]')!
+        .getBoundingClientRect();
+      return { x: h.left + 60, y: h.top + h.height / 2 };
+    });
+    await page.mouse.move(grab.x, grab.y);
+    await page.mouse.down();
+    // Past the activation distance, which folds the list and re-anchors the grab.
+    await page.mouse.move(grab.x, grab.y + 10, { steps: 3 });
+
+    // Aim from the FOLDED layout, which only exists now: just above the other
+    // window's midpoint, which is what makes it step aside.
+    const targetY = await page.evaluate(() => {
+      const r = document
+        .querySelector('[data-drag-row-id="w0"]')!
+        .getBoundingClientRect();
+      return r.top + r.height / 2 - 8;
+    });
+    await page.mouse.move(grab.x, targetY, { steps: 8 });
+    await page.waitForTimeout(320);
+
+    const geom = await page.evaluate(() => {
+      const rows = [
+        ...document.querySelectorAll<HTMLElement>('[data-drag-row-id]'),
+      ].filter((r) => r.querySelector('[data-window-drag-handle]') !== null);
+      const shift = (r: HTMLElement) =>
+        Number(/translateY\((-?[\d.]+)px\)/.exec(r.style.transform)?.[1] ?? 0);
+      const layoutTop = (r: HTMLElement) =>
+        r.getBoundingClientRect().top - shift(r);
+
+      const from = rows.findIndex((r) => r.hasAttribute('data-drag-held'));
+      const held = rows[from];
+      // Dragging up: the row ABOVE steps down into the vacated slot.
+      const stepped = rows[from - 1];
+      return {
+        from,
+        rowCount: rows.length,
+        slotTop: layoutTop(held),
+        steppedTop: stepped.getBoundingClientRect().top,
+        steppedShift: shift(stepped),
+        // The gap the fallback reads: between the row above's bottom edge and
+        // the held row's top.
+        gapAbove:
+          layoutTop(held) -
+          (layoutTop(stepped) + stepped.getBoundingClientRect().height),
+      };
+    });
+
+    await page.keyboard.press('Escape');
+    await page.mouse.up();
+
+    // PREMISES. The held row really is the last one, so the fallback branch is
+    // the one under test; there is a gap above it to read; and the row above
+    // really stepped, downwards.
+    expect(geom.from).toBe(geom.rowCount - 1);
+    expect(geom.gapAbove).toBeGreaterThan(0);
+    expect(geom.steppedShift).toBeGreaterThan(0);
+
+    // THE CLAIM. It lands on the slot, gap included.
+    expect(geom.steppedTop).toBeCloseTo(geom.slotTop, 0);
+
+    expect(await storedOrder(page)).toEqual(['w0', 'w1']);
+  });
+});
+
 // The pane's scroll, and whether the given window's header is wholly on screen.
 const paneState = (page: Page, windowId: string) =>
   page.evaluate((id) => {

--- a/src/components/home/rightpane/rowDrag/RowDragArea.tsx
+++ b/src/components/home/rightpane/rowDrag/RowDragArea.tsx
@@ -46,7 +46,9 @@ interface DragState {
   toIndex: number;
   // How far the held row has travelled from where it was picked up.
   offset: number;
-  height: number;
+  // How far every row it has passed must move to close up behind it -- the room
+  // the held row occupies, not the height it measures (KAN-163).
+  footprint: number;
 }
 
 interface Ctx {
@@ -122,6 +124,70 @@ interface Rect {
   height: number;
 }
 
+// How much room a row takes up: its border box plus the margin that separates
+// it from the row beside it. Lifting it out of the flow closes exactly this
+// much, wherever it sits, which is what the preview shifts every passed row by.
+//
+// Not the same number as its height, and the difference is why KAN-163 existed.
+// Every row is a wrapper this file owns, holding a block the list owns, and
+// that block's margin COLLAPSES THROUGH the wrapper -- the wrapper sets no
+// bottom border, padding or height to stop it. So the margin spaces the rows on
+// screen while sitting outside the wrapper's border box, which is the only
+// thing getBoundingClientRect reports. Measured: a folded window row is 32px
+// tall and 40px apart from the next one.
+//
+// MEASURED AMONG ITS SIBLINGS, not against the next row in the list, and that
+// distinction is load-bearing. The `tabs` scope is a FLAT list of every tab in
+// the window, so two consecutive ROWS need not be consecutive in the LAYOUT:
+// between the last tab before a group and that group's first member sits the
+// group's band header. Reading the next row's top there swallows 32px of chrome
+// belonging to neither row, and the held tab reports a 66px footprint instead
+// of its own 34 -- measured, and four times worse than the bug this fixes.
+//
+// Siblings cannot lie that way: whatever sits between two of them is margin.
+//
+// Read from the layout rather than the stylesheet, because the value is
+// per-list and not reliably predictable from the CSS: windows sit 8px apart,
+// items 2px, and tabs within a group 0px.
+function footprintOf(
+  el: HTMLElement | null,
+  container: HTMLElement | null,
+  height: number
+): number {
+  if (!el) return height;
+
+  // A wrapper that exists only to hold this row IS the row as far as the list
+  // is concerned -- a loose tab is a `tabs` row inside an `items` row, and the
+  // margin that spaces it lives on the outer one. Never climb past the drag
+  // area itself, which would start measuring the list against its neighbours.
+  let box: HTMLElement = el;
+  while (
+    box !== container &&
+    box.parentElement &&
+    box.parentElement !== container &&
+    box.parentElement.children.length === 1
+  ) {
+    box = box.parentElement;
+  }
+
+  const self = box.getBoundingClientRect();
+
+  // The distance to the next sibling's top IS the footprint.
+  const next = box.nextElementSibling;
+  if (next) return next.getBoundingClientRect().top - self.top;
+
+  // The last one has no next sibling to measure against, so use the gap above
+  // it instead: one CSS rule sets the separation, so the two gaps are equal.
+  const prev = box.previousElementSibling;
+  if (prev) {
+    return self.height + (self.top - prev.getBoundingClientRect().bottom);
+  }
+
+  // An only child has no margin to discover, and a one-row list cannot be
+  // reordered anyway.
+  return self.height;
+}
+
 export const RowDragArea: React.FC<RowDragAreaProps> = ({
   rowIds,
   scope,
@@ -148,7 +214,11 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
     started: boolean;
     rects: Rect[];
     fromIndex: number;
+    // The held row's border box, which is what the containment guard's slack is
+    // measured in, and its footprint, which is what the preview shifts by. Two
+    // names because they are two different quantities (KAN-163).
     height: number;
+    footprint: number;
     lastX: number;
     lastY: number;
     // Auto-scroll (KAN-152). The scrolling ancestor, and where it stood when
@@ -237,6 +307,7 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
         rects: [],
         fromIndex: rowIds.indexOf(rowId),
         height: 0,
+        footprint: 0,
         lastX: clientX,
         lastY: clientY,
         scroller,
@@ -331,7 +402,7 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
         // auto-scroll just travelled.
         offset:
           l.lastY - l.startY + (l.scroller?.scrollTop ?? 0) - l.startScrollTop,
-        height: l.height,
+        footprint: l.footprint,
       });
     };
 
@@ -446,6 +517,14 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
           };
         });
         l.height = l.rects[l.fromIndex]?.height ?? 0;
+        // Measured in the same frame as the rects above, and from the element
+        // rather than from them -- see footprintOf on why the list order cannot
+        // answer this.
+        l.footprint = footprintOf(
+          rows.current.get(l.rowId) ?? null,
+          containerRef.current,
+          l.height
+        );
 
         // Re-read now that the list may have collapsed: the limit captured at
         // pointer-down described the expanded content, and auto-scrolling to
@@ -661,12 +740,14 @@ export const DraggableRow: React.FC<DraggableRowProps & { index: number }> = ({
     if (held) {
       translate = drag.offset;
     } else if (drag.toIndex > drag.fromIndex) {
-      // Dragging down: everything it has passed moves up one slot.
+      // Dragging down: everything it has passed moves up one slot. One slot is
+      // the held row's FOOTPRINT -- lifting it out of the flow closes the gap it
+      // sat in as well as the box it filled (KAN-163).
       if (index > drag.fromIndex && index <= drag.toIndex)
-        translate = -drag.height;
+        translate = -drag.footprint;
     } else if (drag.toIndex < drag.fromIndex) {
       if (index >= drag.toIndex && index < drag.fromIndex)
-        translate = drag.height;
+        translate = drag.footprint;
     }
   }
 


### PR DESCRIPTION
## What

**KAN-163.** While a row is dragged, the rows it passes close up behind it — and they stopped one margin short of the slot they were filling. The preview moved them by the held row's measured height, which is the `DraggableRow` wrapper's border box; the block inside it carries a margin that collapses through the wrapper, so that margin is part of the row's footprint in the list and absent from its box.

Measured mid-drag on a real build, folded window list: rows **32px tall, 40px apart**, so the preview was 8px short every time. The gap opening ahead was 40px where a row plus its spacing needs 48. Group list: 32px tall, 34px apart, 2px short.

Visual only — the landing index comes from measured midpoints and never used this number. Unreleased: window drag is not in v1.7.0.

The rule itself was right. Lifting a row out of the flow displaces everything below it by that row's own footprint, whatever the other rows measure, so one shift value for all of them is sound. Only the magnitude was wrong.

## The number cannot be a constant

The three lists differ — windows sit 8px apart, items 2px, tabs within a group 0px — and none of it is reliably predictable from the CSS.

The group figure is **2px, not the 4px KAN-163 originally recorded**. That 4px came from an unfolded group measuring 96px against a 100px pitch, and the drag never reads that layout: a group compresses when it is picked up and the rects are taken after. Reasoning from `margin: 2px 0` instead gave 2px. Two careful predictions disagreed, which is the argument for reading the value out of the layout at the moment it is spent. The ticket description is corrected.

## Siblings, not the next row in the list

The first cut measured to the next **row**. That is only the row's footprint when consecutive rows are also consecutive in the layout, and the `tabs` scope breaks it: that list is every tab in the window flattened, so the row after a loose tab can be a group's first member, with the group's 32px band header between them belonging to neither.

```
the tabs scope, every row 32px tall
row                              gap to next row   footprint computed
a0     loose, before a group           34                66
alpha0 inside a group                   0                32
alpha2 last member                      2                34
beta2  last member, before a group     34                66
```

A tab beside a group reported **66px instead of 34**, so every tab it passed jumped a whole band header — four times worse than the bug being fixed. Every test in this PR passed against it, because both lists I had covered happened to be contiguous; the mutations did not help either, since a mutant proves a test can fail, not that the tests cover the right lists. Justine found it dragging the build by hand.

Whatever sits between two siblings is margin. A list order cannot promise that.

## How

* **`footprintOf(el, container, height)`** takes the element, not the rects: a `Rect[]` cannot distinguish a contiguous list from a scattered one. It returns the distance to the row's next DOM sibling, or for the last one its height plus the gap above it, or its height if it has no siblings at all.
* **It climbs to the outermost box that exists only to hold this row**, stopping at the drag area. A loose tab is a `tabs` row nested inside an `items` row, and the margin spacing it lives on the outer one.
* **`l.height` is untouched.** It also feeds the containment guard's slack (`isInsideList`, the KAN-132 rule that stops a tab leaving its window). Overwriting it with the footprint would have widened that drop tolerance by 4px in the window list as a side effect of a cosmetic fix. Two quantities, two names.
* `Rect.top` was added and then removed again: the sibling measurement does not need it.

## Tests

**1332 pass**, **79 e2e pass** (4 new), tsc clean, Prettier clean on every changed file, lint unchanged (the same 25 warnings as main, none in the changed files).

Each new spec measures mid-drag with the 0.18s step transition settled, then abandons the drag with Escape so nothing commits. Each carries its own premises — the held row is the one expected, the pick-up scrolled nothing, the row below really stepped, and **the pitch exceeds the height at all**, which is what stops the assertion passing vacuously on a list with no margin to forget. The tab spec builds its expected value from rows the held tab is not part of.

jsdom cannot see any of this: with no layout engine every rect is zero and all four assertions pass against the broken code.

Every test was seen failing first. Mutations, each failing its own named tests:

```
pitch reverted to the border box       window 8px, group 2px, tab 2px
wrapper climb removed                  tab alone, by 2px  (12 others green)
gap-above term dropped                 last row alone, by 8px  (13 others green)
```

Two mutations were rejected by tsc before they ran (unreachable narrowing, then `false &&` killing a null check). A mutation that does not compile silently tests the previous bundle, so each one's exit code was checked before its result.

## Follow-on

**KAN-164** is filed and fixed on a branch, held until this merges: a tab drag changes the tab's *group*, and nothing said which one until release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
