### PR TITLE
Carry a group's frame along with its tabs (KAN-165)

### DIFF
--- a/e2e/group-drag.spec.ts
+++ b/e2e/group-drag.spec.ts
@@ -744,3 +744,96 @@ test.describe('a tab drag says which group it will join', () => {
     expect(await itemOrder(page)).toEqual(START);
   });
 });
+
+// KAN-165. The engine translates individual tab rows. A group's FRAME -- its
+// title row and colour strip -- is not a row in the tab list, so nothing moved
+// it, and members slid out through their own group: measured, the first member
+// of Alpha ended at 189 while its title stayed at 191, sitting on top of it.
+//
+// The rule: a shift shared by EVERY member of a group belongs to the group, so
+// the frame travels with them. When members disagree the pointer is inside that
+// group and it is making room rather than moving, so the frame stays put.
+test.describe('a group travels whole', () => {
+  test('its title and strip move with its tabs when a tab passes it', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await open(context, extensionId);
+
+    const start = await page.evaluate(() => {
+      const w1 = document.querySelector<HTMLElement>(
+        '[data-drag-row-id="w1"]'
+      )!;
+      let pane = w1.parentElement;
+      while (
+        pane &&
+        !['auto', 'scroll'].includes(getComputedStyle(pane).overflowY)
+      )
+        pane = pane.parentElement;
+      const held = document.querySelector<HTMLElement>(
+        '[data-drag-row-id="a0"]'
+      )!;
+      const hb = held.getBoundingClientRect();
+      const pb = pane!.getBoundingClientRect();
+      pane!.scrollTop += hb.top + hb.height / 2 - (pb.top + pb.height / 2);
+      const h = document
+        .querySelector<HTMLElement>('[data-drag-row-id="a0"]')!
+        .getBoundingClientRect();
+      return { x: h.left + 80, y: h.top + h.height / 2 };
+    });
+
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(start.x, start.y + 10, { steps: 3 });
+    // Past the WHOLE of Alpha, so every one of its members shifts alike.
+    const pastAlpha = await page.evaluate(() => {
+      const r = document
+        .querySelector('[data-drag-row-id="a1"]')!
+        .getBoundingClientRect();
+      return r.top + r.height / 2 + 4;
+    });
+    await page.mouse.move(start.x, pastAlpha, { steps: 12 });
+    await page.waitForTimeout(320);
+
+    const geom = await page.evaluate(() => {
+      const shift = (el: HTMLElement) =>
+        Number(/translateY\((-?[\d.]+)px\)/.exec(el.style.transform)?.[1] ?? 0);
+      const band = document.querySelector<HTMLElement>(
+        '[data-band-id="alpha"]'
+      )!;
+      const members = [
+        ...band.querySelectorAll<HTMLElement>('[data-drag-row-id]'),
+      ];
+      const title = band.querySelector<HTMLElement>(
+        '[data-group-drag-handle]'
+      )!;
+      const strip = band.querySelector<HTMLElement>(
+        '[data-group-color-strip]'
+      )!;
+      const r2 = (v: number) => Math.round(v * 100) / 100;
+      return {
+        memberShifts: members.map(shift),
+        titleShift: shift(title),
+        stripShift: shift(strip),
+        titleBottom: r2(title.getBoundingClientRect().bottom),
+        firstMemberTop: r2(members[0].getBoundingClientRect().top),
+      };
+    });
+
+    await page.keyboard.press('Escape');
+    await page.mouse.up();
+
+    // PREMISES: every member moved, and moved alike -- which is what makes the
+    // shift the GROUP's rather than any one row's.
+    expect(geom.memberShifts.length).toBeGreaterThan(1);
+    expect(new Set(geom.memberShifts).size).toBe(1);
+    expect(geom.memberShifts[0]).not.toBe(0);
+
+    // THE CLAIM: the frame went with them, and the group is still whole.
+    expect(geom.titleShift).toBe(geom.memberShifts[0]);
+    expect(geom.stripShift).toBe(geom.memberShifts[0]);
+    expect(geom.titleBottom).toBeLessThanOrEqual(geom.firstMemberTop + 1);
+
+    expect(await itemOrder(page)).toEqual(START);
+  });
+});

--- a/src/components/common/GroupColorPicker.tsx
+++ b/src/components/common/GroupColorPicker.tsx
@@ -164,7 +164,9 @@ const GroupColorPicker: React.FC<GroupColorPickerProps> = ({
             ${bandStyle};
             cursor: pointer;
             /* Named properties, never the all keyword. */
-            transition-property: width, flex-basis, margin-right;
+            /* transform joins the list for KAN-165: the strip travels
+               with its group's tabs and must glide as they do. */
+            transition-property: width, flex-basis, margin-right, transform;
             transition-duration: 150ms;
             transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
             /* 6px + 3px, still 9px. Widening without shrinking the margin

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -1,7 +1,9 @@
 import React, {
   MouseEventHandler,
   useCallback,
+  useLayoutEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
@@ -47,7 +49,10 @@ import type {
   GroupRun,
 } from '../../../utils/functions/tabGroups';
 import { applyTabGroups } from '../../../utils/functions/windows';
+
+import { groupFrameOffset } from '../../../utils/functions/groupFrame';
 import { RowDragArea, DraggableRow } from './rowDrag/RowDragArea';
+import { useDragState } from './rowDrag/dragContext';
 import { bandAt } from './rowDrag/dropRules';
 
 interface WindowEntryContainerProps {
@@ -66,6 +71,44 @@ interface WindowEntryContainerProps {
   onAddCurrTabToWindowClick: MouseEventHandler;
   onDeleteClick: MouseEventHandler;
 }
+
+// KAN-165. Carries a group's frame along with its tabs.
+//
+// The engine translates individual tab rows. A group's title row and colour
+// strip are not rows in that list, so nothing moved them, and members slid out
+// through their own group -- measured, the first member of a three-tab group
+// ended 2px ABOVE its own title.
+//
+// Rendered INSIDE the drag area because that is the only place the live drag
+// can be read; WindowEntryContainer itself sits outside the area's provider.
+// It draws nothing.
+//
+// The two parts are moved through the DOM rather than by prop, because they are
+// rendered in different places -- the strip by GroupColorPicker -- and
+// threading a per-move offset into a component with no other reason to know
+// about dragging would be worse than this. The offset changes only when the
+// landing index does, not on every pointer move.
+const GroupFrameFollower: React.FC<{ memberIndices: number[] }> = ({
+  memberIndices,
+}) => {
+  const drag = useDragState('tabs');
+  const offset = groupFrameOffset(drag, memberIndices);
+  const anchor = useRef<HTMLSpanElement | null>(null);
+
+  useLayoutEffect(() => {
+    const band = anchor.current?.closest<HTMLElement>('[data-band-id]');
+    if (!band) return;
+    const transform = offset ? `translateY(${offset}px)` : '';
+    for (const part of [
+      band.querySelector<HTMLElement>('[data-group-color-strip]'),
+      band.querySelector<HTMLElement>('[data-group-drag-handle]'),
+    ]) {
+      if (part) part.style.transform = transform;
+    }
+  }, [offset]);
+
+  return <span ref={anchor} hidden />;
+};
 
 const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
   title,
@@ -874,6 +917,11 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                         }
                       `}
                     >
+                      <GroupFrameFollower
+                        memberIndices={item.tabs.map(
+                          (member) => indexOfTab.get(member.tabId) ?? -1
+                        )}
+                      />
                       {/* The colour is Chrome's own group identity, not app chrome
                     (BINDING CONSTRAINT 1) -- TAB_GROUP_COLOR_HEX is a fixed
                     map, not routed through useThemeColors, so it reads the
@@ -936,6 +984,10 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                             position: relative;
                             display: flex;
                             align-items: center;
+                            /* KAN-165: the frame travels with its tabs, so it
+                               has to glide like they do. Same duration as the
+                               rows stepping aside in RowDragArea. */
+                            transition: transform 0.18s ease;
                             /* 32px, the height the window row and every tab row
                          already stand at -- measured, not guessed. At 22px the
                          hover fill read as a short band wedged between

--- a/src/components/home/rightpane/rowDrag/RowDragArea.tsx
+++ b/src/components/home/rightpane/rowDrag/RowDragArea.tsx
@@ -32,6 +32,12 @@ import React, {
 } from 'react';
 
 import {
+  DragContext,
+  type Ctx,
+  type DragState,
+  type DragScopes,
+} from './dragContext';
+import {
   ACTIVATION_DISTANCE_PX,
   isInEditableField,
   isInsideList,
@@ -39,38 +45,6 @@ import {
   type DraggableRowProps,
   type RowDragAreaProps,
 } from './dropRules';
-
-interface DragState {
-  rowId: string;
-  fromIndex: number;
-  toIndex: number;
-  // How far the held row has travelled from where it was picked up.
-  offset: number;
-  // How far every row it has passed must move to close up behind it -- the room
-  // the held row occupies, not the height it measures (KAN-163).
-  footprint: number;
-}
-
-interface Ctx {
-  register: (rowId: string, el: HTMLElement | null) => void;
-  begin: (
-    rowId: string,
-    clientX: number,
-    clientY: number,
-    target: EventTarget | null
-  ) => void;
-  drag: DragState | null;
-}
-
-// The lists a row can join. `nearest` is what every unscoped row joins, as
-// before scopes existed; `byScope` holds every enclosing list that declared a
-// scope, so a row can name one through the lists in between (KAN-160).
-interface DragScopes {
-  nearest: Ctx;
-  byScope: Readonly<Partial<Record<string, Ctx>>>;
-}
-
-const DragContext = React.createContext<DragScopes | null>(null);
 
 // How close to an edge the pointer must be for the list to start travelling,
 // and how fast it goes at its deepest. 48px is roughly a row and a half here,

--- a/src/components/home/rightpane/rowDrag/dragContext.ts
+++ b/src/components/home/rightpane/rowDrag/dragContext.ts
@@ -1,0 +1,53 @@
+import React, { useContext } from 'react';
+
+// The live drag, and the context carrying it.
+//
+// Split out of RowDragArea.tsx because a file that exports components must
+// export nothing else for Fast Refresh to work, and `useDragState` has to be
+// importable by anything that must move WITH the rows without being one of
+// them -- a group's title row and colour strip (KAN-165).
+
+export interface DragState {
+  rowId: string;
+  fromIndex: number;
+  toIndex: number;
+  // How far the held row has travelled from where it was picked up.
+  offset: number;
+  // How far every row it has passed must move to close up behind it -- the room
+  // the held row occupies, not the height it measures (KAN-163).
+  footprint: number;
+}
+
+export interface Ctx {
+  register: (rowId: string, el: HTMLElement | null) => void;
+  begin: (
+    rowId: string,
+    clientX: number,
+    clientY: number,
+    target: EventTarget | null
+  ) => void;
+  drag: DragState | null;
+}
+
+// The lists a row can join. `nearest` is what every unscoped row joins, as
+// before scopes existed; `byScope` holds every enclosing list that declared a
+// scope, so a row can name one through the lists in between (KAN-160).
+export interface DragScopes {
+  nearest: Ctx;
+  byScope: Readonly<Partial<Record<string, Ctx>>>;
+}
+
+export const DragContext = React.createContext<DragScopes | null>(null);
+
+/**
+ * The live drag on a named list, or null when nothing is being dragged there.
+ *
+ * Same resolution as DraggableRow: a named scope, or the nearest enclosing
+ * list. Must be called from inside the area, like any consumer of a context.
+ */
+export function useDragState(scope?: string): DragState | null {
+  const scopes = useContext(DragContext);
+  const ctx =
+    (scope === undefined ? scopes?.nearest : scopes?.byScope[scope]) ?? null;
+  return ctx?.drag ?? null;
+}

--- a/src/tests/utils/functions/groupFrame.test.ts
+++ b/src/tests/utils/functions/groupFrame.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'vitest';
+
+import { groupFrameOffset } from '../../../utils/functions/groupFrame';
+import type { DragState } from '../../../components/home/rightpane/rowDrag/dragContext';
+
+// KAN-165. A group's frame -- title row and colour strip -- is not a row in the
+// tab list, so the engine never translates it, and members slid out through
+// their own group: measured in the popup, the first member of Alpha ended at
+// 189 while its title stayed at 191, sitting on top of it.
+//
+// The rule under test: a shift shared by EVERY member belongs to the group.
+const drag = (over: Partial<DragState> = {}): DragState => ({
+  rowId: 'held',
+  fromIndex: 0,
+  toIndex: 0,
+  offset: 0,
+  footprint: 34,
+  ...over,
+});
+
+describe('groupFrameOffset', () => {
+  test('no drag leaves the frame alone', () => {
+    expect(groupFrameOffset(null, [1, 2, 3])).toBe(0);
+  });
+
+  test('a group the held row has passed entirely travels with it', () => {
+    // Held row at 0 moving to 4; the group owns 1..3, all inside the range.
+    expect(
+      groupFrameOffset(drag({ fromIndex: 0, toIndex: 4 }), [1, 2, 3])
+    ).toBe(-34);
+  });
+
+  test('dragging upward carries the frame the other way', () => {
+    // Held row at 5 moving to 1; the group owns 1..3, all inside the range.
+    expect(
+      groupFrameOffset(drag({ fromIndex: 5, toIndex: 1 }), [1, 2, 3])
+    ).toBe(34);
+  });
+
+  test('a group the held row has not reached does not move', () => {
+    expect(groupFrameOffset(drag({ fromIndex: 0, toIndex: 2 }), [5, 6])).toBe(
+      0
+    );
+  });
+
+  // The case that makes this a rule rather than a constant: the pointer is
+  // INSIDE this group, so it is opening a slot, not travelling.
+  test('a group only half passed keeps its frame still', () => {
+    expect(
+      groupFrameOffset(drag({ fromIndex: 0, toIndex: 2 }), [1, 2, 3])
+    ).toBe(0);
+  });
+
+  // Not via a special case: the held row's own index falls outside both
+  // shifted ranges, so it reads 0 while its siblings read -34, and the
+  // disagreement is what holds the frame still.
+  test('a group holding the held row does not move: it is losing a member', () => {
+    // Members 2 and 3, and the held row IS member 2. Every other member sits
+    // inside the shifted range, so the held row's own 0 is the only thing
+    // holding the frame still. A group of [1, 2, 3] disagrees at index 1 as
+    // well and would pass this however the held row were treated -- a mutation
+    // proved exactly that.
+    expect(groupFrameOffset(drag({ fromIndex: 2, toIndex: 5 }), [2, 3])).toBe(
+      0
+    );
+  });
+
+  test('a group with no members has nothing to follow', () => {
+    expect(groupFrameOffset(drag({ fromIndex: 0, toIndex: 4 }), [])).toBe(0);
+  });
+});

--- a/src/utils/functions/groupFrame.ts
+++ b/src/utils/functions/groupFrame.ts
@@ -1,0 +1,54 @@
+import type { DragState } from '../../components/home/rightpane/rowDrag/dragContext';
+
+/**
+ * How far a row at `index` is shifted by the drag previewing `drag`.
+ *
+ * The same arithmetic DraggableRow applies to itself: everything the held row
+ * has passed closes up behind it by one footprint.
+ *
+ * The held row itself falls out as 0, because neither range includes its own
+ * index -- and that is exactly right here. It tracks the pointer rather than a
+ * slot, so a group containing it holds one member that is not moving with the
+ * others, which makes the group disagree and stay put. It is losing a member,
+ * not travelling. An explicit guard for this was written first and removed: a
+ * mutation proved it could never change an answer.
+ */
+function rowShift(drag: DragState, index: number): number {
+  if (drag.toIndex > drag.fromIndex) {
+    return index > drag.fromIndex && index <= drag.toIndex
+      ? -drag.footprint
+      : 0;
+  }
+  if (drag.toIndex < drag.fromIndex) {
+    return index >= drag.toIndex && index < drag.fromIndex ? drag.footprint : 0;
+  }
+  return 0;
+}
+
+/**
+ * How far a group's FRAME -- its title row and colour strip -- should move
+ * during a drag over the tab list (KAN-165).
+ *
+ * The engine translates individual tab rows, and a group's frame is not one of
+ * them, so without this it stays put while its members slide out through it:
+ * measured, the first member of a three-tab group ended 2px ABOVE its own
+ * title.
+ *
+ * The rule is that a shift shared by EVERY member belongs to the group. If they
+ * all move alike, the group itself has moved and its frame goes with them. If
+ * they disagree, the pointer is inside this group and it is opening a slot
+ * rather than travelling -- the frame is already in the right place, and the
+ * spare strip at the bottom is exactly where the incoming tab will sit.
+ *
+ * A group holding the held row also returns 0: that row tracks the pointer
+ * rather than a slot, so the group is losing a member, not moving.
+ */
+export function groupFrameOffset(
+  drag: DragState | null,
+  memberIndices: readonly number[]
+): number {
+  if (!drag || memberIndices.length === 0) return 0;
+  const shifts = memberIndices.map((index) => rowShift(drag, index));
+  const [first] = shifts;
+  return shifts.every((shift) => shift === first) ? first : 0;
+}


### PR DESCRIPTION
## What

**KAN-165.** A group's title row and colour strip did not move with its tabs, so members slid out through their own group.

The engine previews a reorder by translating the rows of *its own list*. The `tabs` scope holds individual tab rows, and a group's frame is not one of them, so nothing ever moved it.

Measured in the popup, dragging a loose tab past a three-tab group:

```
                       today          with the fix
member shifts          -34 -34 -34    -34 -34 -34
title / strip top      191            157
first member top       189            189
title above members?   NO             yes
```

The first member ended at **189 while its own title stayed at 191** — two pixels above it, sitting on the title. Members also moved independently of one another, so the group was not even contiguous mid-drag.

Pre-existing since tab drag met groups (KAN-128 / KAN-11), and unreleased.

## The rule

Spiked in the browser before any code was written:

> a shift shared by **every** member of a group belongs to the group, so the frame travels with them

When members disagree, the pointer is inside that group and it is opening a slot rather than moving. The frame is then already where it should be, and the spare strip at the bottom is exactly where the incoming tab will sit — so "disagree" means "hold still", not "approximate something".

## How

* **`groupFrameOffset(drag, memberIndices)`** is a pure function over the drag state and the group's member indices, so the rule is unit-tested without a browser.
* **`GroupFrameFollower`** renders nothing and lives inside the drag area, because that is the only place the live drag can be read — the component rendering the band sits outside the area's provider. It writes the two parts through the DOM rather than by prop, because they are rendered in different places (the strip by `GroupColorPicker`), and the offset changes only when the landing index does, not per pointer move.
* **`dragContext.ts`** is new: the drag state, its context and `useDragState` move there. A file that exports components must export nothing else for Fast Refresh, and the hook has to be importable by anything that must move with the rows without being one of them. `RowDragArea` imports them back.
* Both parts glide rather than jump — the title takes the rows' own 0.18s, and `transform` joins the strip's existing transition list.

## The held row needs no special case

Worth reading, because the code says less than it looks like it should. A group containing the held row must not travel — it is losing a member, not moving. There is no branch for that: the held row's own index falls outside both shifted ranges, so it reads 0 while its siblings read -34, and the disagreement is what holds the frame still.

An explicit guard was written first and **deleted, because a mutation proved it could never change an answer**. The test for it was then wrong too — a group of `[1,2,3]` disagrees at index 1 as well, and passed however the held row was treated. It now uses `[2,3]`, where the held row's own 0 is the only thing holding the frame, and the mutation dies: `expected -34 to be +0`.

## Tests

**1339 pass** (7 new), **80 e2e pass** (1 new), tsc clean, Prettier clean, lint unchanged (the same 25 warnings as main).

Seven unit cases: both directions, a group not reached, a group only half passed, a group holding the held row, and a group with no members. The e2e drags a tab past a whole group and requires the frame's shift to equal its members' — carrying its own premises, that every member moved and moved alike.

Mutations, each failing its own tests:

```
disagreeing members no longer block the move     1 unit test failed
the follower never writes the transform          e2e failed
the held row treated like its siblings           1 unit test failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
