### PR TITLE
Show a tab crossing a group's title row, and the frame that answers (KAN-168, KAN-170, KAN-171)

### DIFF
--- a/e2e/group-drag.spec.ts
+++ b/e2e/group-drag.spec.ts
@@ -814,9 +814,18 @@ test.describe('a group travels whole', () => {
       return {
         memberShifts: members.map(shift),
         titleShift: shift(title),
-        stripShift: shift(strip),
         titleBottom: r2(title.getBoundingClientRect().bottom),
         firstMemberTop: r2(members[0].getBoundingClientRect().top),
+        // KAN-171. The strip's painted EXTENT, not its transform. It no longer
+        // moves as a rigid block -- joining a group makes the frame a row
+        // longer -- so the honest claim is where it starts and ends, which is
+        // also what a transform assertion could never have caught going wrong.
+        titleTop: r2(title.getBoundingClientRect().top),
+        stripTop: r2(strip.getBoundingClientRect().top),
+        stripBottom: r2(strip.getBoundingClientRect().bottom),
+        lastMemberBottom: r2(
+          members[members.length - 1].getBoundingClientRect().bottom
+        ),
       };
     });
 
@@ -831,8 +840,14 @@ test.describe('a group travels whole', () => {
 
     // THE CLAIM: the frame went with them, and the group is still whole.
     expect(geom.titleShift).toBe(geom.memberShifts[0]);
-    expect(geom.stripShift).toBe(geom.memberShifts[0]);
     expect(geom.titleBottom).toBeLessThanOrEqual(geom.firstMemberTop + 1);
+
+    // And the strip spans the whole of it -- from the title row's top to the
+    // last member's bottom. That invariant holds at rest, while the group
+    // travels, and while it is gaining a row, which is why it replaced an
+    // equality between two transforms (KAN-171).
+    expect(geom.stripTop).toBeCloseTo(geom.titleTop, 0);
+    expect(geom.stripBottom).toBeCloseTo(geom.lastMemberBottom, 0);
 
     expect(await itemOrder(page)).toEqual(START);
   });

--- a/e2e/tab-group-join-preview.spec.ts
+++ b/e2e/tab-group-join-preview.spec.ts
@@ -63,6 +63,19 @@ const AFTER_FROM_BELOW: Tab[] = [
   tab('alpha2', 'alpha'),
 ];
 
+// alpha0 LEAVES Alpha, dragged up out of its band (KAN-168). Its row index is
+// unchanged -- moveTabInternal splices it out and back in at 3 and drops the
+// membership -- so alpha1 inherits the group and alpha0 sits loose above it.
+const AFTER_LEAVING: Tab[] = [
+  tab('a0'),
+  tab('a1'),
+  tab('a2'),
+  tab('alpha0'),
+  tab('alpha1', 'alpha'),
+  tab('alpha2', 'alpha'),
+  tab('a3'),
+];
+
 const ROWS = ['a0', 'a1', 'a2', 'a3', 'alpha0', 'alpha1', 'alpha2'] as const;
 
 // Measured in the real popup at 790x550 on 2026-09-12, tops relative to a0.
@@ -87,6 +100,20 @@ const TRUTH = {
     a2: 98,
     header: 66,
     alpha0: 130,
+    alpha1: 162,
+    alpha2: 194,
+    a3: 228,
+  },
+  // KAN-168. alpha0 leaves Alpha upward. The exact inverse of fromAbove: the
+  // tab and the title row swap back, and the members it leaves behind do not
+  // move. PREDICTED from fromAbove and then measured -- if the prediction is
+  // wrong this is the assertion that says so.
+  leaving: {
+    a0: 0,
+    a1: 32,
+    a2: 64,
+    alpha0: 96,
+    header: 130,
     alpha1: 162,
     alpha2: 194,
     a3: 228,
@@ -189,6 +216,15 @@ test.describe('ground truth: what the drop actually does', () => {
       await tops(await open(context, extensionId, AFTER_FROM_BELOW))
     ).toEqual(TRUTH.fromBelow);
   });
+
+  test('alpha0 leaving Alpha upward swaps it back past the title row', async ({
+    context,
+    extensionId,
+  }) => {
+    expect(await tops(await open(context, extensionId, AFTER_LEAVING))).toEqual(
+      TRUTH.leaving
+    );
+  });
 });
 
 // Drag `rowId` onto Alpha's title row and read the preview WITHOUT releasing,
@@ -203,13 +239,27 @@ test.describe('ground truth: what the drop actually does', () => {
 // pointer move catches them at the start of the ease and reports a row that is
 // about to move as one that is not. Measured -- the members read 130 mid-flight
 // where they settle at 164.
-async function previewOfDropOnAlphaTitle(page: Page, rowId: string) {
+// The middle of Alpha's title row: inside the band, so a release joins Alpha.
+const titleRowY = async (page: Page) => {
+  const b = (await page
+    .locator('[data-band-id="alpha"] [data-group-drag-handle]')
+    .boundingBox())!;
+  return b.y + b.height / 2;
+};
+
+// Just ABOVE the band, in the lower part of the last loose tab over it. A
+// release here is outside every band, so it leaves the group -- and the window
+// is narrow on purpose: higher passes a2's midpoint and changes the row index
+// too, which is a different case (KAN-168 covers only the index-preserving one).
+const aboveBandY = async (page: Page) => {
+  const band = (await page.locator('[data-band-id="alpha"]').boundingBox())!;
+  return band.y - 6;
+};
+
+async function previewOfDragging(page: Page, rowId: string, toY: number) {
   const before = await tops(page);
   const from = (await page
     .locator(`[data-drag-row-id="${rowId}"]`)
-    .boundingBox())!;
-  const onto = (await page
-    .locator('[data-band-id="alpha"] [data-group-drag-handle]')
     .boundingBox())!;
 
   await page.mouse.move(from.x + 40, from.y + from.height / 2);
@@ -217,7 +267,7 @@ async function previewOfDropOnAlphaTitle(page: Page, rowId: string) {
   // Clear ACTIVATION_DISTANCE_PX before travelling, then step so the engine
   // sees a real gesture rather than one jump.
   await page.mouse.move(from.x + 40, from.y + from.height / 2 + 8);
-  await page.mouse.move(onto.x + 40, onto.y + onto.height / 2, { steps: 6 });
+  await page.mouse.move(from.x + 40, toY, { steps: 6 });
 
   const preview = await page.evaluate(
     ([rows, held, pre]: [
@@ -277,7 +327,7 @@ test.describe('the preview predicts the drop', () => {
     extensionId,
   }) => {
     const page = await open(context, extensionId, BEFORE);
-    const preview = await previewOfDropOnAlphaTitle(page, 'a2');
+    const preview = await previewOfDragging(page, 'a2', await titleRowY(page));
 
     // The members and the tab below the group do not move, and the landing
     // slot therefore must NOT be drawn on top of any of them.
@@ -303,7 +353,7 @@ test.describe('the preview predicts the drop', () => {
     extensionId,
   }) => {
     const page = await open(context, extensionId, BEFORE);
-    const preview = await previewOfDropOnAlphaTitle(page, 'a3');
+    const preview = await previewOfDragging(page, 'a3', await titleRowY(page));
 
     // The frame does NOT travel, though every one of its members moves alike.
     // That is the case the unanimity rule could not express.
@@ -315,5 +365,38 @@ test.describe('the preview predicts the drop', () => {
 
     // Exact, in the direction the index alone already described.
     expect(preview.a3).toBe(TRUTH.fromBelow.a3);
+  });
+
+  // KAN-168, reported from the shipped build. Leaving a group changes the tab's
+  // membership without changing its row index, which is the same blind spot
+  // KAN-166 fixed for joining -- so the slot was drawn at the tab's own origin,
+  // INSIDE the band and under the title row, while the drop put it above.
+  test('alpha0 dragged out: the title row drops below it and the slot leaves the band', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await open(context, extensionId, BEFORE);
+    const preview = await previewOfDragging(
+      page,
+      'alpha0',
+      await aboveBandY(page)
+    );
+
+    // The promised slot is ABOVE the title row, not under it. This is the
+    // assertion the screenshot failed: the slot sat at 130, its own origin,
+    // inside the band.
+    expect(preview.alpha0).toBeLessThan(preview.header);
+
+    // 2px below where it lands, and this direction is where KAN-167 shows up
+    // in the SLOT rather than only in the shifts: leaving the band stops the
+    // tab paying the band's 2px margin, which the measured tops cannot know in
+    // advance. Asserted as the number the engine produces, with the 2px named.
+    expect(preview.alpha0).toBe(TRUTH.leaving.alpha0 + 2);
+
+    // The title row drops to make way, and the members left behind hold still.
+    expect(preview.header).toBe(TRUTH.leaving.header);
+    expect(preview.alpha1).toBe(TRUTH.leaving.alpha1);
+    expect(preview.alpha2).toBe(TRUTH.leaving.alpha2);
+    expect(preview.a3).toBe(TRUTH.leaving.a3);
   });
 });

--- a/e2e/tab-group-join-preview.spec.ts
+++ b/e2e/tab-group-join-preview.spec.ts
@@ -76,6 +76,19 @@ const AFTER_LEAVING: Tab[] = [
   tab('a3'),
 ];
 
+// a2 joins Alpha at its SECOND position (KAN-170), from directly above. Unlike
+// the head case its row index DOES change -- 2 -> 3 -- because it now has to
+// pass alpha0 as well as the title row.
+const AFTER_SECOND_POSITION: Tab[] = [
+  tab('a0'),
+  tab('a1'),
+  tab('alpha0', 'alpha'),
+  tab('a2', 'alpha'),
+  tab('alpha1', 'alpha'),
+  tab('alpha2', 'alpha'),
+  tab('a3'),
+];
+
 const ROWS = ['a0', 'a1', 'a2', 'a3', 'alpha0', 'alpha1', 'alpha2'] as const;
 
 // Measured in the real popup at 790x550 on 2026-09-12, tops relative to a0.
@@ -114,6 +127,18 @@ const TRUTH = {
     a2: 64,
     alpha0: 96,
     header: 130,
+    alpha1: 162,
+    alpha2: 194,
+    a3: 228,
+  },
+  // KAN-170. a2 dropped on Alpha's SECOND slot, from above. The title row and
+  // alpha0 both step up past it; everything below alpha0 holds still.
+  secondPosition: {
+    a0: 0,
+    a1: 32,
+    header: 66,
+    alpha0: 98,
+    a2: 130,
     alpha1: 162,
     alpha2: 194,
     a3: 228,
@@ -217,6 +242,15 @@ test.describe('ground truth: what the drop actually does', () => {
     ).toEqual(TRUTH.fromBelow);
   });
 
+  test('a2 joining Alpha at its second position passes alpha0 too', async ({
+    context,
+    extensionId,
+  }) => {
+    expect(
+      await tops(await open(context, extensionId, AFTER_SECOND_POSITION))
+    ).toEqual(TRUTH.secondPosition);
+  });
+
   test('alpha0 leaving Alpha upward swaps it back past the title row', async ({
     context,
     extensionId,
@@ -254,6 +288,15 @@ const titleRowY = async (page: Page) => {
 const aboveBandY = async (page: Page) => {
   const band = (await page.locator('[data-band-id="alpha"]').boundingBox())!;
   return band.y - 6;
+};
+
+// Inside the band, but PAST alpha0's midpoint -- so the landing index names
+// the second slot rather than the first. The strip between alpha0's midpoint
+// and the band's bottom edge is where "which member does it land beside?" has
+// to be answered by the index rather than by the band (KAN-170).
+const secondSlotY = async (page: Page) => {
+  const b = (await page.locator('[data-drag-row-id="alpha0"]').boundingBox())!;
+  return b.y + b.height * 0.75;
 };
 
 async function previewOfDragging(page: Page, rowId: string, toY: number) {
@@ -365,6 +408,37 @@ test.describe('the preview predicts the drop', () => {
 
     // Exact, in the direction the index alone already described.
     expect(preview.a3).toBe(TRUTH.fromBelow.a3);
+  });
+
+  // KAN-170, reported from the shipped build. Aiming at the group's SECOND
+  // slot from above drew the slot in its FIRST, because the rule that spots a
+  // tab landing at the head compared two indices counted in different lists:
+  // toIndex counts the rows with the held one lifted out, groupFirstIndex
+  // counts all of them, and those agree only when the held row is BELOW the
+  // group. The drop was right the whole time; only the preview lied.
+  test('a2 dropped on the second slot: the slot goes there, not to the head', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await open(context, extensionId, BEFORE);
+    const preview = await previewOfDragging(
+      page,
+      'a2',
+      await secondSlotY(page)
+    );
+
+    // Below alpha0, not above it. This is the assertion the screenshot failed.
+    expect(preview.a2).toBe(TRUTH.secondPosition.a2);
+    expect(preview.a2).toBeGreaterThan(preview.alpha0);
+
+    // alpha0 steps up past the held row as well as the title row does.
+    expect(preview.alpha0).toBe(TRUTH.secondPosition.alpha0 - 2);
+    expect(preview.header).toBe(TRUTH.secondPosition.header - 2);
+
+    // Nothing below the slot moves.
+    expect(preview.alpha1).toBe(TRUTH.secondPosition.alpha1);
+    expect(preview.alpha2).toBe(TRUTH.secondPosition.alpha2);
+    expect(preview.a3).toBe(TRUTH.secondPosition.a3);
   });
 
   // KAN-168, reported from the shipped build. Leaving a group changes the tab's

--- a/e2e/tab-group-join-preview.spec.ts
+++ b/e2e/tab-group-join-preview.spec.ts
@@ -505,6 +505,59 @@ test.describe('the preview predicts the drop', () => {
     // And the strip covers the same extent, rather than keeping its length.
     expect(painted.strip!.top).toBe(painted.band!.top);
     expect(painted.strip!.bottom).toBe(painted.band!.bottom);
+
+    // THE HIT AREA MUST NOT MOVE. Growing the frame previews the RESULT; it
+    // does not make the target bigger. bandAt reads this box on every pointer
+    // move, so a band that grew its own hit area would keep the pointer inside
+    // itself and LATCH as the drop target -- measured in CI, where a pointer
+    // moved clear of every band left one still marked.
+    // PREMISE: the band's painted box really did grow past its resting top,
+    // so the strip of screen tested below exists at all.
+    expect(painted.band!.top).toBeLessThan(rest.band!.top);
+  });
+
+  // KAN-171, found by CI rather than by the eye. Growing the band previews the
+  // RESULT; it must not enlarge the TARGET. It did, and the result was a latch:
+  // marking a band grew its box, the grown box kept the pointer inside it, and
+  // bandAt went on naming it however far the pointer moved out. A first attempt
+  // at this asserted the geometry instead and could not see the bug at all --
+  // restoring the border box left it green.
+  test('a band that has grown does not capture the pointer in the space it grew into', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await open(context, extensionId, BEFORE);
+    const restTop = (await page
+      .locator('[data-band-id="alpha"]')
+      .boundingBox())!.y;
+
+    await previewOfDragging(page, 'a2', await titleRowY(page), {
+      settle: true,
+    });
+    const isTarget = () =>
+      page.evaluate(() =>
+        document
+          .querySelector('[data-band-id="alpha"]')!
+          .hasAttribute('data-drop-target')
+      );
+
+    // PREMISE: it is the drop target, and it grew upward past its resting top.
+    expect(await isTarget()).toBe(true);
+    const grownTop = (await page
+      .locator('[data-band-id="alpha"]')
+      .boundingBox())!.y;
+    expect(grownTop).toBeLessThan(restTop - 4);
+
+    // Into the strip the band grew into: above where it rests, inside where it
+    // now paints. Released here the tab lands ungrouped, so the band must let
+    // the pointer go.
+    const box = (await page.locator('[data-drag-row-id="a2"]').boundingBox())!;
+    await page.mouse.move(box.x + 40, (grownTop + restTop) / 2, { steps: 4 });
+
+    await expect.poll(isTarget).toBe(false);
+
+    await page.keyboard.press('Escape');
+    await page.mouse.up();
   });
 
   // KAN-170, reported from the shipped build. Aiming at the group's SECOND

--- a/e2e/tab-group-join-preview.spec.ts
+++ b/e2e/tab-group-join-preview.spec.ts
@@ -299,7 +299,12 @@ const secondSlotY = async (page: Page) => {
   return b.y + b.height * 0.75;
 };
 
-async function previewOfDragging(page: Page, rowId: string, toY: number) {
+async function previewOfDragging(
+  page: Page,
+  rowId: string,
+  toY: number,
+  opts: { settle?: boolean } = {}
+) {
   const before = await tops(page);
   const from = (await page
     .locator(`[data-drag-row-id="${rowId}"]`)
@@ -311,6 +316,9 @@ async function previewOfDragging(page: Page, rowId: string, toY: number) {
   // sees a real gesture rather than one jump.
   await page.mouse.move(from.x + 40, from.y + from.height / 2 + 8);
   await page.mouse.move(from.x + 40, toY, { steps: 6 });
+  // The frame's own parts carry a 0.18s transition (KAN-165), so anything read
+  // from a RECT rather than from a commanded transform has to wait it out.
+  if (opts.settle) await page.waitForTimeout(400);
 
   const preview = await page.evaluate(
     ([rows, held, pre]: [
@@ -357,12 +365,72 @@ async function previewOfDragging(page: Page, rowId: string, toY: number) {
     [ROWS, rowId, before] as [readonly string[], string, Record<string, number>]
   );
 
+  if (opts.settle) return preview;
   // Escape rather than release: this asserts on the preview, and a commit
   // would rewrite the very layout being measured.
   await page.keyboard.press('Escape');
   await page.mouse.up();
   return preview;
 }
+
+// The band's painted box, its title row and its colour strip, relative to a0.
+// KAN-171: these three have to describe the group the DROP will make, and the
+// band's own box never moves on its own -- a transform on the title row cannot
+// change its parent's layout box.
+const framePaint = (page: Page) =>
+  page.evaluate(() => {
+    const base = document
+      .querySelector('[data-drag-row-id="a0"]')!
+      .getBoundingClientRect().top;
+    const at = (el: Element | null) => {
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return {
+        top: Math.round(r.top - base),
+        bottom: Math.round(r.bottom - base),
+      };
+    };
+    return {
+      band: at(document.querySelector('[data-band-id="alpha"]')),
+      strip: at(
+        document.querySelector(
+          '[data-band-id="alpha"] [data-group-color-strip]'
+        )
+      ),
+    };
+  });
+
+// The painted extent a group's frame should show, which is NOT its layout box
+// once the preview has moved anything. Measured from the tint and the strip.
+const framePreview = (page: Page) =>
+  page.evaluate(() => {
+    const base = document
+      .querySelector('[data-drag-row-id="a0"]')!
+      .getBoundingClientRect().top;
+    const paint = (sel: string) => {
+      const el = document.querySelector<HTMLElement>(sel);
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      const before = getComputedStyle(el, '::before');
+      // The paint layer, where there is one, is what carries the extent.
+      const top = parseFloat(before.top);
+      const bottom = parseFloat(before.bottom);
+      if (before.content === 'none' || Number.isNaN(top)) {
+        return {
+          top: Math.round(r.top - base),
+          bottom: Math.round(r.bottom - base),
+        };
+      }
+      return {
+        top: Math.round(r.top - base + top),
+        bottom: Math.round(r.bottom - base - bottom),
+      };
+    };
+    return {
+      band: paint('[data-band-id="alpha"]'),
+      strip: paint('[data-band-id="alpha"] [data-group-color-strip]'),
+    };
+  });
 
 test.describe('the preview predicts the drop', () => {
   test('a2 dropped on the title: the title row rises and the members hold still', async ({
@@ -408,6 +476,35 @@ test.describe('the preview predicts the drop', () => {
 
     // Exact, in the direction the index alone already described.
     expect(preview.a3).toBe(TRUTH.fromBelow.a3);
+  });
+
+  // KAN-171, reported from the shipped build. A group's frame changes LENGTH
+  // when a tab joins it, and a transform can only express POSITION -- so the
+  // tinted box kept its resting extent while the title row moved out of the
+  // top of it, and the strip moved up rigidly and fell short at the bottom.
+  test('a2 dropped on the title: the band and its strip cover the group the drop will make', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await open(context, extensionId, BEFORE);
+
+    const rest = await framePaint(page);
+    expect(rest.band).toEqual({ top: 98, bottom: 226 });
+    expect(rest.strip).toEqual({ top: 98, bottom: 226 });
+
+    await previewOfDragging(page, 'a2', await titleRowY(page), {
+      settle: true,
+    });
+    const painted = await framePreview(page);
+
+    // The drop makes the band 66..226. The preview is allowed the usual 2px of
+    // KAN-167 at the moving edge; the fixed edge has to be exact.
+    expect(painted.band!.top).toBe(TRUTH.fromAbove.header - 2);
+    expect(painted.band!.bottom).toBe(rest.band!.bottom);
+
+    // And the strip covers the same extent, rather than keeping its length.
+    expect(painted.strip!.top).toBe(painted.band!.top);
+    expect(painted.strip!.bottom).toBe(painted.band!.bottom);
   });
 
   // KAN-170, reported from the shipped build. Aiming at the group's SECOND

--- a/src/components/common/GroupColorPicker.tsx
+++ b/src/components/common/GroupColorPicker.tsx
@@ -91,6 +91,25 @@ const GroupColorPicker: React.FC<GroupColorPickerProps> = ({
     align-self: stretch;
     background-color: ${TAB_GROUP_COLOR_HEX[current]};
 
+    /* KAN-171. The strip changes LENGTH while a tab is dragged into or out of
+       this group -- one row's worth -- and it used to be moved by a transform,
+       which can only change where a fixed-length box sits. Measured: dragging
+       a tab into a group's head, the strip read 64..192, moved up 34 and still
+       128 long, falling 34px short of the band's bottom at 226.
+
+       MARGINS ON A STRETCHED ITEM, which is the one way to resize this without
+       reflowing anything. The item's MARGIN box is what fills the flex line, so
+       a negative margin-top makes the border box that much taller and starts it
+       that much higher, while the line -- and therefore the band, and therefore
+       every row below it -- is untouched. A height would have done the opposite
+       and grown the band.
+
+       The two numbers are the frame's previewed extent, published on the band
+       by GroupFrameFollower and inherited from it. Both default to zero, so
+       outside a drag, and outside a band, this is the plain strip it was. */
+    margin-top: var(--frame-top, 0px);
+    margin-bottom: calc(-1 * var(--frame-bottom, 0px));
+
     /* KAN-164. While a tab is dragged, the group it would join opens up: the
        strip widens in the group's OWN colour rather than the app growing a
        ring in a colour it uses nowhere else.

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -93,22 +93,32 @@ interface WindowEntryContainerProps {
 // threading a per-move offset into a component with no other reason to know
 // about dragging would be worse than this. The offset changes only when the
 // landing slot does, not on every pointer move.
-const GroupFrameFollower: React.FC<{ groupId: string }> = ({ groupId }) => {
+const GroupFrameFollower: React.FC<{
+  groupId: string;
+  lastMemberId: string | undefined;
+}> = ({ groupId, lastMemberId }) => {
   const drag = useDragState('tabs');
-  const offset = drag?.shifts[groupId] ?? 0;
+  const top = drag?.shifts[groupId] ?? 0;
+  const bottom =
+    (lastMemberId === undefined ? 0 : drag?.shifts[lastMemberId]) ?? 0;
   const anchor = useRef<HTMLSpanElement | null>(null);
 
   useLayoutEffect(() => {
     const band = anchor.current?.closest<HTMLElement>('[data-band-id]');
     if (!band) return;
-    const transform = offset ? `translateY(${offset}px)` : '';
-    for (const part of [
-      band.querySelector<HTMLElement>('[data-group-color-strip]'),
-      band.querySelector<HTMLElement>('[data-group-drag-handle]'),
-    ]) {
-      if (part) part.style.transform = transform;
-    }
-  }, [offset]);
+    // The frame's EXTENT, published for the paint layers to read (KAN-171).
+    // Custom properties rather than inline styles on each part, because the
+    // strip is rendered by GroupColorPicker and these have to reach it without
+    // that component learning anything about dragging.
+    band.style.setProperty('--frame-top', `${top}px`);
+    band.style.setProperty('--frame-bottom', `${bottom}px`);
+
+    // The title row is a real row and moves as one, so it keeps a transform.
+    // The strip does NOT: it has to change length, not position, and a
+    // transform cannot say that.
+    const handle = band.querySelector<HTMLElement>('[data-group-drag-handle]');
+    if (handle) handle.style.transform = top ? `translateY(${top}px)` : '';
+  }, [top, bottom]);
 
   return <span ref={anchor} hidden />;
 };
@@ -980,7 +990,36 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                       css={css`
                         display: flex;
                         align-items: stretch;
-                        margin: 2px 0;
+
+                        /* KAN-171. The band's painted box has to cover the
+                           group the DROP will make, which is a row taller than
+                           the one on screen when a tab is joining it. Its own
+                           box cannot follow on its own: the title row moves by
+                           transform, and a transform on a child never changes
+                           its parent's layout box. Measured, the tint kept its
+                           resting 98..226 while the drop makes it 66..226, so
+                           the title row sat above its own tint.
+
+                           PADDING PAIRED WITH NEGATIVE MARGIN, so the box grows
+                           while its content and its contribution to the flow
+                           both stay exactly where they were -- the preview
+                           deliberately holds the layout still, and a real height
+                           change would push every row below the band.
+
+                           GROWTH ONLY, and that is not a shortcut: this paints
+                           only for the group a tab is being dropped into, and
+                           joining a group can never make it shorter. The strip
+                           handles both directions, because it is also drawn
+                           while a tab is LEAVING. */
+                        --frame-grow-top: max(
+                          0px,
+                          calc(-1 * var(--frame-top, 0px))
+                        );
+                        --frame-grow-bottom: max(0px, var(--frame-bottom, 0px));
+                        padding-top: var(--frame-grow-top);
+                        padding-bottom: var(--frame-grow-bottom);
+                        margin: calc(2px - var(--frame-grow-top)) 0
+                          calc(2px - var(--frame-grow-bottom));
 
                         /* KAN-164: a tab released here joins this group.
                            Outline rather than border, so marking a band
@@ -1006,6 +1045,12 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                            state in this pane is made of. The strip's widen
                            (GroupColorPicker) is the part that carries the
                            meaning without relying on hue. */
+                        /* KAN-164: a tab released here joins this group, so
+                           the group answers in its own colour. A wash rather
+                           than a ring, because fills are what every other
+                           state in this pane is made of. The strip's widen
+                           (GroupColorPicker) is the part that carries the
+                           meaning without relying on hue. */
                         &[data-drop-target] {
                           background-color: color-mix(
                             in srgb,
@@ -1016,7 +1061,10 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                         }
                       `}
                     >
-                      <GroupFrameFollower groupId={item.group.groupId} />
+                      <GroupFrameFollower
+                        groupId={item.group.groupId}
+                        lastMemberId={item.tabs[item.tabs.length - 1]?.tabId}
+                      />
                       {/* The colour is Chrome's own group identity, not app chrome
                     (BINDING CONSTRAINT 1) -- TAB_GROUP_COLOR_HEX is a fixed
                     map, not routed through useThemeColors, so it reads the

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -269,6 +269,18 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
   );
   const itemIds = useMemo(() => items.map(itemIdOf), [items]);
 
+  // Which group each tab is currently in, so the rule below can see a tab
+  // LEAVING one as well as joining one (KAN-168). The engine knows only where
+  // the pointer is; where the row STARTED is the list's own knowledge.
+  const groupOfTab = useMemo(() => {
+    const byId = new Map<string, string>();
+    for (const tab of tabs) {
+      if (tab.chromeGroupId !== undefined)
+        byId.set(tab.tabId, tab.chromeGroupId);
+    }
+    return byId;
+  }, [tabs]);
+
   // Where in the window's tab list each group's first member sits.
   const groupFirstIndex = useMemo(() => {
     const byId = new Map<string, number>();
@@ -297,16 +309,34 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
   //
   // The DROP is untouched. This is the preview only; the reducer still receives
   // the raw index and produces the same arrangement.
-  const landsAfterFixedRow = useCallback(
-    (toIndex: number, target: string | undefined) => {
-      if (target === undefined) return undefined;
-      const first = groupFirstIndex.get(target);
-      // At or above the first member is the strip where the two answers
-      // disagree. Below it the tab is landing BETWEEN members, where its row
-      // index already says everything.
-      return first !== undefined && toIndex <= first ? target : undefined;
+  const landsBesideFixedRow = useCallback(
+    (rowId: string, toIndex: number, target: string | undefined) => {
+      // Landing inside a band: the tab joins that group, or moves to the head
+      // of the one it is already in. Either way it ends up UNDER that title
+      // row. At or above the first member is the strip where the index and the
+      // band disagree; below it the tab is landing BETWEEN members, where its
+      // row index already says everything.
+      if (target !== undefined) {
+        const first = groupFirstIndex.get(target);
+        return first !== undefined && toIndex <= first
+          ? { fixedRowId: target, side: 'after' as const }
+          : undefined;
+      }
+
+      // KAN-168. Landing outside every band, having started inside one: the
+      // tab LEAVES its group, and above its first member that means crossing
+      // the title row the other way. Its row index does not change -- the
+      // reducer splices it out and back in at the same place and only drops
+      // the membership -- so without this the preview has nothing to say and
+      // draws the landing slot at the tab's own origin, inside the band.
+      const held = groupOfTab.get(rowId);
+      if (held === undefined) return undefined;
+      const first = groupFirstIndex.get(held);
+      return first !== undefined && toIndex <= first
+        ? { fixedRowId: held, side: 'before' as const }
+        : undefined;
     },
-    [groupFirstIndex]
+    [groupFirstIndex, groupOfTab]
   );
 
   const handleMoveGroup = useCallback(
@@ -871,7 +901,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
             dragKind="tab"
             resolveDrop={bandAt}
             onDropTargetChange={markDropTargetBand}
-            landsAfterFixedRow={landsAfterFixedRow}
+            landsBesideFixedRow={landsBesideFixedRow}
             // Each group's title row: drawn in this list, never dragged in it.
             // Scoped to `tabs` only -- in the `items` list a group is one row
             // that CONTAINS its title, so counting it there would double it.

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -113,6 +113,32 @@ const GroupFrameFollower: React.FC<{
     band.style.setProperty('--frame-top', `${top}px`);
     band.style.setProperty('--frame-bottom', `${bottom}px`);
 
+    // The band's painted box has to cover the group the DROP will make, which
+    // is a row taller than the one on screen while a tab is joining it. Its own
+    // box cannot follow on its own: the title row moves by transform, and a
+    // transform on a child never changes its parent's layout box. Measured, the
+    // tint kept its resting 98..226 while the drop makes it 66..226, so the
+    // title row sat above its own tint.
+    //
+    // PADDING PAIRED WITH NEGATIVE MARGIN, so the box grows while its content
+    // and its contribution to the flow both stay where they were. The preview
+    // deliberately holds the layout still, and a real height change would push
+    // every row below the band.
+    //
+    // GROWTH ONLY: the tint paints for a group a tab is being dropped INTO, and
+    // joining a group never makes it shorter. The strip handles both
+    // directions, since it is also drawn while a tab is leaving.
+    //
+    // INLINE rather than in the stylesheet, because bandAt has to read the
+    // padding back on every pointer move to keep the hit area still -- see the
+    // note there, and `style.paddingTop` costs nothing next to a computed one.
+    const growTop = Math.max(0, -top);
+    const growBottom = Math.max(0, bottom);
+    band.style.paddingTop = growTop ? `${growTop}px` : '';
+    band.style.paddingBottom = growBottom ? `${growBottom}px` : '';
+    band.style.marginTop = growTop ? `${2 - growTop}px` : '';
+    band.style.marginBottom = growBottom ? `${2 - growBottom}px` : '';
+
     // The title row is a real row and moves as one, so it keeps a transform.
     // The strip does NOT: it has to change length, not position, and a
     // transform cannot say that.
@@ -991,35 +1017,7 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
                         display: flex;
                         align-items: stretch;
 
-                        /* KAN-171. The band's painted box has to cover the
-                           group the DROP will make, which is a row taller than
-                           the one on screen when a tab is joining it. Its own
-                           box cannot follow on its own: the title row moves by
-                           transform, and a transform on a child never changes
-                           its parent's layout box. Measured, the tint kept its
-                           resting 98..226 while the drop makes it 66..226, so
-                           the title row sat above its own tint.
-
-                           PADDING PAIRED WITH NEGATIVE MARGIN, so the box grows
-                           while its content and its contribution to the flow
-                           both stay exactly where they were -- the preview
-                           deliberately holds the layout still, and a real height
-                           change would push every row below the band.
-
-                           GROWTH ONLY, and that is not a shortcut: this paints
-                           only for the group a tab is being dropped into, and
-                           joining a group can never make it shorter. The strip
-                           handles both directions, because it is also drawn
-                           while a tab is LEAVING. */
-                        --frame-grow-top: max(
-                          0px,
-                          calc(-1 * var(--frame-top, 0px))
-                        );
-                        --frame-grow-bottom: max(0px, var(--frame-bottom, 0px));
-                        padding-top: var(--frame-grow-top);
-                        padding-bottom: var(--frame-grow-bottom);
-                        margin: calc(2px - var(--frame-grow-top)) 0
-                          calc(2px - var(--frame-grow-bottom));
+                        margin: 2px 0;
 
                         /* KAN-164: a tab released here joins this group.
                            Outline rather than border, so marking a band

--- a/src/components/home/rightpane/WindowEntryContainer.tsx
+++ b/src/components/home/rightpane/WindowEntryContainer.tsx
@@ -309,16 +309,39 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
   //
   // The DROP is untouched. This is the preview only; the reducer still receives
   // the raw index and produces the same arrangement.
+  // Where a group's head sits in the space `toIndex` is counted in (KAN-170).
+  //
+  // TWO LISTS, AND THEY ARE NOT THE SAME ONE. `groupFirstIndex` counts every
+  // row; `toIndex` counts the rows with the HELD row lifted out, because it is
+  // the number of midpoints the pointer has passed. Lifting a row out shifts
+  // everything below it down one, so the two agree only when the held row sits
+  // BELOW the group.
+  //
+  // Comparing them directly made the head test over-reach by exactly one slot
+  // for any tab dragged down from above, which swallowed the group's second
+  // position into its first -- the slot drew above the first member while the
+  // drop landed below it. See KAN-131: an index is only valid in the list that
+  // produced it.
+  const headInLandingSpace = useCallback(
+    (groupId: string, rowId: string) => {
+      const first = groupFirstIndex.get(groupId);
+      if (first === undefined) return undefined;
+      const fromIndex = indexOfTab.get(rowId);
+      return fromIndex !== undefined && fromIndex < first ? first - 1 : first;
+    },
+    [groupFirstIndex, indexOfTab]
+  );
+
   const landsBesideFixedRow = useCallback(
     (rowId: string, toIndex: number, target: string | undefined) => {
       // Landing inside a band: the tab joins that group, or moves to the head
       // of the one it is already in. Either way it ends up UNDER that title
-      // row. At or above the first member is the strip where the index and the
-      // band disagree; below it the tab is landing BETWEEN members, where its
-      // row index already says everything.
+      // row. At or above the head is the strip where the index and the band
+      // disagree; below it the tab is landing BETWEEN members, where its row
+      // index already says everything.
       if (target !== undefined) {
-        const first = groupFirstIndex.get(target);
-        return first !== undefined && toIndex <= first
+        const head = headInLandingSpace(target, rowId);
+        return head !== undefined && toIndex <= head
           ? { fixedRowId: target, side: 'after' as const }
           : undefined;
       }
@@ -329,14 +352,18 @@ const WindowEntryContainer: React.FC<WindowEntryContainerProps> = ({
       // reducer splices it out and back in at the same place and only drops
       // the membership -- so without this the preview has nothing to say and
       // draws the landing slot at the tab's own origin, inside the band.
+      //
+      // The same head, in the same space -- though here the adjustment is
+      // always zero, since a tab leaving its own group started inside it and so
+      // never sits above its own head.
       const held = groupOfTab.get(rowId);
       if (held === undefined) return undefined;
-      const first = groupFirstIndex.get(held);
-      return first !== undefined && toIndex <= first
+      const head = headInLandingSpace(held, rowId);
+      return head !== undefined && toIndex <= head
         ? { fixedRowId: held, side: 'before' as const }
         : undefined;
     },
-    [groupFirstIndex, groupOfTab]
+    [groupOfTab, headInLandingSpace]
   );
 
   const handleMoveGroup = useCallback(

--- a/src/components/home/rightpane/rowDrag/RowDragArea.tsx
+++ b/src/components/home/rightpane/rowDrag/RowDragArea.tsx
@@ -48,7 +48,7 @@ import {
 import {
   landingDeltaOf,
   previewShifts,
-  slotLandingAfter,
+  slotLandingBeside,
   type PreviewSlot,
 } from '../../../../utils/functions/dragPreview';
 
@@ -187,7 +187,7 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
   resolveDrop,
   onDropTargetChange,
   fixedRowSelector,
-  landsAfterFixedRow,
+  landsBesideFixedRow,
   disabled = false,
   children,
 }) => {
@@ -418,13 +418,13 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
       // indices, so there is no second derivation to disagree with the first --
       // which is exactly how the slot came to be drawn on an occupied row.
       const from = l.slotOfRow[l.fromIndex] ?? l.fromIndex;
-      const fixed = landsAfterFixedRow?.(toIndex, target);
+      const beside = landsBesideFixedRow?.(l.rowId, toIndex, target);
       const fixedSlot =
-        fixed === undefined ? undefined : l.slotOfFixed.get(fixed);
+        beside === undefined ? undefined : l.slotOfFixed.get(beside.fixedRowId);
       const to =
-        fixedSlot === undefined
+        fixedSlot === undefined || beside === undefined
           ? l.slotOfRow[toIndex] ?? toIndex
-          : slotLandingAfter(from, fixedSlot);
+          : slotLandingBeside(from, fixedSlot, beside.side);
 
       setDrag({
         rowId: l.rowId,
@@ -757,7 +757,7 @@ export const RowDragArea: React.FC<RowDragAreaProps> = ({
     resolveDrop,
     onDropTargetChange,
     fixedRowSelector,
-    landsAfterFixedRow,
+    landsBesideFixedRow,
     dragKind,
     restoreScrollIfNoDrop,
   ]);

--- a/src/components/home/rightpane/rowDrag/dropRules.ts
+++ b/src/components/home/rightpane/rowDrag/dropRules.ts
@@ -201,7 +201,26 @@ export function bandAt(
     '[data-band-id]'
   )) {
     const r = band.getBoundingClientRect();
-    if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) {
+    // THE CONTENT BOX, not the border box (KAN-171). While a tab is being
+    // dropped into a group, the band grows by one row's worth of padding so its
+    // tint can show the group the release will make -- and that padding must
+    // not enlarge what the pointer can hit. It did, and the result was a LATCH:
+    // marking a band made the band bigger, which kept the pointer inside it,
+    // which kept it marked. Measured in CI, a pointer moved clear of every band
+    // left one still lit.
+    //
+    // Growing the frame previews the RESULT. It is not a bigger target.
+    //
+    // Read off the inline style rather than a computed one because this runs
+    // for every band on every pointer move; the follower writes it there.
+    const padTop = parseFloat(band.style.paddingTop) || 0;
+    const padBottom = parseFloat(band.style.paddingBottom) || 0;
+    if (
+      x >= r.left &&
+      x <= r.right &&
+      y >= r.top + padTop &&
+      y <= r.bottom - padBottom
+    ) {
       return band.dataset.bandId;
     }
   }

--- a/src/components/home/rightpane/rowDrag/dropRules.ts
+++ b/src/components/home/rightpane/rowDrag/dropRules.ts
@@ -6,6 +6,8 @@
 // function.
 import type { ReactNode } from 'react';
 
+import type { LandingSide } from '../../../../utils/functions/dragPreview';
+
 export const ACTIVATION_DISTANCE_PX = 5;
 
 // Form fields and editable regions: a press inside one begins typing or a
@@ -126,8 +128,8 @@ export interface RowDragAreaProps {
    */
   fixedRowSelector?: string;
   /**
-   * Which fixed row the dragged row will land immediately after, when the index
-   * alone does not describe where it ends up (KAN-166).
+   * Which fixed row the dragged row ends up beside, and on which side, when the
+   * index alone does not describe where it ends up (KAN-166, KAN-168).
    *
    * A tab released inside a group's band joins that group, and the band's rect
    * includes the group's TITLE row -- while the landing index comes from row
@@ -136,19 +138,27 @@ export interface RowDragAreaProps {
    * "inside it". Both are right: the tab becomes the group's FIRST member, so
    * it lands under the title row rather than above it.
    *
-   * The area cannot know that. It knows an index and whatever `resolveDrop`
-   * answered; what a group IS, and which row starts it, belong to the list. So
-   * the list names the title row and the area works out the rest -- including
-   * that the answer differs by direction, since a row arriving from above SWAPS
-   * with the title row while one arriving from below lands past it.
+   * THE SIDE IS THE WHOLE POINT, and leaving it out was KAN-168. A drop that
+   * changes a tab's group crosses that group's title row, and it crosses in
+   * both directions: joining at the head lands the tab under the title,
+   * dragging out of the group lands it above. Neither changes the tab's row
+   * index, so an index cannot express either one.
+   *
+   * The area cannot know any of this. It knows an index and whatever
+   * `resolveDrop` answered; what a group IS, which row starts it, and which
+   * group the dragged row is already in all belong to the list. So the list is
+   * given the row's id and names the title row and the side, and the area works
+   * out the slot -- including that the slot also depends on which direction the
+   * row is travelling.
    *
    * The DROP is unaffected -- this shapes the preview only, and the reducer
    * still receives the raw index, which produces the same arrangement.
    */
-  landsAfterFixedRow?: (
+  landsBesideFixedRow?: (
+    rowId: string,
     toIndex: number,
     target: string | undefined
-  ) => string | undefined;
+  ) => { fixedRowId: string; side: LandingSide } | undefined;
   // Dragging is off while the list on screen is a FILTERED view of the stored
   // one (KAN-131). toIndex counts rendered rows, and the reducers apply it to
   // the stored array, so a drag in a narrowed list lands somewhere the user

--- a/src/tests/utils/functions/dragPreview.test.ts
+++ b/src/tests/utils/functions/dragPreview.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest';
 import {
   landingDeltaOf,
   previewShifts,
-  slotLandingAfter,
+  slotLandingBeside,
   type PreviewSlot,
 } from '../../../utils/functions/dragPreview';
 
@@ -57,7 +57,7 @@ describe('previewShifts', () => {
     const shifts = previewShifts(
       LAYOUT,
       2,
-      slotLandingAfter(2, ALPHA),
+      slotLandingBeside(2, ALPHA, 'after'),
       FOOTPRINT
     );
 
@@ -71,7 +71,7 @@ describe('previewShifts', () => {
     const shifts = previewShifts(
       LAYOUT,
       7,
-      slotLandingAfter(7, ALPHA),
+      slotLandingBeside(7, ALPHA, 'after'),
       FOOTPRINT
     );
 
@@ -113,16 +113,57 @@ describe('previewShifts', () => {
   });
 });
 
-describe('slotLandingAfter', () => {
-  // A row landing immediately after a title row indexes the list with itself
-  // lifted out, so coming from above it takes the title row's own slot -- they
-  // swap -- and coming from below it takes the slot after it.
-  test('from above, the row takes the title rows slot', () => {
-    expect(slotLandingAfter(2, ALPHA)).toBe(3);
+describe('slotLandingBeside', () => {
+  // A row landing beside a title row indexes the list with itself lifted out,
+  // so coming from above it takes the title row's own slot -- they swap -- and
+  // coming from below it takes the slot past it.
+  test('joining from above, the row takes the title rows slot', () => {
+    expect(slotLandingBeside(2, ALPHA, 'after')).toBe(3);
   });
 
-  test('from below, the row takes the slot after the title row', () => {
-    expect(slotLandingAfter(7, ALPHA)).toBe(4);
+  test('joining from below, the row takes the slot after the title row', () => {
+    expect(slotLandingBeside(7, ALPHA, 'after')).toBe(4);
+  });
+
+  // KAN-168. Leaving a group is the same crossing in the other direction: the
+  // tab ends up immediately BEFORE the title row rather than after it.
+  test('leaving upward, the row takes the title rows own slot', () => {
+    // alpha0 is at slot 4 -- immediately below the title row at 3.
+    expect(slotLandingBeside(4, ALPHA, 'before')).toBe(3);
+  });
+
+  test('leaving upward from deeper in the group lands in the same slot', () => {
+    // Which member it was does not change where it ends up: above the title.
+    expect(slotLandingBeside(6, ALPHA, 'before')).toBe(3);
+  });
+
+  test('a row already above the title row lands one slot earlier', () => {
+    expect(slotLandingBeside(1, ALPHA, 'before')).toBe(2);
+  });
+});
+
+describe('previewShifts for a tab leaving its group', () => {
+  // Measured (e2e/tab-group-join-preview.spec.ts): alpha0 leaves Alpha upward,
+  // the title row drops to 130 from 98, and alpha1/alpha2 do NOT move.
+  test('the title row drops and the members left behind hold still', () => {
+    const shifts = previewShifts(
+      LAYOUT,
+      4,
+      slotLandingBeside(4, ALPHA, 'before'),
+      32
+    );
+
+    expect(shifts.alpha).toBe(32);
+    expect(shifts.alpha1 ?? 0).toBe(0);
+    expect(shifts.alpha2 ?? 0).toBe(0);
+    expect(shifts.a3 ?? 0).toBe(0);
+    expect(shifts.a2 ?? 0).toBe(0);
+  });
+
+  test('the landing slot is the title rows own top', () => {
+    expect(
+      landingDeltaOf(LAYOUT, 4, slotLandingBeside(4, ALPHA, 'before'))
+    ).toBe(-32);
   });
 });
 
@@ -132,11 +173,15 @@ describe('landingDeltaOf', () => {
   // index clamp this replaces could never be, because it pointed the slot at
   // the first member whichever side the tab arrived from.
   test('joining from above lands on the title rows top', () => {
-    expect(landingDeltaOf(LAYOUT, 2, slotLandingAfter(2, ALPHA))).toBe(34);
+    expect(
+      landingDeltaOf(LAYOUT, 2, slotLandingBeside(2, ALPHA, 'after'))
+    ).toBe(34);
   });
 
   test('joining from below lands on the first members top', () => {
-    expect(landingDeltaOf(LAYOUT, 7, slotLandingAfter(7, ALPHA))).toBe(-98);
+    expect(
+      landingDeltaOf(LAYOUT, 7, slotLandingBeside(7, ALPHA, 'after'))
+    ).toBe(-98);
   });
 
   test('an index off the end of the list travels nowhere', () => {

--- a/src/utils/functions/dragPreview.ts
+++ b/src/utils/functions/dragPreview.ts
@@ -64,17 +64,33 @@ export function previewShifts(
   return shifts;
 }
 
+// Which side of a title row a drop leaves the dragged row on.
+//
+// A drop that changes a tab's group CROSSES that group's title row, and which
+// way it crosses is the whole difference between the two cases (KAN-168):
+// joining at the head puts the tab under the title, leaving puts it above.
+export type LandingSide = 'before' | 'after';
+
 /**
- * The slot a row takes when it lands immediately after the fixed slot `fixed`.
+ * The slot a row takes when it lands immediately beside the fixed slot `fixed`.
  *
  * An index into the list with the held row already lifted out, matching how the
  * engine's own landing index is counted -- which is why the answer depends on
- * which side the row is coming from. From above, removing it shuffles the fixed
- * slot up one, so landing after it means taking its old place: the two SWAP.
- * From below, nothing above the fixed slot moved, so the row lands past it.
+ * which side the row is coming FROM as well as which side it lands on. From
+ * above, removing it shuffles the fixed slot up one, so landing after it means
+ * taking its old place: the two SWAP. From below, nothing above the fixed slot
+ * moved, so the row lands past it.
+ *
+ * `before` is always one slot earlier than `after`, in both directions, because
+ * the two name the gaps either side of the same element.
  */
-export function slotLandingAfter(from: number, fixed: number): number {
-  return from < fixed ? fixed : fixed + 1;
+export function slotLandingBeside(
+  from: number,
+  fixed: number,
+  side: LandingSide
+): number {
+  const after = from < fixed ? fixed : fixed + 1;
+  return side === 'after' ? after : after - 1;
 }
 
 /**


### PR DESCRIPTION
## What

**KAN-168.** The mirror of KAN-166, which fixed only the joining half. Reported by Justine from the shipped build.

A tab that is the **first member** of a group, dragged up out of its band:

* the drop puts it **above the group, loose** — correct
* the dashed landing slot was drawn **inside the band, under the title row**, at the tab's own original position — wrong

Drag a little further down and the band blooms (KAN-164) to say "it stays in the group", which is right. So the two previews disagreed about the same gesture, and the slot was the one lying.

## Cause

Leaving a group does not change the tab's row index, only its `chromeGroupId` — `moveTabInternal` splices it out and back in at the same place. So `toIndex === fromIndex`, and the preview had nothing to say.

That is the same blind spot KAN-166 fixed, one case over. KAN-166 taught the preview that a drop can cross a group's **title row**, but wired only one side: `landsAfterFixedRow` returned a group only when `resolveDrop` named one, and dragging *out* names nothing.

## The rule that was missing: the side

A drop that changes a tab's group crosses that group's title row, **both ways**:

| | the tab ends up |
|---|---|
| joining at the head | immediately **after** the title row |
| leaving upward | immediately **before** it |

Neither changes the row index, so an index cannot express either one.

* `landsAfterFixedRow` → **`landsBesideFixedRow`**, returning `{ fixedRowId, side }`, and now taking the dragged row's id — *which group a tab is already in* is the list's knowledge, not the engine's.
* `slotLandingAfter` → **`slotLandingBeside`**. `before` is always one slot earlier than `after`, in both travel directions, because the two name the gaps either side of the same element.

## Measured

Real popup, 790x550. `alpha0` leaving a three-member Alpha, tops relative to `a0`:

```
before   a0 0  a1 32  a2 64  title 98    alpha0 130  alpha1 162  alpha2 194  a3 228
after    a0 0  a1 32  a2 64  alpha0 96   title 130   alpha1 162  alpha2 194  a3 228
```

The exact inverse of joining from above: the tab and the title row swap back, and **the members left behind do not move**. Predicted from the KAN-166 measurement, then confirmed against a real render — the ground-truth assertion is what would have caught me if the prediction had been wrong.

## Known: the 2px, again

The landing slot is 2px below where the tab lands **in this direction**, because leaving the band stops the tab paying the band's 2px margin and the measured tops cannot know that in advance. That is **KAN-167** surfacing in the slot rather than only in the shifts — joining was exact, leaving is not. The test asserts the number the engine produces and names the 2px rather than hiding it behind a tolerance.

## Known: KAN-169, filed

A group with only **one** member is **deleted** when that member leaves. The preview draws a phantom title row instead, leaving every row below it 36px high. Measured:

```
BEFORE    a0 0  a1 32  a2 64  header 98    s0 130  a3 164
AFTER     a0 0  a1 32  a2 64  (no header)  s0 96   a3 128
PREVIEW   a0 0  a1 32  a2 64  header 130   s0 98   a3 164
```

**Pre-existing and not a regression** — `a3` was previewed at 164 before this change too. What this PR does move is the slot: 130 (34px wrong, inside the band) → 98 (2px). Expressing the rest means letting a fixed row be *removed* by a drag, which is a different rule from the one KAN-166/168 added, not an extension of it.

## Tests

**1348 unit pass** (5 new), **92 e2e pass** (2 new), tsc clean, Prettier clean, lint unchanged (the same 25 warnings as main).

The new e2e pair follows the file's existing shape: measure the arrangement `moveTabInternal` actually produces, then drive the real drag and assert the live preview predicts it.

Three mutations of the **built artifact**, each caught by the new test while the other six stayed green:

```
side ignored, always land after the title row (KAN-166 behaviour) -> fails
the list never reports a tab LEAVING its group (pre-KAN-168)      -> fails
leaving reported on the wrong side                                -> fails
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also fixed here: KAN-170

Reported from the shipped build while this PR was open, and **present on main since KAN-166** — so it rides along rather than stacking, since it is the same rule and this branch is not merged.

A loose tab sitting directly **above** a group, dragged into that group's **second** slot, drew its landing slot in the **first** — above the member already there. The drop was right the whole time.

**Two indices counted in different lists.** The head test compared `toIndex` against `groupFirstIndex`:

* `groupFirstIndex` counts **every** row
* `toIndex` counts the rows with the **held row lifted out** — it is the number of midpoints the pointer has passed

Lifting a row out shifts everything below it down one, so the two agree only when the held row sits *below* the group. Dragging down from above, the test over-reached by exactly one slot.

KAN-131 already said this — *an index is only valid in the list that produced it* — and it reappeared inside the rule written to fix KAN-166.

`headInLandingSpace` now answers where a group's head sits in the space `toIndex` is counted in: `first - 1` when the held row is above the group, `first` otherwise. The KAN-168 leaving branch shares it and is unaffected **by construction** — a tab leaving its own group started inside it, so it never sits above its own head.

Measured, dragging `a2` into Alpha's second slot:

```
truth     a0 0  a1 32  title 66  alpha0 98  a2 130  alpha1 162  alpha2 194  a3 228
preview   the slot drew at 98 -- alpha0's own place, 32px high
```

Two more artifact mutations, both caught:

```
compare the two indices directly again (the shipped bug) -> fails
adjust in the wrong direction                            -> fails, AND breaks KAN-168's case
```

That second one is the useful one: it shows the leaving branch genuinely depends on the adjustment being zero there, rather than passing by luck.

## Totals

**1348 unit pass**, **94 e2e pass** (4 new across both tickets), tsc clean, Prettier clean, lint unchanged.

---

## Also fixed here: KAN-171

Reported from the KAN-168/170 build. Two symptoms, one cause: dragging a tab into a group's head, the **tint** did not reach the top of the group — the title row sat above its own tinted box — and the **strip** moved up but kept its length, falling a row short at the bottom.

Measured, `a2` onto Alpha's title, relative to `a0`, read after the 0.18s frame transition settles:

```
          band       title     strip      lastMember
rest      98..226    98..130   98..226    194..226
drag      98..226    64..96    64..192    194..226
drop      66..226    66..98    66..226    194..226
```

**A group's frame changes LENGTH when a tab joins or leaves it, and KAN-165 could only express POSITION.** Both parts were moved by `translateY`, which carries a fixed-length box, and the band's own painted box was never touched — a transform on a child cannot change its parent's layout box.

The constraint: **it must not reflow.** The numbers show why — `lastMember` is `194..226` in all three states, and nothing below the band moves. So a real height change is out, and so is an explicit height on the strip, which is `align-self: stretch` and would have grown the band.

Two resizes that leave the flow alone:

* the **band** grows by *padding paired with negative margin* — its box gets taller while its content and its contribution to the flow both stay put. Growth only, and that is not a shortcut: this paints only for a group a tab is being dropped into, and joining one can never make it shorter.
* the **strip** resizes by *margins on a stretched item*. Its margin box is what fills the flex line, so a negative `margin-top` makes the border box that much taller and starts it that much higher, while the line — and therefore the band — is untouched. It handles both directions, because it is also drawn while a tab is *leaving*.

Both read one pair of numbers, the title row's shift and the last member's, published on the band by `GroupFrameFollower` and inherited by the strip — so `GroupColorPicker` still knows nothing about dragging. The title row keeps its transform: it is a real row and does move as one.

### A test that could not have caught this

KAN-165's own test asserted an **equality between two transforms**. That is a property assertion of exactly the kind KAN-134 warned about — and it could never have caught the strip being the wrong *length*. It now asserts the invariant: **the strip spans from the title row's top to the last member's bottom**, which holds at rest, while the group travels, and while it is gaining a row.

### Known gap

Related to KAN-169: if the **held** row is the group's last member and it is leaving, the band's bottom should rise by that row's footprint, and the last member's shift cannot say so — a held row is given no shift, because it tracks the pointer.

### Mutations

```
the band never grows (the shipped bug)  -> KAN-171 + KAN-168 tests fail
the strip back to a fixed length        -> KAN-171 + KAN-165 travel tests fail
the strip's bottom ignores the frame    -> KAN-165 travel test fails
```

Each caught by the test that owns that direction.

## Totals

**1348 unit pass**, **95 e2e pass** (5 new across the three tickets), tsc clean, Prettier clean, lint unchanged.
